### PR TITLE
fix: change tuntap dependency to appium-ios-tuntap

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@types/node": "^24.0.10",
     "@xmldom/xmldom": "^0.9.8",
     "npm-run-all2": "^7.0.2",
-    "tuntap-bridge": "^0.x"
+    "appium-ios-tuntap": "^0.x"
   },
   "files": [
     "src",

--- a/src/lib/tunnel/index.ts
+++ b/src/lib/tunnel/index.ts
@@ -1,5 +1,8 @@
 import { logger } from '@appium/support';
-import { type TunnelConnection, connectToTunnelLockdown } from 'appium-ios-tuntap';
+import {
+  type TunnelConnection,
+  connectToTunnelLockdown,
+} from 'appium-ios-tuntap';
 import type { TLSSocket } from 'tls';
 
 import { RemoteXpcConnection } from '../remote-xpc/remote-xpc-connection.js';

--- a/src/lib/tunnel/index.ts
+++ b/src/lib/tunnel/index.ts
@@ -1,6 +1,6 @@
 import { logger } from '@appium/support';
+import { type TunnelConnection, connectToTunnelLockdown } from 'appium-ios-tuntap';
 import type { TLSSocket } from 'tls';
-import { type TunnelConnection, connectToTunnelLockdown } from 'tuntap-bridge';
 
 import { RemoteXpcConnection } from '../remote-xpc/remote-xpc-connection.js';
 

--- a/src/lib/tunnel/packet-stream-client.ts
+++ b/src/lib/tunnel/packet-stream-client.ts
@@ -1,7 +1,7 @@
 import { logger } from '@appium/support';
+import type { PacketConsumer, PacketData } from 'appium-ios-tuntap';
 import { EventEmitter } from 'events';
 import { type Socket, createConnection } from 'net';
-import type { PacketConsumer, PacketData } from 'tuntap-bridge';
 
 const log = logger.getLogger('PacketStreamClient');
 

--- a/src/lib/tunnel/packet-stream-server.ts
+++ b/src/lib/tunnel/packet-stream-server.ts
@@ -1,7 +1,7 @@
 import { logger } from '@appium/support';
+import type { PacketConsumer, PacketData } from 'appium-ios-tuntap';
 import { EventEmitter } from 'events';
 import { type Server, type Socket, createServer } from 'net';
-import type { PacketConsumer, PacketData } from 'tuntap-bridge';
 
 const log = logger.getLogger('PacketStreamServer');
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,8 +1,8 @@
 /**
  * Common type definitions for the appium-ios-remotexpc library
  */
+import type { PacketData } from 'appium-ios-tuntap';
 import { EventEmitter } from 'events';
-import type { PacketData } from 'tuntap-bridge';
 
 import type { BaseService, Service } from '../services/ios/base-service.js';
 import type { RemoteXpcConnection } from './remote-xpc/remote-xpc-connection.js';

--- a/src/services/ios/syslog-service/index.ts
+++ b/src/services/ios/syslog-service/index.ts
@@ -1,6 +1,6 @@
 import { logger } from '@appium/support';
+import type { PacketConsumer, PacketData } from 'appium-ios-tuntap';
 import { EventEmitter } from 'events';
-import type { PacketConsumer, PacketData } from 'tuntap-bridge';
 
 import { isBinaryPlist } from '../../../lib/plist/binary-plist-parser.js';
 import { parsePlist } from '../../../lib/plist/unified-plist-parser.js';


### PR DESCRIPTION
This pull request replaces the dependency on `tuntap-bridge` with `appium-ios-tuntap` across the project. The changes involve updating the `package.json` file and modifying all relevant imports in the codebase to reflect the new dependency. This update ensures compatibility with the latest library and improves maintainability.

### Dependency Update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L77-R77): Replaced the `tuntap-bridge` dependency with `appium-ios-tuntap`. (`[package.jsonL77-R77](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L77-R77)`)

### Codebase Updates for Dependency Replacement:

* [`src/lib/tunnel/index.ts`](diffhunk://#diff-25cf99a934ef1adbb8807893a1e277bb82028a0fb58c8fa956467e280ae4d97bR2-L3): Updated imports to use `appium-ios-tuntap` instead of `tuntap-bridge`. (`[src/lib/tunnel/index.tsR2-L3](diffhunk://#diff-25cf99a934ef1adbb8807893a1e277bb82028a0fb58c8fa956467e280ae4d97bR2-L3)`)
* [`src/lib/tunnel/packet-stream-client.ts`](diffhunk://#diff-d9d493211fcfad9e4f047d76ddfd52127a8ec939191fe5b049cdf31071a9d041R2-L4): Replaced `tuntap-bridge` imports with `appium-ios-tuntap` for type definitions. (`[src/lib/tunnel/packet-stream-client.tsR2-L4](diffhunk://#diff-d9d493211fcfad9e4f047d76ddfd52127a8ec939191fe5b049cdf31071a9d041R2-L4)`)
* [`src/lib/tunnel/packet-stream-server.ts`](diffhunk://#diff-9946934fbf91f4925437960871f3ee7e0345123f382fe93ffd0e456a6c846245R2-L4): Updated type imports from `tuntap-bridge` to `appium-ios-tuntap`. (`[src/lib/tunnel/packet-stream-server.tsR2-L4](diffhunk://#diff-9946934fbf91f4925437960871f3ee7e0345123f382fe93ffd0e456a6c846245R2-L4)`)
* [`src/lib/types.ts`](diffhunk://#diff-b8b77f5be18cf56dca425b3a5b8e9d2e754dd37fe0e3612b95cd4e9bccda08a5R4-L5): Changed `PacketData` type import to use `appium-ios-tuntap`. (`[src/lib/types.tsR4-L5](diffhunk://#diff-b8b77f5be18cf56dca425b3a5b8e9d2e754dd37fe0e3612b95cd4e9bccda08a5R4-L5)`)
* [`src/services/ios/syslog-service/index.ts`](diffhunk://#diff-be6149dff249e03cb8ebc0a11f221897ad7ba316d58ec79c69a97c0d15579114R2-L3): Replaced `tuntap-bridge` imports with `appium-ios-tuntap` for type definitions. (`[src/services/ios/syslog-service/index.tsR2-L3](diffhunk://#diff-be6149dff249e03cb8ebc0a11f221897ad7ba316d58ec79c69a97c0d15579114R2-L3)`)