### PR TITLE
chore: TLV encoding/decoding for Apple TV pairing protocol

### DIFF
--- a/src/lib/apple-tv/tlv/decoder.ts
+++ b/src/lib/apple-tv/tlv/decoder.ts
@@ -50,12 +50,19 @@ export function decodeTLV8ToDict(
   buffer: Buffer,
 ): Partial<Record<PairingDataComponentTypeValue, Buffer>> {
   const items = decodeTLV8(buffer);
-  const result: Partial<Record<PairingDataComponentTypeValue, Buffer>> = {};
+  const result: Partial<Record<PairingDataComponentTypeValue, Buffer[]>> = {};
 
   for (const { type, data } of items) {
-    const existing = result[type];
-    result[type] = existing ? Buffer.concat([existing, data]) : data;
+    if (!result[type]) {
+      result[type] = [];
+    }
+    result[type]!.push(data);
   }
 
-  return result;
+  return Object.fromEntries(
+    Object.entries(result).map(([type, buffers]) => [
+      type,
+      Buffer.concat(buffers as Buffer[]),
+    ]),
+  ) as Partial<Record<PairingDataComponentTypeValue, Buffer>>;
 }

--- a/src/lib/apple-tv/tlv/decoder.ts
+++ b/src/lib/apple-tv/tlv/decoder.ts
@@ -1,0 +1,61 @@
+import { TLV8Error } from '../errors.js';
+import type { PairingDataComponentTypeValue, TLV8Item } from '../types.js';
+
+/**
+ * Decodes a TLV8-formatted buffer into an array of TLV8 items.
+ *
+ * @param buffer - A Node.js Buffer containing TLV8 encoded data
+ * @returns Array of TLV8Item objects with `type` and `data`
+ * @throws TLV8Error if the buffer does not contain valid TLV8 data
+ */
+export function decodeTLV8(buffer: Buffer): TLV8Item[] {
+  const items: TLV8Item[] = [];
+  let offset = 0;
+
+  while (offset < buffer.length) {
+    if (offset + 2 > buffer.length) {
+      throw new TLV8Error(
+        `Invalid TLV8: insufficient data for type and length at offset ${offset}`,
+      );
+    }
+
+    const type = buffer[offset] as PairingDataComponentTypeValue;
+    const length = buffer[offset + 1];
+    offset += 2;
+
+    if (offset + length > buffer.length) {
+      throw new TLV8Error(
+        `Invalid TLV8: insufficient data for value at offset ${offset}`,
+      );
+    }
+
+    const data = buffer.subarray(offset, offset + length);
+    offset += length;
+
+    items.push({ type, data });
+  }
+
+  return items;
+}
+
+/**
+ * Decodes a TLV8-formatted buffer into a dictionary mapping
+ * each TLV8 type to its corresponding data buffer. If the same
+ * type occurs more than once, their values are concatenated.
+ *
+ * @param buffer - A Node.js Buffer containing TLV8 encoded data
+ * @returns A dictionary of type-value mappings
+ */
+export function decodeTLV8ToDict(
+  buffer: Buffer,
+): Partial<Record<PairingDataComponentTypeValue, Buffer>> {
+  const items = decodeTLV8(buffer);
+  const result: Partial<Record<PairingDataComponentTypeValue, Buffer>> = {};
+
+  for (const { type, data } of items) {
+    const existing = result[type];
+    result[type] = existing ? Buffer.concat([existing, data]) : data;
+  }
+
+  return result;
+}

--- a/src/lib/apple-tv/tlv/encoder.ts
+++ b/src/lib/apple-tv/tlv/encoder.ts
@@ -1,0 +1,33 @@
+import { TLV8_MAX_FRAGMENT_SIZE } from '../constants.js';
+import type { TLV8Item } from '../types.js';
+
+/**
+ * Encodes an array of TLV8 items into a single TLV8-compliant buffer.
+ * If a data value exceeds TLV8_MAX_FRAGMENT_SIZE, it will be split across multiple entries.
+ *
+ * @param items - Array of TLV8 items to encode
+ * @returns A Buffer containing the encoded TLV8 data
+ */
+export function encodeTLV8(items: TLV8Item[]): Buffer {
+  const chunks: Buffer[] = [];
+
+  for (const { type, data } of items) {
+    let offset = 0;
+
+    while (offset < data.length) {
+      const fragmentLength = Math.min(
+        TLV8_MAX_FRAGMENT_SIZE,
+        data.length - offset,
+      );
+
+      chunks.push(
+        Buffer.from([type, fragmentLength]),
+        data.subarray(offset, offset + fragmentLength),
+      );
+
+      offset += fragmentLength;
+    }
+  }
+
+  return Buffer.concat(chunks);
+}

