### PR TITLE
chore: call identifiers command once in case of TSS

### DIFF
--- a/src/lib/tss/index.ts
+++ b/src/lib/tss/index.ts
@@ -219,29 +219,27 @@ export class TSSRequest {
 
 /**
  * Get manifest from Apple's TSS (Ticket Signing Server)
- * @param ecid The device ECID
+ * @param personalizationIdentifiers The device personalization identifiers
  * @param buildManifest The build manifest dictionary
- * @param queryPersonalizationIdentifiers Function to query personalization identifiers
  * @param queryNonce Function to query nonce
  * @returns Promise resolving to the manifest bytes
  */
 export async function getManifestFromTSS(
-  ecid: number,
+  personalizationIdentifiers: PlistDictionary,
   buildManifest: PlistDictionary,
-  queryPersonalizationIdentifiers: () => Promise<PlistDictionary>,
   queryNonce: (personalizedImageType: string) => Promise<Buffer>,
 ): Promise<Buffer> {
   log.debug('Starting TSS manifest generation process');
 
   const request = new TSSRequest();
 
-  const personalizationIdentifiers = await queryPersonalizationIdentifiers();
   for (const [key, value] of Object.entries(personalizationIdentifiers)) {
     if (key.startsWith('Ap,')) {
       request.update({ [key]: value });
     }
   }
 
+  const ecid = personalizationIdentifiers.UniqueChipID as number;
   const boardId = personalizationIdentifiers.BoardId as number;
   const chipId = personalizationIdentifiers.ChipID as number;
 

--- a/src/services/ios/mobile-image-mounter/index.ts
+++ b/src/services/ios/mobile-image-mounter/index.ts
@@ -440,18 +440,10 @@ class MobileImageMounterService
         log.debug('Personalization manifest not found on device, using TSS...');
 
         const identifiers = await this.queryPersonalizationIdentifiers();
-        const ecid = identifiers.UniqueChipID as number;
-
-        if (!ecid) {
-          throw new Error(
-            'Could not retrieve device ECID from personalization identifiers',
-          );
-        }
 
         const manifest = await getManifestFromTSS(
-          ecid,
+          identifiers,
           buildManifest,
-          () => this.queryPersonalizationIdentifiers(),
           (type: string) => this.queryNonce(type),
         );
 


### PR DESCRIPTION
Resolves comment - https://github.com/appium/appium-ios-remotexpc/pull/68#discussion_r2345925096

Reduces the number of calls for `queryPersonalizationIdentifiers` from 2 to 1. 
Move `ECID` retrieval inside `getManifestFromTSS`.