### PR TITLE
chore: add appletv encryption module for RemoteXPC support

### DIFF
--- a/src/lib/apple-tv/constants.ts
+++ b/src/lib/apple-tv/constants.ts
@@ -92,3 +92,34 @@ export const OPACK2_SMALL_STRING_MAX = 0x20;
 export const OPACK2_SMALL_BYTES_MAX = 0x20;
 export const OPACK2_SMALL_ARRAY_MAX = 15;
 export const OPACK2_SMALL_DICT_MAX = 15;
+
+// OPACK2 number type markers
+export const OPACK2_INT8_MARKER = 0x30;
+export const OPACK2_INT32_MARKER = 0x32;
+export const OPACK2_INT64_MARKER = 0x33;
+export const OPACK2_FLOAT_MARKER = 0x35;
+
+// OPACK2 string type markers
+export const OPACK2_SMALL_STRING_BASE = 0x40;
+export const OPACK2_STRING_8BIT_LEN_MARKER = 0x61;
+export const OPACK2_STRING_16BIT_LEN_MARKER = 0x62;
+export const OPACK2_STRING_32BIT_LEN_MARKER = 0x63;
+
+// OPACK2 bytes type markers
+export const OPACK2_SMALL_BYTES_BASE = 0x70;
+export const OPACK2_BYTES_8BIT_LEN_MARKER = 0x91;
+export const OPACK2_BYTES_16BIT_LEN_MARKER = 0x92;
+export const OPACK2_BYTES_32BIT_LEN_MARKER = 0x93;
+
+// OPACK2 array type markers
+export const OPACK2_SMALL_ARRAY_BASE = 0xd0;
+export const OPACK2_VARIABLE_ARRAY_MARKER = 0xdf;
+
+// OPACK2 dictionary type markers
+export const OPACK2_SMALL_DICT_BASE = 0xe0;
+export const OPACK2_VARIABLE_DICT_MARKER = 0xef;
+
+// OPACK2 size limits
+export const OPACK2_UINT8_MAX = 0xff;
+export const OPACK2_UINT16_MAX = 0xffff;
+export const OPACK2_UINT32_MAX = 0xffffffff;

--- a/src/lib/apple-tv/constants.ts
+++ b/src/lib/apple-tv/constants.ts
@@ -81,3 +81,14 @@ export const HKDF_HASH_ALGORITHM = 'sha512';
 
 // Output length (in bytes) for HKDF key derivation
 export const HKDF_HASH_LENGTH = 64;
+
+// OPACK2 encoding constants
+export const OPACK2_NULL = 0x03;
+export const OPACK2_TRUE = 0x01;
+export const OPACK2_FALSE = 0x02;
+export const OPACK2_SMALL_INT_OFFSET = 8;
+export const OPACK2_SMALL_INT_MAX = 0x27;
+export const OPACK2_SMALL_STRING_MAX = 0x20;
+export const OPACK2_SMALL_BYTES_MAX = 0x20;
+export const OPACK2_SMALL_ARRAY_MAX = 15;
+export const OPACK2_SMALL_DICT_MAX = 15;

--- a/src/lib/apple-tv/encryption/chacha20-poly1305.ts
+++ b/src/lib/apple-tv/encryption/chacha20-poly1305.ts
@@ -1,0 +1,121 @@
+import { createCipheriv, createDecipheriv } from 'node:crypto';
+
+import { CryptographyError } from '../errors.js';
+
+export interface ChaCha20Poly1305Params {
+  plaintext?: Buffer;
+  ciphertext?: Buffer;
+  key: Buffer;
+  nonce: Buffer;
+  aad?: Buffer;
+}
+
+interface DecryptionAttempt {
+  tagLen: number;
+  aad?: Buffer;
+}
+
+/**
+ * Encrypts data using ChaCha20-Poly1305 AEAD cipher
+ * @param params - Encryption parameters including plaintext, key, nonce, and optional AAD
+ * @returns Buffer containing encrypted data concatenated with authentication tag
+ * @throws CryptographyError if encryption fails or required parameters are missing
+ */
+export function encryptChaCha20Poly1305(
+  params: ChaCha20Poly1305Params,
+): Buffer {
+  const { plaintext, key, nonce, aad } = params;
+
+  if (!plaintext) {
+    throw new CryptographyError('Plaintext is required for encryption');
+  }
+
+  if (!key || key.length !== 32) {
+    throw new CryptographyError('Key must be 32 bytes');
+  }
+
+  if (!nonce || nonce.length !== 12) {
+    throw new CryptographyError('Nonce must be 12 bytes');
+  }
+
+  try {
+    const cipher = createCipheriv('chacha20-poly1305', key, nonce) as any;
+
+    if (aad) {
+      cipher.setAAD(aad, { plaintextLength: plaintext.length });
+    }
+
+    const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+    const authTag = cipher.getAuthTag();
+
+    return Buffer.concat([encrypted, authTag]);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new CryptographyError(
+      `ChaCha20-Poly1305 encryption failed: ${message}`,
+    );
+  }
+}
+
+/**
+ * Decrypts data using ChaCha20-Poly1305 AEAD cipher with multiple fallback strategies
+ * @param params - Decryption parameters including ciphertext, key, nonce, and optional AAD
+ * @returns Buffer containing decrypted plaintext
+ * @throws CryptographyError if all decryption attempts fail or required parameters are missing
+ */
+export function decryptChaCha20Poly1305(
+  params: ChaCha20Poly1305Params,
+): Buffer {
+  const { ciphertext, key, nonce, aad } = params;
+
+  if (!ciphertext) {
+    throw new CryptographyError('Ciphertext is required for decryption');
+  }
+
+  if (!key || key.length !== 32) {
+    throw new CryptographyError('Key must be 32 bytes');
+  }
+
+  if (!nonce || nonce.length !== 12) {
+    throw new CryptographyError('Nonce must be 12 bytes');
+  }
+
+  if (ciphertext.length < 16) {
+    throw new CryptographyError(
+      'Ciphertext too short to contain authentication tag',
+    );
+  }
+
+  const decryptionAttempts: DecryptionAttempt[] = [
+    { tagLen: 16, aad },
+    { tagLen: 16, aad: Buffer.alloc(0) },
+    { tagLen: 16, aad: undefined },
+    { tagLen: 12, aad },
+    { tagLen: 12, aad: Buffer.alloc(0) },
+  ];
+
+  for (const attempt of decryptionAttempts) {
+    try {
+      const encrypted = ciphertext.subarray(
+        0,
+        ciphertext.length - attempt.tagLen,
+      );
+      const authTag = ciphertext.subarray(ciphertext.length - attempt.tagLen);
+
+      const decipher = createDecipheriv('chacha20-poly1305', key, nonce) as any;
+      decipher.setAuthTag(authTag);
+
+      if (attempt.aad !== undefined) {
+        decipher.setAAD(attempt.aad, { plaintextLength: encrypted.length });
+      }
+
+      return Buffer.concat([decipher.update(encrypted), decipher.final()]);
+    } catch {
+      // Continue to next decryption attempt
+    }
+  }
+
+  throw new CryptographyError(
+    'ChaCha20-Poly1305 decryption failed: invalid ciphertext or authentication tag',
+  );
+}