--- a/src/lib/apple-tv/tlv/index.ts
+++ b/src/lib/apple-tv/tlv/index.ts
@@ -1,0 +1,6 @@
+export { encodeTLV8 } from './encoder.js';
+export { decodeTLV8, decodeTLV8ToDict } from './decoder.js';
+export {
+  createSetupManualPairingData,
+  createPairVerificationData,
+} from './pairing-tlv.js';

--- a/src/lib/apple-tv/tlv/pairing-tlv.ts
+++ b/src/lib/apple-tv/tlv/pairing-tlv.ts
@@ -1,0 +1,31 @@
+import { PairingDataComponentType } from '../constants.js';
+import { encodeTLV8 } from './encoder.js';
+
+/**
+ * Creates TLV8-encoded setup data for manual pairing, with default METHOD and STATE.
+ *
+ * @returns Base64-encoded TLV8 string for manual pairing
+ */
+export function createSetupManualPairingData(): string {
+  const tlv = encodeTLV8([
+    { type: PairingDataComponentType.METHOD, data: Buffer.from([0x00]) },
+    { type: PairingDataComponentType.STATE, data: Buffer.from([0x01]) },
+  ]);
+
+  return tlv.toString('base64');
+}
+
+/**
+ * Creates TLV8-encoded data for pair verification, including the X25519 public key.
+ *
+ * @param x25519PublicKey - A buffer containing the X25519 public key
+ * @returns Base64-encoded TLV8 string for verification
+ */
+export function createPairVerificationData(x25519PublicKey: Buffer): string {
+  const tlv = encodeTLV8([
+    { type: PairingDataComponentType.STATE, data: Buffer.from([0x01]) },
+    { type: PairingDataComponentType.PUBLIC_KEY, data: x25519PublicKey },
+  ]);
+
+  return tlv.toString('base64');
+}

