### PR TITLE
fix: use 0.9 explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@appium/strongbox": "^1.0.0-rc.1",
     "@appium/support": "^7.0.0-rc.1",
     "@types/node": "^24.0.10",
-    "@xmldom/xmldom": "^0.x",
+    "@xmldom/xmldom": "^0.9.8",
     "npm-run-all2": "^7.0.2",
     "appium-ios-tuntap": "^0.x"
   },

--- a/src/lib/plist/plist-parser.ts
+++ b/src/lib/plist/plist-parser.ts
@@ -1,5 +1,5 @@
 import { logger } from '@appium/support';
-import { DOMParser, Element, Node } from '@xmldom/xmldom';
+import { DOMParser } from '@xmldom/xmldom';
 
 import type { PlistArray, PlistDictionary, PlistValue } from '../types.js';
 import { PlistService } from './plist-service.js';

--- a/src/lib/plist/plist-parser.ts
+++ b/src/lib/plist/plist-parser.ts
@@ -1,5 +1,5 @@
 import { logger } from '@appium/support';
-import { DOMParser } from '@xmldom/xmldom';
+import { DOMParser, Element, Node } from '@xmldom/xmldom';
 
 import type { PlistArray, PlistDictionary, PlistValue } from '../types.js';
 import { PlistService } from './plist-service.js';


### PR DESCRIPTION
It looks like the library released [0.8.11](https://www.npmjs.com/package/@xmldom/xmldom/v/0.8.11) recently, but the code in this repository expects to use 0.9 (e.g. https://www.npmjs.com/package/@xmldom/xmldom/v/0.9.8)

The v0.9 includes Element, for example, properly so we should explicitly require `0.9+`