### PR TITLE
fix: Fix the reponse of diagnostics from shim service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@types/node": "^22.14.0",
         "@xmldom/xmldom": "^0.9.8",
         "npm-run-all2": "^7.0.2",
-        "tuntap-bridge": "^0.0.3"
+        "tuntap-bridge": "^0.x"
       },
       "devDependencies": {
         "@appium/eslint-config-appium-ts": "^1.0.4",


### PR DESCRIPTION
This pull request refactors the `DiagnosticsService` class in `src/services/ios/diagnostic-service/index.ts` to streamline the diagnostic data retrieval process and improve error handling. It removes redundant code, simplifies the logic for processing responses, and eliminates unused imports.

### Code simplification and refactoring:

* Removed the `try-catch` block and redundant checks for response types in the `DiagnosticsService` class, simplifying the logic for handling `additionalResponse`. The method now directly checks for diagnostic data and throws an error if the status is not successful. [[1]](diffhunk://#diff-f0be01527f9a463e7721573d8daf70e91c6e0c8b152fb41e40808897350e211fL217) [[2]](diffhunk://#diff-f0be01527f9a463e7721573d8daf70e91c6e0c8b152fb41e40808897350e211fL228-L283)
* Updated the return value to directly use `additionalResponse.Diagnostics.IORegistry` when diagnostic data is present, eliminating unnecessary merging of responses.

### Cleanup:

* Removed the unused import of `MobileGestaltKeys` from `src/services/ios/diagnostic-service/index.ts`.