--- a/test/unit/apple-tv/tlv/decoder.spec.ts
+++ b/test/unit/apple-tv/tlv/decoder.spec.ts
@@ -1,0 +1,144 @@
+import { expect } from 'chai';
+
+import { TLV8Error } from '../../../../src/lib/apple-tv/errors.js';
+import {
+  decodeTLV8,
+  decodeTLV8ToDict,
+} from '../../../../src/lib/apple-tv/tlv/decoder.js';
+
+describe('TLV8 Decoder', function () {
+  describe('decodeTLV8', function () {
+    it('should decode a single TLV8 item', function () {
+      const buffer = Buffer.from([0x01, 0x03, 0x42, 0x43, 0x44]);
+
+      const result = decodeTLV8(buffer);
+
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].type).to.equal(0x01);
+      expect(result[0].data).to.deep.equal(Buffer.from([0x42, 0x43, 0x44]));
+    });
+
+    it('should decode multiple TLV8 items', function () {
+      const buffer = Buffer.from([
+        0x01, 0x01, 0x42, 0x02, 0x02, 0x43, 0x44, 0x03, 0x03, 0x45, 0x46, 0x47,
+      ]);
+
+      const result = decodeTLV8(buffer);
+
+      expect(result).to.have.lengthOf(3);
+
+      expect(result[0].type).to.equal(0x01);
+      expect(result[0].data).to.deep.equal(Buffer.from([0x42]));
+
+      expect(result[1].type).to.equal(0x02);
+      expect(result[1].data).to.deep.equal(Buffer.from([0x43, 0x44]));
+
+      expect(result[2].type).to.equal(0x03);
+      expect(result[2].data).to.deep.equal(Buffer.from([0x45, 0x46, 0x47]));
+    });
+
+    it('should handle empty buffer', function () {
+      const buffer = Buffer.alloc(0);
+
+      const result = decodeTLV8(buffer);
+
+      expect(result).to.deep.equal([]);
+    });
+
+    it('should decode fragmented data', function () {
+      const buffer = Buffer.from([
+        0x05,
+        0xff,
+        ...Buffer.alloc(255, 0xab),
+        0x05,
+        0x01,
+        0xab,
+      ]);
+
+      const result = decodeTLV8(buffer);
+
+      expect(result).to.have.lengthOf(2);
+      expect(result[0].type).to.equal(0x05);
+      expect(result[0].data).to.deep.equal(Buffer.alloc(255, 0xab));
+      expect(result[1].type).to.equal(0x05);
+      expect(result[1].data).to.deep.equal(Buffer.from([0xab]));
+    });
+
+    it('should throw error for insufficient data for type and length', function () {
+      const buffer = Buffer.from([0x01]);
+
+      expect(() => decodeTLV8(buffer)).to.throw(
+        TLV8Error,
+        'Invalid TLV8: insufficient data for type and length at offset 0',
+      );
+    });
+
+    it('should throw error for insufficient data for value', function () {
+      const buffer = Buffer.from([0x01, 0x05, 0x42, 0x43]);
+
+      expect(() => decodeTLV8(buffer)).to.throw(
+        TLV8Error,
+        'Invalid TLV8: insufficient data for value at offset 2',
+      );
+    });
+  });
+
+  describe('decodeTLV8ToDict', function () {
+    it('should decode to dictionary with unique types', function () {
+      const buffer = Buffer.from([
+        0x01, 0x01, 0x42, 0x02, 0x02, 0x43, 0x44, 0x03, 0x03, 0x45, 0x46, 0x47,
+      ]);
+
+      const result = decodeTLV8ToDict(buffer);
+
+      expect(result[0x01]).to.deep.equal(Buffer.from([0x42]));
+      expect(result[0x02]).to.deep.equal(Buffer.from([0x43, 0x44]));
+      expect(result[0x03]).to.deep.equal(Buffer.from([0x45, 0x46, 0x47]));
+    });
+
+    it('should concatenate data for repeated types', function () {
+      const buffer = Buffer.from([
+        0x05,
+        0xff,
+        ...Buffer.alloc(255, 0xab),
+        0x05,
+        0x01,
+        0xab,
+        0x06,
+        0x02,
+        0xcc,
+        0xdd,
+        0x05,
+        0x02,
+        0xee,
+        0xff,
+      ]);
+
+      const result = decodeTLV8ToDict(buffer);
+
+      expect(result[0x05]).to.deep.equal(
+        Buffer.concat([
+          Buffer.alloc(255, 0xab),
+          Buffer.from([0xab]),
+          Buffer.from([0xee, 0xff]),
+        ]),
+      );
+
+      expect(result[0x06]).to.deep.equal(Buffer.from([0xcc, 0xdd]));
+    });
+
+    it('should handle empty buffer', function () {
+      const buffer = Buffer.alloc(0);
+
+      const result = decodeTLV8ToDict(buffer);
+
+      expect(result).to.deep.equal({});
+    });
+
+    it('should throw error for malformed data', function () {
+      const buffer = Buffer.from([0x01, 0x05, 0x42]);
+
+      expect(() => decodeTLV8ToDict(buffer)).to.throw(TLV8Error);
+    });
+  });
+});

--- a/test/unit/apple-tv/tlv/encoder.spec.ts
+++ b/test/unit/apple-tv/tlv/encoder.spec.ts
@@ -47,12 +47,18 @@ describe('TLV8 Encoder', function () {
 
       const result = encodeTLV8(items);
 
-      expect(result.length).to.equal(2 + TLV8_MAX_FRAGMENT_SIZE + 2 + (256 - TLV8_MAX_FRAGMENT_SIZE));
+      expect(result.length).to.equal(
+        2 + TLV8_MAX_FRAGMENT_SIZE + 2 + (256 - TLV8_MAX_FRAGMENT_SIZE),
+      );
       expect(result[0]).to.equal(0x05);
       expect(result[1]).to.equal(TLV8_MAX_FRAGMENT_SIZE);
-      expect(result.subarray(2, 2 + TLV8_MAX_FRAGMENT_SIZE)).to.deep.equal(Buffer.alloc(TLV8_MAX_FRAGMENT_SIZE, 0xab));
+      expect(result.subarray(2, 2 + TLV8_MAX_FRAGMENT_SIZE)).to.deep.equal(
+        Buffer.alloc(TLV8_MAX_FRAGMENT_SIZE, 0xab),
+      );
       expect(result[2 + TLV8_MAX_FRAGMENT_SIZE]).to.equal(0x05);
-      expect(result[3 + TLV8_MAX_FRAGMENT_SIZE]).to.equal(256 - TLV8_MAX_FRAGMENT_SIZE);
+      expect(result[3 + TLV8_MAX_FRAGMENT_SIZE]).to.equal(
+        256 - TLV8_MAX_FRAGMENT_SIZE,
+      );
       expect(result[4 + TLV8_MAX_FRAGMENT_SIZE]).to.equal(0xab);
     });
 

