### PR TITLE
fix: To close the connection on appium-xcuitest-driver we need to expose remoteXPC

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export type {
   TunnelResult,
   TunnelRegistry,
   TunnelRegistryEntry,
+  DiagnosticsServiceWithConnection,
 } from './lib/types.js';
 export {
   createUsbmux,

--- a/src/lib/remote-xpc/remote-xpc-connection.ts
+++ b/src/lib/remote-xpc/remote-xpc-connection.ts
@@ -457,5 +457,4 @@ function extractServices(response: string): ServicesResponse {
   return { services };
 }
 
-export default RemoteXpcConnection;
-export { type Service, type ServicesResponse };
+export { RemoteXpcConnection, type Service, type ServicesResponse };

--- a/src/lib/tunnel/index.ts
+++ b/src/lib/tunnel/index.ts
@@ -2,7 +2,7 @@ import { logger } from '@appium/support';
 import type { TLSSocket } from 'tls';
 import { type TunnelConnection, connectToTunnelLockdown } from 'tuntap-bridge';
 
-import RemoteXpcConnection from '../remote-xpc/remote-xpc-connection.js';
+import { RemoteXpcConnection } from '../remote-xpc/remote-xpc-connection.js';
 
 const log = logger.getLogger('TunnelManager');
 
@@ -251,5 +251,5 @@ class TunnelManagerService {
 // Create and export the singleton instance
 export const TunnelManager = new TunnelManagerService();
 // Export packet streaming IPC functionality
-export { PacketStreamServer } from './packet-stream-server.js';
 export { PacketStreamClient } from './packet-stream-client.js';
+export { PacketStreamServer } from './packet-stream-server.js';

--- a/src/lib/tunnel/index.ts
+++ b/src/lib/tunnel/index.ts
@@ -64,9 +64,12 @@ class TunnelManagerService {
   async createRemoteXPCConnection(
     address: string,
     rsdPort: number,
-  ): Promise<any> {
+  ): Promise<RemoteXpcConnection> {
     try {
-      const remoteXPC = new RemoteXpcConnection([address, rsdPort]);
+      const remoteXPC: RemoteXpcConnection = new RemoteXpcConnection([
+        address,
+        rsdPort,
+      ]);
 
       // Connect to RemoteXPC with delay between retries
       let retries = 3;
@@ -75,7 +78,6 @@ class TunnelManagerService {
       while (retries > 0) {
         try {
           await remoteXPC.connect();
-
           // Update the registry entry with the RemoteXPC connection
           const entry = this.tunnelRegistry.get(address);
           if (entry) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -5,7 +5,7 @@ import { EventEmitter } from 'events';
 import type { PacketData } from 'tuntap-bridge';
 
 import type { BaseService, Service } from '../services/ios/base-service.js';
-import type RemoteXpcConnection from './remote-xpc/remote-xpc-connection.js';
+import type { RemoteXpcConnection } from './remote-xpc/remote-xpc-connection.js';
 import type { Device } from './usbmux/index.js';
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -5,6 +5,7 @@ import { EventEmitter } from 'events';
 import type { PacketData } from 'tuntap-bridge';
 
 import type { BaseService, Service } from '../services/ios/base-service.js';
+import type RemoteXpcConnection from './remote-xpc/remote-xpc-connection.js';
 import type { Device } from './usbmux/index.js';
 
 /**
@@ -188,6 +189,17 @@ export interface DiagnosticsServiceConstructor {
    * @param address Tuple containing [host, port]
    */
   new (address: [string, number]): DiagnosticsService;
+}
+
+/**
+ * Represents a DiagnosticsService instance with its associated RemoteXPC connection
+ * This allows callers to properly manage the connection lifecycle
+ */
+export interface DiagnosticsServiceWithConnection {
+  /** The DiagnosticsService instance */
+  diagnosticsService: DiagnosticsService;
+  /** The RemoteXPC connection that can be used to close the connection */
+  remoteXPC: RemoteXpcConnection;
 }
 
 /**

--- a/src/services.ts
+++ b/src/services.ts
@@ -1,6 +1,6 @@
 import { strongbox } from '@appium/strongbox';
 
-import RemoteXpcConnection from './lib/remote-xpc/remote-xpc-connection.js';
+import { RemoteXpcConnection } from './lib/remote-xpc/remote-xpc-connection.js';
 import { TunnelManager } from './lib/tunnel/index.js';
 import { TunnelApiClient } from './lib/tunnel/tunnel-api-client.js';
 import type {

--- a/src/services.ts
+++ b/src/services.ts
@@ -4,7 +4,7 @@ import RemoteXpcConnection from './lib/remote-xpc/remote-xpc-connection.js';
 import { TunnelManager } from './lib/tunnel/index.js';
 import { TunnelApiClient } from './lib/tunnel/tunnel-api-client.js';
 import type {
-  DiagnosticsService as DiagnosticsServiceType,
+  DiagnosticsServiceWithConnection,
   SyslogService as SyslogServiceType,
 } from './lib/types.js';
 import DiagnosticsService from './services/ios/diagnostic-service/index.js';
@@ -15,15 +15,18 @@ const TUNNEL_REGISTRY_PORT = 'tunnelRegistryPort';
 
 export async function startDiagnosticsService(
   udid: string,
-): Promise<DiagnosticsServiceType> {
+): Promise<DiagnosticsServiceWithConnection> {
   const { remoteXPC, tunnelConnection } = await createRemoteXPCConnection(udid);
   const diagnosticsService = remoteXPC.findService(
     DiagnosticsService.RSD_SERVICE_NAME,
   );
-  return new DiagnosticsService([
-    tunnelConnection.host,
-    parseInt(diagnosticsService.port, 10),
-  ]);
+  return {
+    remoteXPC: remoteXPC as RemoteXpcConnection,
+    diagnosticsService: new DiagnosticsService([
+      tunnelConnection.host,
+      parseInt(diagnosticsService.port, 10),
+    ]),
+  };
 }
 
 export async function startSyslogService(

--- a/src/services/ios/diagnostic-service/index.ts
+++ b/src/services/ios/diagnostic-service/index.ts
@@ -223,7 +223,6 @@ class DiagnosticsService
       emptyRequest,
       timeout,
     );
-    log.debug('Additional response: ', additionalResponse);
     const hasDiagnostics =
       'Diagnostics' in additionalResponse &&
       typeof additionalResponse.Diagnostics === 'object' &&

--- a/test/integration/diagnostics-test.ts
+++ b/test/integration/diagnostics-test.ts
@@ -12,7 +12,10 @@ describe('Diagnostics Service', function () {
   const udid = process.env.UDID || '';
 
   before(async function () {
-    diagService = await Services.startDiagnosticsService(udid);
+    let { diagnosticsService, remoteXPC } =
+      await Services.startDiagnosticsService(udid);
+    diagService = diagnosticsService;
+    remoteXPC = remoteXPC;
   });
 
   after(async function () {


### PR DESCRIPTION
This pull request introduces improvements to type definitions, enhances the lifecycle management of diagnostics services, and refines code readability and reliability. The most significant changes include the addition of a new type for managing diagnostics services with associated connections, updates to the `startDiagnosticsService` function to return structured data, and adjustments to type safety in the `TunnelManagerService` class.

### Type Definitions and Lifecycle Management Enhancements:

* [`src/lib/types.ts`](diffhunk://#diff-b8b77f5be18cf56dca425b3a5b8e9d2e754dd37fe0e3612b95cd4e9bccda08a5R194-R204): Added the `DiagnosticsServiceWithConnection` interface to represent a diagnostics service instance alongside its associated `RemoteXpcConnection`. This helps callers manage the connection lifecycle effectively.
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R22): Exported the newly added `DiagnosticsServiceWithConnection` type for broader accessibility.

### Function Updates for Diagnostics Service:

* [`src/services.ts`](diffhunk://#diff-0b56585a4d2a7aeba081842d16a9f0550cad13bff761d427c051fb1b7d5c8799L18-R29): Modified the `startDiagnosticsService` function to return a structured object containing both the `DiagnosticsService` instance and its associated `RemoteXpcConnection`, improving clarity and lifecycle management.

### Type Safety Improvements:

* [`src/lib/tunnel/index.ts`](diffhunk://#diff-25cf99a934ef1adbb8807893a1e277bb82028a0fb58c8fa956467e280ae4d97bL67-R72): Updated the `createRemoteXPCConnection` method in `TunnelManagerService` to return a `RemoteXpcConnection` type instead of a generic `any`, enhancing type safety and readability.

### Code Refinements:

* [`src/services/ios/diagnostic-service/index.ts`](diffhunk://#diff-f0be01527f9a463e7721573d8daf70e91c6e0c8b152fb41e40808897350e211fL226): Removed unnecessary debug logging for additional responses in the `DiagnosticsService` class, simplifying the code.

### Test Updates:

* [`test/integration/diagnostics-test.ts`](diffhunk://#diff-381c37523fcba6061a5759f69f14b16ba7deab94337ea51f7d7e10a9514a1a4dL15-R18): Adjusted the integration test setup for `DiagnosticsService` to accommodate the new structured return type from `startDiagnosticsService`, ensuring compatibility with the updated function signature.