### PR TITLE
chore: Add build release to npm module

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,5 +74,13 @@
     "@xmldom/xmldom": "^0.9.8",
     "npm-run-all2": "^7.0.2",
     "tuntap-bridge": "^0.x"
-  }
+  },
+  "files": [
+    "src",
+    "scripts",
+    "build/src",
+    "!.DS_Store",
+    "CHANGELOG.md",
+    "LICENSE"
+  ]
 }


### PR DESCRIPTION
This pull request introduces a minor update to the `package.json` file, adding a `files` field to specify which files should be included in the package distribution.