--- a/src/lib/apple-tv/encryption/ed25519.ts
+++ b/src/lib/apple-tv/encryption/ed25519.ts
@@ -1,0 +1,121 @@
+import {
+  type KeyPairKeyObjectResult,
+  generateKeyPairSync,
+  sign,
+} from 'node:crypto';
+
+import { CryptographyError } from '../errors.js';
+import type { PairingKeys } from '../types.js';
+
+const ED25519_PUBLIC_KEY_LENGTH = 32;
+const ED25519_PRIVATE_KEY_LENGTH = 32;
+const ED25519_PKCS8_PREFIX = Buffer.from(
+  '302e020100300506032b657004220420',
+  'hex',
+);
+
+/**
+ * Generates a new Ed25519 key pair for cryptographic operations
+ * @returns PairingKeys object containing 32-byte public and private key buffers
+ * @throws CryptographyError if key generation fails
+ */
+export function generateEd25519KeyPair(): PairingKeys {
+  try {
+    const keyPair: KeyPairKeyObjectResult = generateKeyPairSync('ed25519');
+
+    const publicKeyDer = keyPair.publicKey.export({
+      type: 'spki',
+      format: 'der',
+    }) as Buffer;
+
+    const privateKeyDer = keyPair.privateKey.export({
+      type: 'pkcs8',
+      format: 'der',
+    }) as Buffer;
+
+    const publicKeyBuffer = extractEd25519PublicKey(publicKeyDer);
+    const privateKeyBuffer = extractEd25519PrivateKey(privateKeyDer);
+
+    return {
+      publicKey: publicKeyBuffer,
+      privateKey: privateKeyBuffer,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new CryptographyError(
+      `Failed to generate Ed25519 key pair: ${message}`,
+    );
+  }
+}
+
+/**
+ * Creates an Ed25519 digital signature for the provided data
+ * @param data - The data to sign
+ * @param privateKey - 32-byte Ed25519 private key
+ * @returns Buffer containing the 64-byte signature
+ * @throws CryptographyError if signing fails or private key is invalid
+ */
+export function createEd25519Signature(
+  data: Buffer,
+  privateKey: Buffer,
+): Buffer {
+  if (!data || data.length === 0) {
+    throw new CryptographyError('Data to sign cannot be empty');
+  }
+
+  if (!privateKey || privateKey.length !== ED25519_PRIVATE_KEY_LENGTH) {
+    throw new CryptographyError(
+      `Private key must be ${ED25519_PRIVATE_KEY_LENGTH} bytes`,
+    );
+  }
+
+  try {
+    const privateKeyDer = Buffer.concat([ED25519_PKCS8_PREFIX, privateKey]);
+
+    return sign(null, data, {
+      key: privateKeyDer,
+      format: 'der',
+      type: 'pkcs8',
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new CryptographyError(
+      `Failed to create Ed25519 signature: ${message}`,
+    );
+  }
+}
+
+/**
+ * Extracts the raw 32-byte public key from DER-encoded SPKI format
+ * @param publicKeyDer - DER-encoded public key
+ * @returns 32-byte public key buffer
+ * @throws CryptographyError if extraction fails
+ */
+function extractEd25519PublicKey(publicKeyDer: Buffer): Buffer {
+  if (publicKeyDer.length < ED25519_PUBLIC_KEY_LENGTH) {
+    throw new CryptographyError('Invalid public key DER format');
+  }
+
+  return publicKeyDer.subarray(publicKeyDer.length - ED25519_PUBLIC_KEY_LENGTH);
+}
+
+/**
+ * Extracts the raw 32-byte private key from DER-encoded PKCS#8 format
+ * @param privateKeyDer - DER-encoded private key
+ * @returns 32-byte private key buffer
+ * @throws CryptographyError if extraction fails
+ */
+function extractEd25519PrivateKey(privateKeyDer: Buffer): Buffer {
+  const octetStringPattern = Buffer.from([0x04, 0x20]);
+  const index = privateKeyDer.indexOf(octetStringPattern);
+
+  if (index !== -1 && index + 34 <= privateKeyDer.length) {
+    return privateKeyDer.subarray(index + 2, index + 34);
+  }
+
+  if (privateKeyDer.length >= 48) {
+    return privateKeyDer.subarray(16, 48);
+  }
+
+  throw new CryptographyError('Unable to extract private key from DER format');
+}

--- a/src/lib/apple-tv/encryption/ed25519.ts
+++ b/src/lib/apple-tv/encryption/ed25519.ts
@@ -1,3 +1,4 @@
+import { logger } from '@appium/support';
 import {
   type KeyPairKeyObjectResult,
   generateKeyPairSync,
@@ -6,6 +7,8 @@ import {
 
 import { CryptographyError } from '../errors.js';
 import type { PairingKeys } from '../types.js';
+
+const log = logger.getLogger('Ed25519');
 
 const ED25519_PUBLIC_KEY_LENGTH = 32;
 const ED25519_PRIVATE_KEY_LENGTH = 32;
@@ -41,6 +44,7 @@ export function generateEd25519KeyPair(): PairingKeys {
       privateKey: privateKeyBuffer,
     };
   } catch (error) {
+    log.error('Failed to generate Ed25519 key pair:', error);
     const message = error instanceof Error ? error.message : String(error);
     throw new CryptographyError(
       `Failed to generate Ed25519 key pair: ${message}`,
@@ -78,6 +82,7 @@ export function createEd25519Signature(
       type: 'pkcs8',
     });
   } catch (error) {
+    log.error('Failed to create Ed25519 signature:', error);
     const message = error instanceof Error ? error.message : String(error);
     throw new CryptographyError(
       `Failed to create Ed25519 signature: ${message}`,

--- a/src/lib/apple-tv/encryption/hkdf.ts
+++ b/src/lib/apple-tv/encryption/hkdf.ts
@@ -1,7 +1,10 @@
+import { logger } from '@appium/support';
 import { createHmac } from 'node:crypto';
 
 import { HKDF_HASH_ALGORITHM, HKDF_HASH_LENGTH } from '../constants.js';
 import { CryptographyError } from '../errors.js';
+
+const log = logger.getLogger('HKDF');
 
 export interface HKDFParams {
   ikm: Buffer;
@@ -47,6 +50,7 @@ export function hkdf(params: HKDFParams): Buffer {
     const extractedKey = hkdfExtract(ikm, salt);
     return hkdfExpand(extractedKey, info, length);
   } catch (error) {
+    log.error('HKDF derivation failed:', error);
     const message = error instanceof Error ? error.message : String(error);
     throw new CryptographyError(`HKDF derivation failed: ${message}`);
   }
@@ -73,7 +77,7 @@ function hkdfExtract(ikm: Buffer, salt: Buffer | null): Buffer {
 function hkdfExpand(prk: Buffer, info: Buffer, length: number): Buffer {
   const numberOfBlocks = Math.ceil(length / HKDF_HASH_LENGTH);
   const blocks: Buffer[] = [];
-  let previousBlock: Buffer<ArrayBufferLike> = Buffer.alloc(0);
+  let previousBlock: Buffer = Buffer.alloc(0);
 
   for (let blockIndex = 1; blockIndex <= numberOfBlocks; blockIndex++) {
     const hmac = createHmac(HKDF_HASH_ALGORITHM, prk);

--- a/src/lib/apple-tv/encryption/hkdf.ts
+++ b/src/lib/apple-tv/encryption/hkdf.ts
@@ -1,0 +1,91 @@
+import { createHmac } from 'node:crypto';
+
+import { HKDF_HASH_ALGORITHM, HKDF_HASH_LENGTH } from '../constants.js';
+import { CryptographyError } from '../errors.js';
+
+export interface HKDFParams {
+  ikm: Buffer;
+  salt: Buffer | null;
+  info: Buffer;
+  length: number;
+}
+
+const MAX_OUTPUT_LENGTH = 255 * HKDF_HASH_LENGTH;
+
+/**
+ * HMAC-based Key Derivation Function (HKDF) as defined in RFC 5869
+ * Derives cryptographic keys from input key material using a two-step process:
+ * 1. Extract: Generate a pseudorandom key from the input key material
+ * 2. Expand: Expand the pseudorandom key to the desired output length
+ *
+ * @param params - HKDF parameters including input key material, salt, info, and desired output length
+ * @returns Buffer containing the derived key material of specified length
+ * @throws CryptographyError if derivation fails or parameters are invalid
+ */
+export function hkdf(params: HKDFParams): Buffer {
+  const { ikm, salt, info, length } = params;
+
+  if (!ikm || ikm.length === 0) {
+    throw new CryptographyError('Input key material (IKM) cannot be empty');
+  }
+
+  if (!info) {
+    throw new CryptographyError('Info parameter is required');
+  }
+
+  if (length <= 0) {
+    throw new CryptographyError('Output length must be positive');
+  }
+
+  if (length > MAX_OUTPUT_LENGTH) {
+    throw new CryptographyError(
+      `Output length cannot exceed ${MAX_OUTPUT_LENGTH} bytes`,
+    );
+  }
+
+  try {
+    const extractedKey = hkdfExtract(ikm, salt);
+    return hkdfExpand(extractedKey, info, length);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new CryptographyError(`HKDF derivation failed: ${message}`);
+  }
+}
+
+/**
+ * HKDF Extract step: generates a pseudorandom key from input key material
+ * @param ikm - Input key material
+ * @param salt - Optional salt value (uses zero salt if null)
+ * @returns Pseudorandom key of hash length
+ */
+function hkdfExtract(ikm: Buffer, salt: Buffer | null): Buffer {
+  const actualSalt = salt || Buffer.alloc(HKDF_HASH_LENGTH);
+  return createHmac(HKDF_HASH_ALGORITHM, actualSalt).update(ikm).digest();
+}
+
+/**
+ * HKDF Expand a step: expands a pseudorandom key to desired output length
+ * @param prk - Pseudorandom key from extract step
+ * @param info - Context and application specific information
+ * @param length - Desired output key material length
+ * @returns Output key material of specified length
+ */
+function hkdfExpand(prk: Buffer, info: Buffer, length: number): Buffer {
+  const numberOfBlocks = Math.ceil(length / HKDF_HASH_LENGTH);
+  const blocks: Buffer[] = [];
+  let previousBlock: Buffer<ArrayBufferLike> = Buffer.alloc(0);
+
+  for (let blockIndex = 1; blockIndex <= numberOfBlocks; blockIndex++) {
+    const hmac = createHmac(HKDF_HASH_ALGORITHM, prk);
+    hmac.update(previousBlock);
+    hmac.update(info);
+    hmac.update(Buffer.from([blockIndex]));
+
+    const currentBlock = hmac.digest();
+    blocks.push(currentBlock);
+    previousBlock = currentBlock;
+  }
+
+  const outputKeyMaterial = Buffer.concat(blocks);
+  return outputKeyMaterial.subarray(0, length);
+}

--- a/src/lib/apple-tv/encryption/index.ts
+++ b/src/lib/apple-tv/encryption/index.ts
@@ -1,0 +1,11 @@
+export { Opack2 } from './opack2.js';
+
+export {
+  encryptChaCha20Poly1305,
+  decryptChaCha20Poly1305,
+  type ChaCha20Poly1305Params,
+} from './chacha20-poly1305.js';
+
+export { generateEd25519KeyPair, createEd25519Signature } from './ed25519.js';
+
+export { hkdf, type HKDFParams } from './hkdf.js';

--- a/src/lib/apple-tv/encryption/opack2.ts
+++ b/src/lib/apple-tv/encryption/opack2.ts
@@ -1,0 +1,245 @@
+import {
+  OPACK2_FALSE,
+  OPACK2_NULL,
+  OPACK2_SMALL_ARRAY_MAX,
+  OPACK2_SMALL_BYTES_MAX,
+  OPACK2_SMALL_DICT_MAX,
+  OPACK2_SMALL_INT_MAX,
+  OPACK2_SMALL_INT_OFFSET,
+  OPACK2_SMALL_STRING_MAX,
+  OPACK2_TRUE,
+} from '../constants.js';
+import { AppleTVError } from '../errors.js';
+
+interface SerializableArray extends Array<SerializableValue> {}
+interface SerializableObject extends Record<string, SerializableValue> {}
+
+type SerializableValue =
+  | null
+  | undefined
+  | boolean
+  | number
+  | string
+  | Buffer
+  | SerializableArray
+  | SerializableObject;
+
+/**
+ * OPACK2 binary serialization format encoder
+ * Implements Apple's OPACK2 protocol for efficient binary serialization of structured data
+ */
+export class Opack2 {
+  /**
+   * Serializes a JavaScript object to OPACK2 binary format
+   * @param obj - The object to serialize (supports primitives, arrays, objects, and Buffers)
+   * @returns Buffer containing the serialized data
+   * @throws AppleTVError if the object contains unsupported types
+   */
+  static dumps(obj: SerializableValue): Buffer {
+    return this.encode(obj);
+  }
+
+  /**
+   * Main encoding dispatcher that routes values to appropriate type-specific encoders
+   * @param obj - Value to encode
+   * @returns Buffer containing encoded value
+   * @throws AppleTVError for unsupported types
+   */
+  private static encode(obj: SerializableValue): Buffer {
+    if (obj === null || obj === undefined) {
+      return Buffer.from([OPACK2_NULL]);
+    }
+
+    if (typeof obj === 'boolean') {
+      return Buffer.from([obj ? OPACK2_TRUE : OPACK2_FALSE]);
+    }
+
+    if (typeof obj === 'number') {
+      return this.encodeNumber(obj);
+    }
+
+    if (typeof obj === 'string') {
+      return this.encodeString(obj);
+    }
+
+    if (Buffer.isBuffer(obj)) {
+      return this.encodeBytes(obj);
+    }
+
+    if (Array.isArray(obj)) {
+      return this.encodeArray(obj);
+    }
+
+    if (
+      typeof obj === 'object' &&
+      !Array.isArray(obj) &&
+      !Buffer.isBuffer(obj)
+    ) {
+      return this.encodeDict(obj as Record<string, SerializableValue>);
+    }
+
+    throw new AppleTVError(
+      `Unsupported type for OPACK2 serialization: ${typeof obj}`,
+    );
+  }
+
+  /**
+   * Encodes numeric values with the appropriate size optimization
+   * @param num - Number to encode
+   * @returns Buffer containing encoded number
+   */
+  private static encodeNumber(num: number): Buffer {
+    if (!Number.isInteger(num) || num < 0) {
+      const buffer = Buffer.allocUnsafe(5);
+      buffer[0] = 0x35;
+      buffer.writeFloatLE(num, 1);
+      return buffer;
+    }
+
+    if (num <= OPACK2_SMALL_INT_MAX) {
+      return Buffer.from([num + OPACK2_SMALL_INT_OFFSET]);
+    }
+
+    if (num <= 0xff) {
+      return Buffer.from([0x30, num]);
+    }
+
+    if (num <= 0xffffffff) {
+      const buffer = Buffer.allocUnsafe(5);
+      buffer[0] = 0x32;
+      buffer.writeUInt32LE(num, 1);
+      return buffer;
+    }
+
+    if (num <= Number.MAX_SAFE_INTEGER) {
+      const buffer = Buffer.allocUnsafe(9);
+      buffer[0] = 0x33;
+      buffer.writeBigUInt64LE(BigInt(num), 1);
+      return buffer;
+    }
+
+    throw new AppleTVError(`Number too large for OPACK2 encoding: ${num}`);
+  }
+
+  /**
+   * Encodes UTF-8 strings with length-optimized headers
+   * @param str - String to encode
+   * @returns Buffer containing encoded string
+   */
+  private static encodeString(str: string): Buffer {
+    const encoded = Buffer.from(str, 'utf8');
+    const length = encoded.length;
+
+    if (length <= OPACK2_SMALL_STRING_MAX) {
+      return Buffer.concat([Buffer.from([0x40 + length]), encoded]);
+    }
+
+    if (length <= 0xff) {
+      return Buffer.concat([Buffer.from([0x61, length]), encoded]);
+    }
+
+    if (length <= 0xffff) {
+      const header = Buffer.allocUnsafe(3);
+      header[0] = 0x62;
+      header.writeUInt16BE(length, 1);
+      return Buffer.concat([header, encoded]);
+    }
+
+    if (length <= 0xffffffff) {
+      const header = Buffer.allocUnsafe(5);
+      header[0] = 0x63;
+      header.writeUInt32BE(length, 1);
+      return Buffer.concat([header, encoded]);
+    }
+
+    throw new AppleTVError(
+      `String too long for OPACK2 encoding: ${length} bytes`,
+    );
+  }
+
+  /**
+   * Encodes binary data with length-optimized headers
+   * @param bytes - Buffer to encode
+   * @returns Buffer containing encoded binary data
+   */
+  private static encodeBytes(bytes: Buffer): Buffer {
+    const length = bytes.length;
+
+    if (length <= OPACK2_SMALL_BYTES_MAX) {
+      return Buffer.concat([Buffer.from([0x70 + length]), bytes]);
+    }
+
+    if (length <= 0xff) {
+      return Buffer.concat([Buffer.from([0x91, length]), bytes]);
+    }
+
+    if (length <= 0xffff) {
+      const header = Buffer.allocUnsafe(3);
+      header[0] = 0x92;
+      header.writeUInt16BE(length, 1);
+      return Buffer.concat([header, bytes]);
+    }
+
+    if (length <= 0xffffffff) {
+      const header = Buffer.allocUnsafe(5);
+      header[0] = 0x93;
+      header.writeUInt32BE(length, 1);
+      return Buffer.concat([header, bytes]);
+    }
+
+    throw new AppleTVError(
+      `Byte array too long for OPACK2 encoding: ${length} bytes`,
+    );
+  }
+
+  /**
+   * Encodes arrays with count-optimized headers
+   * @param arr - Array to encode
+   * @returns Buffer containing encoded array
+   */
+  private static encodeArray(arr: SerializableValue[]): Buffer {
+    const length = arr.length;
+
+    if (length < OPACK2_SMALL_ARRAY_MAX) {
+      const parts = [Buffer.from([0xd0 + length])];
+      for (const item of arr) {
+        parts.push(Buffer.from(this.encode(item)));
+      }
+      return Buffer.concat(parts);
+    }
+
+    const parts = [Buffer.from([0xdf])];
+    for (const item of arr) {
+      parts.push(Buffer.from(this.encode(item)));
+    }
+    parts.push(Buffer.from([OPACK2_NULL]));
+    return Buffer.concat(parts);
+  }
+
+  /**
+   * Encodes objects/dictionaries with count-optimized headers
+   * @param dict - Object to encode
+   * @returns Buffer containing encoded dictionary
+   */
+  private static encodeDict(dict: Record<string, SerializableValue>): Buffer {
+    const entries = Object.entries(dict);
+    const length = entries.length;
+
+    if (length < OPACK2_SMALL_DICT_MAX) {
+      const parts = [Buffer.from([0xe0 + length])];
+      for (const [key, value] of entries) {
+        parts.push(Buffer.from(this.encode(key)));
+        parts.push(Buffer.from(this.encode(value)));
+      }
+      return Buffer.concat(parts);
+    }
+
+    const parts = [Buffer.from([0xef])];
+    for (const [key, value] of entries) {
+      parts.push(Buffer.from(this.encode(key)));
+      parts.push(Buffer.from(this.encode(value)));
+    }
+    parts.push(Buffer.from([OPACK2_NULL, OPACK2_NULL]));
+    return Buffer.concat(parts);
+  }
+}

--- a/test/unit/apple-tv/encryption/chacha20-poly1305.spec.ts
+++ b/test/unit/apple-tv/encryption/chacha20-poly1305.spec.ts
@@ -1,0 +1,151 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import {
+  type ChaCha20Poly1305Params,
+  decryptChaCha20Poly1305,
+  encryptChaCha20Poly1305,
+} from '../../../../src/lib/apple-tv/encryption/chacha20-poly1305.js';
+import { CryptographyError } from '../../../../src/lib/apple-tv/errors.js';
+
+describe('Apple TV Encryption - ChaCha20-Poly1305', () => {
+  const validKey = Buffer.alloc(32, 0x42);
+  const validNonce = Buffer.alloc(12, 0x24);
+  const plaintext = Buffer.from('Hello, World!', 'utf8');
+  const aad = Buffer.from('additional authenticated data', 'utf8');
+
+  describe('encryptChaCha20Poly1305', () => {
+    it('should encrypt plaintext without AAD', () => {
+      const params: ChaCha20Poly1305Params = {
+        plaintext,
+        key: validKey,
+        nonce: validNonce,
+      };
+
+      const result = encryptChaCha20Poly1305(params);
+
+      expect(result).to.be.instanceOf(Buffer);
+      expect(result.length).to.equal(plaintext.length + 16);
+    });
+
+    it('should encrypt plaintext with AAD', () => {
+      const params: ChaCha20Poly1305Params = {
+        plaintext,
+        key: validKey,
+        nonce: validNonce,
+        aad,
+      };
+
+      const result = encryptChaCha20Poly1305(params);
+
+      expect(result).to.be.instanceOf(Buffer);
+      expect(result.length).to.equal(plaintext.length + 16);
+    });
+
+    it('should throw when plaintext is missing', () => {
+      const params: ChaCha20Poly1305Params = {
+        key: validKey,
+        nonce: validNonce,
+      };
+
+      expect(() => encryptChaCha20Poly1305(params)).to.throw(
+        CryptographyError,
+        'Plaintext is required for encryption',
+      );
+    });
+
+    it('should throw when key is wrong size', () => {
+      const params: ChaCha20Poly1305Params = {
+        plaintext,
+        key: Buffer.alloc(16),
+        nonce: validNonce,
+      };
+
+      expect(() => encryptChaCha20Poly1305(params)).to.throw(
+        CryptographyError,
+        'Key must be 32 bytes',
+      );
+    });
+
+    it('should throw when nonce is wrong size', () => {
+      const params: ChaCha20Poly1305Params = {
+        plaintext,
+        key: validKey,
+        nonce: Buffer.alloc(8),
+      };
+
+      expect(() => encryptChaCha20Poly1305(params)).to.throw(
+        CryptographyError,
+        'Nonce must be 12 bytes',
+      );
+    });
+  });
+
+  describe('decryptChaCha20Poly1305', () => {
+    it('should decrypt ciphertext without AAD', () => {
+      const encrypted = encryptChaCha20Poly1305({
+        plaintext,
+        key: validKey,
+        nonce: validNonce,
+      });
+
+      const decrypted = decryptChaCha20Poly1305({
+        ciphertext: encrypted,
+        key: validKey,
+        nonce: validNonce,
+      });
+
+      expect(decrypted).to.be.instanceOf(Buffer);
+      expect(decrypted.equals(plaintext)).to.be.true;
+    });
+
+    it('should decrypt ciphertext with AAD', () => {
+      const encrypted = encryptChaCha20Poly1305({
+        plaintext,
+        key: validKey,
+        nonce: validNonce,
+        aad,
+      });
+
+      const decrypted = decryptChaCha20Poly1305({
+        ciphertext: encrypted,
+        key: validKey,
+        nonce: validNonce,
+        aad,
+      });
+
+      expect(decrypted.equals(plaintext)).to.be.true;
+    });
+
+    it('should fail to decrypt with wrong key', () => {
+      const encrypted = encryptChaCha20Poly1305({
+        plaintext,
+        key: validKey,
+        nonce: validNonce,
+      });
+
+      const wrongKey = Buffer.alloc(32, 0x99);
+
+      expect(() =>
+        decryptChaCha20Poly1305({
+          ciphertext: encrypted,
+          key: wrongKey,
+          nonce: validNonce,
+        }),
+      ).to.throw(CryptographyError, 'ChaCha20-Poly1305 decryption failed');
+    });
+
+    it('should throw when ciphertext is too short', () => {
+      const params: ChaCha20Poly1305Params = {
+        ciphertext: Buffer.alloc(10),
+        key: validKey,
+        nonce: validNonce,
+      };
+
+      expect(() => decryptChaCha20Poly1305(params)).to.throw(
+        CryptographyError,
+        'Ciphertext too short to contain authentication tag',
+      );
+    });
+  });
+});

--- a/test/unit/apple-tv/encryption/ed25519.spec.ts
+++ b/test/unit/apple-tv/encryption/ed25519.spec.ts
@@ -1,0 +1,86 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import {
+  createEd25519Signature,
+  generateEd25519KeyPair,
+} from '../../../../src/lib/apple-tv/encryption/ed25519.js';
+import { CryptographyError } from '../../../../src/lib/apple-tv/errors.js';
+
+describe('Apple TV Encryption - Ed25519', () => {
+  describe('generateEd25519KeyPair', () => {
+    it('should generate a valid key pair', () => {
+      const keyPair = generateEd25519KeyPair();
+
+      expect(keyPair).to.have.property('publicKey');
+      expect(keyPair).to.have.property('privateKey');
+      expect(keyPair.publicKey).to.be.instanceOf(Buffer);
+      expect(keyPair.privateKey).to.be.instanceOf(Buffer);
+      expect(keyPair.publicKey.length).to.equal(32);
+      expect(keyPair.privateKey.length).to.equal(32);
+    });
+
+    it('should generate different key pairs each time', () => {
+      const keyPair1 = generateEd25519KeyPair();
+      const keyPair2 = generateEd25519KeyPair();
+
+      expect(keyPair1.publicKey.equals(keyPair2.publicKey)).to.be.false;
+      expect(keyPair1.privateKey.equals(keyPair2.privateKey)).to.be.false;
+    });
+  });
+
+  describe('createEd25519Signature', () => {
+    let validPrivateKey: Buffer;
+
+    beforeEach(function () {
+      const keyPair = generateEd25519KeyPair();
+      validPrivateKey = keyPair.privateKey;
+    });
+
+    it('should create a valid signature', () => {
+      const data = Buffer.from('Hello, World!', 'utf8');
+      const signature = createEd25519Signature(data, validPrivateKey);
+
+      expect(signature).to.be.instanceOf(Buffer);
+      expect(signature.length).to.equal(64);
+    });
+
+    it('should create consistent signatures for same data and key', () => {
+      const data = Buffer.from('Test message', 'utf8');
+
+      const signature1 = createEd25519Signature(data, validPrivateKey);
+      const signature2 = createEd25519Signature(data, validPrivateKey);
+
+      expect(signature1.equals(signature2)).to.be.true;
+    });
+
+    it('should create different signatures for different data', () => {
+      const data1 = Buffer.from('Message 1', 'utf8');
+      const data2 = Buffer.from('Message 2', 'utf8');
+
+      const signature1 = createEd25519Signature(data1, validPrivateKey);
+      const signature2 = createEd25519Signature(data2, validPrivateKey);
+
+      expect(signature1.equals(signature2)).to.be.false;
+    });
+
+    it('should throw when data is empty', () => {
+      const emptyData = Buffer.alloc(0);
+
+      expect(() => createEd25519Signature(emptyData, validPrivateKey)).to.throw(
+        CryptographyError,
+        'Data to sign cannot be empty',
+      );
+    });
+
+    it('should throw when private key is wrong size', () => {
+      const data = Buffer.from('test', 'utf8');
+      const shortKey = Buffer.alloc(16);
+
+      expect(() => createEd25519Signature(data, shortKey)).to.throw(
+        CryptographyError,
+        'Private key must be 32 bytes',
+      );
+    });
+  });
+});

--- a/test/unit/apple-tv/encryption/hkdf.spec.ts
+++ b/test/unit/apple-tv/encryption/hkdf.spec.ts
@@ -1,0 +1,163 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import {
+  type HKDFParams,
+  hkdf,
+} from '../../../../src/lib/apple-tv/encryption/hkdf.js';
+import { CryptographyError } from '../../../../src/lib/apple-tv/errors.js';
+
+describe('Apple TV Encryption - HKDF', () => {
+  const defaultIkm = Buffer.from('input key material', 'utf8');
+  const defaultSalt = Buffer.from('salt value', 'utf8');
+  const defaultInfo = Buffer.from('info string', 'utf8');
+
+  describe('basic functionality', () => {
+    it('should derive key with all parameters', () => {
+      const params: HKDFParams = {
+        ikm: defaultIkm,
+        salt: defaultSalt,
+        info: defaultInfo,
+        length: 32,
+      };
+
+      const result = hkdf(params);
+
+      expect(result).to.be.instanceOf(Buffer);
+      expect(result.length).to.equal(32);
+    });
+
+    it('should derive key with null salt', () => {
+      const params: HKDFParams = {
+        ikm: defaultIkm,
+        salt: null,
+        info: defaultInfo,
+        length: 32,
+      };
+
+      const result = hkdf(params);
+
+      expect(result).to.be.instanceOf(Buffer);
+      expect(result.length).to.equal(32);
+    });
+
+    it('should produce consistent results for same inputs', () => {
+      const params: HKDFParams = {
+        ikm: defaultIkm,
+        salt: defaultSalt,
+        info: defaultInfo,
+        length: 48,
+      };
+
+      const result1 = hkdf(params);
+      const result2 = hkdf(params);
+
+      expect(result1.equals(result2)).to.be.true;
+    });
+
+    it('should produce different results for different IKM', () => {
+      const params1: HKDFParams = {
+        ikm: Buffer.from('ikm1', 'utf8'),
+        salt: defaultSalt,
+        info: defaultInfo,
+        length: 32,
+      };
+
+      const params2: HKDFParams = {
+        ikm: Buffer.from('ikm2', 'utf8'),
+        salt: defaultSalt,
+        info: defaultInfo,
+        length: 32,
+      };
+
+      const result1 = hkdf(params1);
+      const result2 = hkdf(params2);
+
+      expect(result1.equals(result2)).to.be.false;
+    });
+  });
+
+  describe('output length variations', () => {
+    it('should handle minimum length (1 byte)', () => {
+      const params: HKDFParams = {
+        ikm: defaultIkm,
+        salt: defaultSalt,
+        info: defaultInfo,
+        length: 1,
+      };
+      const result = hkdf(params);
+
+      expect(result.length).to.equal(1);
+    });
+
+    it('should handle maximum allowed length (255 * 64 = 16320 bytes)', () => {
+      const params: HKDFParams = {
+        ikm: defaultIkm,
+        salt: defaultSalt,
+        info: defaultInfo,
+        length: 16320,
+      };
+      const result = hkdf(params);
+
+      expect(result.length).to.equal(16320);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should throw when IKM is empty', () => {
+      const params: HKDFParams = {
+        ikm: Buffer.alloc(0),
+        salt: defaultSalt,
+        info: defaultInfo,
+        length: 32,
+      };
+
+      expect(() => hkdf(params)).to.throw(
+        CryptographyError,
+        'Input key material (IKM) cannot be empty',
+      );
+    });
+
+    it('should throw when info is missing', () => {
+      const params: HKDFParams = {
+        ikm: defaultIkm,
+        salt: defaultSalt,
+        info: null as any,
+        length: 32,
+      };
+
+      expect(() => hkdf(params)).to.throw(
+        CryptographyError,
+        'Info parameter is required',
+      );
+    });
+
+    it('should throw when length is zero', () => {
+      const params: HKDFParams = {
+        ikm: defaultIkm,
+        salt: defaultSalt,
+        info: defaultInfo,
+        length: 0,
+      };
+
+      expect(() => hkdf(params)).to.throw(
+        CryptographyError,
+        'Output length must be positive',
+      );
+    });
+
+    it('should throw when length exceeds maximum', () => {
+      const params: HKDFParams = {
+        ikm: defaultIkm,
+        salt: defaultSalt,
+        info: defaultInfo,
+        length: 16321,
+      };
+
+      expect(() => hkdf(params)).to.throw(
+        CryptographyError,
+        'Output length cannot exceed 16320 bytes',
+      );
+    });
+  });
+});

--- a/test/unit/apple-tv/encryption/opack2.spec.ts
+++ b/test/unit/apple-tv/encryption/opack2.spec.ts
@@ -1,0 +1,190 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { Opack2 } from '../../../../src/lib/apple-tv/encryption/opack2.js';
+import { AppleTVError } from '../../../../src/lib/apple-tv/errors.js';
+
+describe('Apple TV Encryption - Opack2', () => {
+  describe('dumps - primitive types', () => {
+    it('should encode null', () => {
+      const result = Opack2.dumps(null);
+      expect(result).to.deep.equal(Buffer.from([0x03]));
+    });
+
+    it('should encode undefined as null', () => {
+      const result = Opack2.dumps(undefined);
+      expect(result).to.deep.equal(Buffer.from([0x03]));
+    });
+
+    it('should encode boolean true', () => {
+      const result = Opack2.dumps(true);
+      expect(result).to.deep.equal(Buffer.from([0x01]));
+    });
+
+    it('should encode boolean false', () => {
+      const result = Opack2.dumps(false);
+      expect(result).to.deep.equal(Buffer.from([0x02]));
+    });
+  });
+
+  describe('dumps - number encoding', () => {
+    it('should encode small integers (0-39)', () => {
+      expect(Opack2.dumps(0)).to.deep.equal(Buffer.from([0x08]));
+      expect(Opack2.dumps(1)).to.deep.equal(Buffer.from([0x09]));
+      expect(Opack2.dumps(39)).to.deep.equal(Buffer.from([0x2f]));
+    });
+
+    it('should encode single byte integers (40-255)', () => {
+      const result = Opack2.dumps(40);
+      expect(result).to.deep.equal(Buffer.from([0x30, 0x28]));
+    });
+
+    it('should encode 32-bit integers', () => {
+      const result = Opack2.dumps(256);
+      expect(result[0]).to.equal(0x32);
+      expect(result.length).to.equal(5);
+    });
+
+    it('should encode negative numbers as float', () => {
+      const result = Opack2.dumps(-1);
+      expect(result[0]).to.equal(0x35);
+      expect(result.length).to.equal(5);
+    });
+
+    it('should throw for numbers too large', () => {
+      const tooLarge = Number.MAX_SAFE_INTEGER + 1;
+      expect(() => Opack2.dumps(tooLarge)).to.throw(
+        AppleTVError,
+        'Number too large for OPACK2 encoding',
+      );
+    });
+  });
+
+  describe('dumps - string encoding', () => {
+    it('should encode empty string', () => {
+      const result = Opack2.dumps('');
+      expect(result).to.deep.equal(Buffer.from([0x40]));
+    });
+
+    it('should encode short strings', () => {
+      const result = Opack2.dumps('Hello');
+      expect(result[0]).to.equal(0x45);
+      expect(result.subarray(1).toString('utf8')).to.equal('Hello');
+    });
+
+    it('should handle UTF-8 strings correctly', () => {
+      const utf8Str = '你好世界🌍';
+      const result = Opack2.dumps(utf8Str);
+      const byteLength = Buffer.from(utf8Str, 'utf8').length;
+      expect(result[0]).to.equal(0x40 + byteLength);
+      expect(result.subarray(1).toString('utf8')).to.equal(utf8Str);
+    });
+  });
+
+  describe('dumps - buffer encoding', () => {
+    it('should encode empty buffer', () => {
+      const result = Opack2.dumps(Buffer.alloc(0));
+      expect(result).to.deep.equal(Buffer.from([0x70]));
+    });
+
+    it('should encode short buffers', () => {
+      const buf = Buffer.from([0x01, 0x02, 0x03]);
+      const result = Opack2.dumps(buf);
+      expect(result[0]).to.equal(0x73);
+      expect(result.subarray(1)).to.deep.equal(buf);
+    });
+  });
+
+  describe('dumps - array encoding', () => {
+    it('should encode empty array', () => {
+      const result = Opack2.dumps([]);
+      expect(result).to.deep.equal(Buffer.from([0xd0]));
+    });
+
+    it('should encode small arrays', () => {
+      const result = Opack2.dumps([1, 2, 3]);
+      expect(result[0]).to.equal(0xd3);
+      expect(result[1]).to.equal(0x09);
+      expect(result[2]).to.equal(0x0a);
+      expect(result[3]).to.equal(0x0b);
+    });
+
+    it('should encode large arrays', () => {
+      const arr = Array(20).fill(true);
+      const result = Opack2.dumps(arr);
+      expect(result[0]).to.equal(0xdf);
+      expect(result[result.length - 1]).to.equal(0x03);
+    });
+  });
+
+  describe('dumps - object encoding', () => {
+    it('should encode empty object', () => {
+      const result = Opack2.dumps({});
+      expect(result).to.deep.equal(Buffer.from([0xe0]));
+    });
+
+    it('should encode small objects', () => {
+      const obj = { a: 1, b: 2 };
+      const result = Opack2.dumps(obj);
+      expect(result[0]).to.equal(0xe2);
+    });
+
+    it('should handle objects with undefined values', () => {
+      const obj = { a: 1, b: undefined, c: 3 };
+      const result = Opack2.dumps(obj);
+      expect(result[0]).to.equal(0xe3);
+    });
+
+    it('should encode large objects', () => {
+      const obj: Record<string, number> = {};
+      for (let i = 0; i < 20; i++) {
+        obj[`key${i}`] = i;
+      }
+      const result = Opack2.dumps(obj);
+      expect(result[0]).to.equal(0xef);
+      expect(result[result.length - 2]).to.equal(0x03);
+      expect(result[result.length - 1]).to.equal(0x03);
+    });
+  });
+
+  describe('dumps - error handling', () => {
+    it('should throw for unsupported types - function', () => {
+      const fn = () => {};
+      expect(() => Opack2.dumps(fn as any)).to.throw(
+        AppleTVError,
+        'Unsupported type for OPACK2 serialization: function',
+      );
+    });
+
+    it('should throw for unsupported types - symbol', () => {
+      const sym = Symbol('test');
+      expect(() => Opack2.dumps(sym as any)).to.throw(
+        AppleTVError,
+        'Unsupported type for OPACK2 serialization: symbol',
+      );
+    });
+  });
+
+  describe('dumps - complex structures', () => {
+    it('should encode nested structures', () => {
+      const complex = {
+        users: [
+          {
+            id: 1,
+            name: 'Alice',
+            active: true,
+            data: Buffer.from([0x01, 0x02, 0x03]),
+          },
+        ],
+        config: {
+          version: 3.14,
+          features: ['feature1', 'feature2'],
+        },
+      };
+
+      const result = Opack2.dumps(complex);
+      expect(result).to.be.instanceOf(Buffer);
+      expect(result.length).to.be.greaterThan(20);
+    });
+  });
+});


### PR DESCRIPTION
The lib/apple-tv/encryption module provides cryptographic utilities required for secure communication with Apple TV devices in the RemoteXPC protocol. added files

- __ChaCha20-Poly1305__ (`chacha20-poly1305.ts`): AEAD encryption/decryption for secure message exchange
- __Ed25519__ (`ed25519.ts`): Digital signature generation and key pair management for device authentication
- __HKDF__ (`hkdf.ts`): Key derivation function for generating session keys from shared secrets
- __OPACK2__ (`opack2.ts`): Apple's proprietary binary serialization format for efficient data encoding
