### PR TITLE
chore: Fix publish pipeline to run unit test

### DIFF
--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -20,7 +20,7 @@ jobs:
         check-latest: true
     - run: npm install --no-package-lock
       name: Install dependencies
-    - run: npm run test
+    - run: npm run test:unit
       name: Run NPM Test
     - run: |
         rm -rf node_modules package-lock.json


### PR DESCRIPTION
This pull request updates the workflow configuration in `.github/workflows/publish.js.yml` to clarify the testing step by specifying that only unit tests should be run.

Workflow configuration changes:

* [`.github/workflows/publish.js.yml`](diffhunk://#diff-d553eea0a3d94c3724f0b0dd06b169a26af11cd911136c7cd2f6e14451616de1L23-R23): Changed the `npm run test` command to `npm run test:unit` in the "Run NPM Test" step to explicitly focus on running unit tests.