--- a/test/unit/apple-tv/tlv/encoder.spec.ts
+++ b/test/unit/apple-tv/tlv/encoder.spec.ts
@@ -1,0 +1,85 @@
+import { expect } from 'chai';
+
+import { TLV8_MAX_FRAGMENT_SIZE } from '../../../../src/lib/apple-tv/constants.js';
+import { encodeTLV8 } from '../../../../src/lib/apple-tv/tlv/encoder.js';
+import type { TLV8Item } from '../../../../src/lib/apple-tv/types.js';
+
+describe('TLV8 Encoder', function () {
+  describe('encodeTLV8', function () {
+    it('should encode a single TLV8 item', function () {
+      const items: TLV8Item[] = [
+        { type: 0x01, data: Buffer.from([0x42, 0x43, 0x44]) },
+      ];
+
+      const result = encodeTLV8(items);
+
+      expect(result).to.deep.equal(Buffer.from([0x01, 0x03, 0x42, 0x43, 0x44]));
+    });
+
+    it('should encode multiple TLV8 items', function () {
+      const items: TLV8Item[] = [
+        { type: 0x01, data: Buffer.from([0x42]) },
+        { type: 0x02, data: Buffer.from([0x43, 0x44]) },
+        { type: 0x03, data: Buffer.from([0x45, 0x46, 0x47]) },
+      ];
+
+      const result = encodeTLV8(items);
+
+      expect(result).to.deep.equal(
+        Buffer.from([
+          0x01, 0x01, 0x42, 0x02, 0x02, 0x43, 0x44, 0x03, 0x03, 0x45, 0x46,
+          0x47,
+        ]),
+      );
+    });
+
+    it('should handle empty items array', function () {
+      const items: TLV8Item[] = [];
+
+      const result = encodeTLV8(items);
+
+      expect(result).to.deep.equal(Buffer.alloc(0));
+    });
+
+    it('should fragment data exceeding TLV8_MAX_FRAGMENT_SIZE', function () {
+      const largeData = Buffer.alloc(256, 0xab);
+      const items: TLV8Item[] = [{ type: 0x05, data: largeData }];
+
+      const result = encodeTLV8(items);
+
+      expect(result.length).to.equal(2 + 255 + 2 + 1);
+      expect(result[0]).to.equal(0x05);
+      expect(result[1]).to.equal(255);
+      expect(result.subarray(2, 257)).to.deep.equal(Buffer.alloc(255, 0xab));
+      expect(result[257]).to.equal(0x05);
+      expect(result[258]).to.equal(1);
+      expect(result[259]).to.equal(0xab);
+    });
+
+    it('should handle data exactly at TLV8_MAX_FRAGMENT_SIZE boundary', function () {
+      const boundaryData = Buffer.alloc(TLV8_MAX_FRAGMENT_SIZE, 0xef);
+      const items: TLV8Item[] = [{ type: 0x08, data: boundaryData }];
+
+      const result = encodeTLV8(items);
+
+      expect(result.length).to.equal(2 + TLV8_MAX_FRAGMENT_SIZE);
+      expect(result[0]).to.equal(0x08);
+      expect(result[1]).to.equal(TLV8_MAX_FRAGMENT_SIZE);
+      expect(result.subarray(2)).to.deep.equal(boundaryData);
+    });
+
+    it('should handle all possible type values', function () {
+      const items: TLV8Item[] = [
+        { type: 0x00, data: Buffer.from([0x00]) },
+        { type: 0x7f, data: Buffer.from([0x7f]) },
+        { type: 0xff, data: Buffer.from([0xff]) },
+      ];
+
+      const result = encodeTLV8(items);
+
+      expect(result).to.deep.equal(
+        Buffer.from([0x00, 0x01, 0x00, 0x7f, 0x01, 0x7f, 0xff, 0x01, 0xff]),
+      );
+    });
+  });
+});

--- a/test/unit/apple-tv/tlv/encoder.spec.ts
+++ b/test/unit/apple-tv/tlv/encoder.spec.ts
@@ -47,13 +47,13 @@ describe('TLV8 Encoder', function () {
 
       const result = encodeTLV8(items);
 
-      expect(result.length).to.equal(2 + 255 + 2 + 1);
+      expect(result.length).to.equal(2 + TLV8_MAX_FRAGMENT_SIZE + 2 + (256 - TLV8_MAX_FRAGMENT_SIZE));
       expect(result[0]).to.equal(0x05);
-      expect(result[1]).to.equal(255);
-      expect(result.subarray(2, 257)).to.deep.equal(Buffer.alloc(255, 0xab));
-      expect(result[257]).to.equal(0x05);
-      expect(result[258]).to.equal(1);
-      expect(result[259]).to.equal(0xab);
+      expect(result[1]).to.equal(TLV8_MAX_FRAGMENT_SIZE);
+      expect(result.subarray(2, 2 + TLV8_MAX_FRAGMENT_SIZE)).to.deep.equal(Buffer.alloc(TLV8_MAX_FRAGMENT_SIZE, 0xab));
+      expect(result[2 + TLV8_MAX_FRAGMENT_SIZE]).to.equal(0x05);
+      expect(result[3 + TLV8_MAX_FRAGMENT_SIZE]).to.equal(256 - TLV8_MAX_FRAGMENT_SIZE);
+      expect(result[4 + TLV8_MAX_FRAGMENT_SIZE]).to.equal(0xab);
     });
 
     it('should handle data exactly at TLV8_MAX_FRAGMENT_SIZE boundary', function () {

--- a/test/unit/apple-tv/tlv/pairing-tlv.spec.ts
+++ b/test/unit/apple-tv/tlv/pairing-tlv.spec.ts
@@ -1,0 +1,101 @@
+import { expect } from 'chai';
+
+import { PairingDataComponentType } from '../../../../src/lib/apple-tv/constants.js';
+import { decodeTLV8ToDict } from '../../../../src/lib/apple-tv/tlv/decoder.js';
+import {
+  createPairVerificationData,
+  createSetupManualPairingData,
+} from '../../../../src/lib/apple-tv/tlv/pairing-tlv.js';
+
+describe('Pairing TLV', function () {
+  describe('createSetupManualPairingData', function () {
+    it('should create valid base64-encoded TLV8 data', function () {
+      const result = createSetupManualPairingData();
+
+      expect(result).to.be.a('string');
+      expect(() => Buffer.from(result, 'base64')).to.not.throw();
+    });
+
+    it('should contain correct METHOD and STATE values', function () {
+      const result = createSetupManualPairingData();
+      const decoded = Buffer.from(result, 'base64');
+      const tlvDict = decodeTLV8ToDict(decoded);
+
+      expect(tlvDict[PairingDataComponentType.METHOD]).to.exist;
+      expect(tlvDict[PairingDataComponentType.METHOD]).to.deep.equal(
+        Buffer.from([0x00]),
+      );
+
+      expect(tlvDict[PairingDataComponentType.STATE]).to.exist;
+      expect(tlvDict[PairingDataComponentType.STATE]).to.deep.equal(
+        Buffer.from([0x01]),
+      );
+    });
+
+    it('should always return the same value', function () {
+      const result1 = createSetupManualPairingData();
+      const result2 = createSetupManualPairingData();
+
+      expect(result1).to.equal(result2);
+    });
+  });
+
+  describe('createPairVerificationData', function () {
+    it('should create valid base64-encoded TLV8 data with public key', function () {
+      const publicKey = Buffer.from([0x01, 0x02, 0x03, 0x04]);
+      const result = createPairVerificationData(publicKey);
+
+      expect(result).to.be.a('string');
+      expect(() => Buffer.from(result, 'base64')).to.not.throw();
+    });
+
+    it('should contain correct STATE and PUBLIC_KEY values', function () {
+      const publicKey = Buffer.from([0xaa, 0xbb, 0xcc, 0xdd]);
+      const result = createPairVerificationData(publicKey);
+      const decoded = Buffer.from(result, 'base64');
+      const tlvDict = decodeTLV8ToDict(decoded);
+
+      expect(tlvDict[PairingDataComponentType.STATE]).to.exist;
+      expect(tlvDict[PairingDataComponentType.STATE]).to.deep.equal(
+        Buffer.from([0x01]),
+      );
+
+      expect(tlvDict[PairingDataComponentType.PUBLIC_KEY]).to.exist;
+      expect(tlvDict[PairingDataComponentType.PUBLIC_KEY]).to.deep.equal(
+        publicKey,
+      );
+    });
+
+    it('should handle typical X25519 public key (32 bytes)', function () {
+      const x25519PublicKey = Buffer.alloc(32, 0xef);
+      const result = createPairVerificationData(x25519PublicKey);
+      const decoded = Buffer.from(result, 'base64');
+      const tlvDict = decodeTLV8ToDict(decoded);
+
+      expect(tlvDict[PairingDataComponentType.PUBLIC_KEY]).to.deep.equal(
+        x25519PublicKey,
+      );
+    });
+
+    it('should handle large public key that requires fragmentation', function () {
+      const largeKey = Buffer.alloc(300, 0x42);
+      const result = createPairVerificationData(largeKey);
+      const decoded = Buffer.from(result, 'base64');
+      const tlvDict = decodeTLV8ToDict(decoded);
+
+      expect(tlvDict[PairingDataComponentType.PUBLIC_KEY]).to.deep.equal(
+        largeKey,
+      );
+    });
+
+    it('should produce different results for different public keys', function () {
+      const key1 = Buffer.from([0x01, 0x02, 0x03]);
+      const key2 = Buffer.from([0x04, 0x05, 0x06]);
+
+      const result1 = createPairVerificationData(key1);
+      const result2 = createPairVerificationData(key2);
+
+      expect(result1).to.not.equal(result2);
+    });
+  });
+});

--- a/test/unit/apple-tv/tlv/tlv-integration.spec.ts
+++ b/test/unit/apple-tv/tlv/tlv-integration.spec.ts
@@ -1,0 +1,146 @@
+import { expect } from 'chai';
+
+import { TLV8_MAX_FRAGMENT_SIZE } from '../../../../src/lib/apple-tv/constants.js';
+import {
+  decodeTLV8,
+  decodeTLV8ToDict,
+} from '../../../../src/lib/apple-tv/tlv/decoder.js';
+import { encodeTLV8 } from '../../../../src/lib/apple-tv/tlv/encoder.js';
+import type { TLV8Item } from '../../../../src/lib/apple-tv/types.js';
+
+describe('TLV8 Integration Tests', function () {
+  describe('Round-trip encoding and decoding', function () {
+    it('should maintain data integrity for simple items', function () {
+      const originalItems: TLV8Item[] = [
+        { type: 0x01, data: Buffer.from([0x42, 0x43, 0x44]) },
+        { type: 0x02, data: Buffer.from([0x45, 0x46]) },
+        { type: 0x03, data: Buffer.from([0x47]) },
+      ];
+
+      const encoded = encodeTLV8(originalItems);
+      const decoded = decodeTLV8(encoded);
+
+      expect(decoded).to.deep.equal(originalItems);
+    });
+
+    it('should handle fragmented data round-trip', function () {
+      const largeData = Buffer.alloc(512);
+      for (let i = 0; i < 512; i++) {
+        largeData[i] = i % 256;
+      }
+
+      const originalItems: TLV8Item[] = [{ type: 0x05, data: largeData }];
+
+      const encoded = encodeTLV8(originalItems);
+      const decoded = decodeTLV8(encoded);
+
+      expect(decoded).to.have.lengthOf(3);
+      expect(decoded[0].type).to.equal(0x05);
+      expect(decoded[1].type).to.equal(0x05);
+      expect(decoded[2].type).to.equal(0x05);
+
+      const reassembled = Buffer.concat(decoded.map((item) => item.data));
+      expect(reassembled).to.deep.equal(largeData);
+    });
+
+    it('should handle mixed fragmented and non-fragmented items', function () {
+      const smallData = Buffer.from([0xaa, 0xbb]);
+      const largeData = Buffer.alloc(300, 0xcc);
+      const mediumData = Buffer.alloc(100, 0xdd);
+
+      const originalItems: TLV8Item[] = [
+        { type: 0x01, data: smallData },
+        { type: 0x02, data: largeData },
+        { type: 0x03, data: mediumData },
+      ];
+
+      const encoded = encodeTLV8(originalItems);
+      const decoded = decodeTLV8(encoded);
+
+      expect(decoded).to.have.lengthOf(4);
+
+      expect(decoded[0]).to.deep.equal({ type: 0x01, data: smallData });
+
+      expect(decoded[1].type).to.equal(0x02);
+      expect(decoded[1].data.length).to.equal(255);
+      expect(decoded[2].type).to.equal(0x02);
+      expect(decoded[2].data.length).to.equal(45);
+
+      expect(decoded[3]).to.deep.equal({ type: 0x03, data: mediumData });
+    });
+  });
+
+  describe('Round-trip with decodeTLV8ToDict', function () {
+    it('should correctly reassemble fragmented data in dictionary', function () {
+      const largeData = Buffer.alloc(512, 0xee);
+      const originalItems: TLV8Item[] = [{ type: 0x10, data: largeData }];
+
+      const encoded = encodeTLV8(originalItems);
+      const decodedDict = decodeTLV8ToDict(encoded);
+
+      expect(decodedDict[0x10]).to.deep.equal(largeData);
+    });
+
+    it('should handle multiple types with fragmentation', function () {
+      const data1 = Buffer.alloc(300, 0x11);
+      const data2 = Buffer.alloc(50, 0x22);
+      const data3 = Buffer.alloc(400, 0x33);
+
+      const originalItems: TLV8Item[] = [
+        { type: 0x01, data: data1 },
+        { type: 0x02, data: data2 },
+        { type: 0x03, data: data3 },
+      ];
+
+      const encoded = encodeTLV8(originalItems);
+      const decodedDict = decodeTLV8ToDict(encoded);
+
+      expect(decodedDict[0x01]).to.deep.equal(data1);
+      expect(decodedDict[0x02]).to.deep.equal(data2);
+      expect(decodedDict[0x03]).to.deep.equal(data3);
+    });
+  });
+
+  describe('Edge cases', function () {
+    it('should handle maximum size data at boundary', function () {
+      const boundaryData = Buffer.alloc(TLV8_MAX_FRAGMENT_SIZE);
+      for (let i = 0; i < TLV8_MAX_FRAGMENT_SIZE; i++) {
+        boundaryData[i] = i % 256;
+      }
+
+      const items: TLV8Item[] = [{ type: 0x42, data: boundaryData }];
+
+      const encoded = encodeTLV8(items);
+      const decoded = decodeTLV8(encoded);
+
+      expect(decoded).to.have.lengthOf(1);
+      expect(decoded[0]).to.deep.equal(items[0]);
+    });
+
+    it('should handle empty items array', function () {
+      const items: TLV8Item[] = [];
+
+      const encoded = encodeTLV8(items);
+      const decoded = decodeTLV8(encoded);
+      const decodedDict = decodeTLV8ToDict(encoded);
+
+      expect(encoded).to.deep.equal(Buffer.alloc(0));
+      expect(decoded).to.deep.equal([]);
+      expect(decodedDict).to.deep.equal({});
+    });
+
+    it('should preserve exact byte sequences through round-trip', function () {
+      const problematicData = Buffer.from([
+        0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0x01, 0x02, 0x03, 0x00, 0xff, 0x00,
+        0xff,
+      ]);
+
+      const items: TLV8Item[] = [{ type: 0x77, data: problematicData }];
+
+      const encoded = encodeTLV8(items);
+      const decoded = decodeTLV8(encoded);
+
+      expect(decoded[0].data).to.deep.equal(problematicData);
+    });
+  });
+});


### PR DESCRIPTION
Implements TLV8 (Type-Length-Value 8-bit) format handling required for Apple TV pairing communication. 

TLV8 format is essential for the HomeKit Accessory Protocol (HAP) used in Apple TV pairing, enabling structured data exchange during the SRP (Secure Remote Password) authentication process.