### PR TITLE
fix(plist): enforce strict length‑prefixed framing in `LengthBasedSplitter`

### DIFF
--- a/src/lib/plist/length-based-splitter.ts
+++ b/src/lib/plist/length-based-splitter.ts
@@ -100,14 +100,6 @@ export class LengthBasedSplitter extends Transform {
         Math.min(MAX_PREVIEW_LENGTH, this.buffer.length),
       );
 
-      // Check for XML format
-      if (isXmlPlistContent(bufferString) || this.isXmlMode) {
-        // This is XML data, set XML mode
-        this.isXmlMode = true;
-        this.processXmlData(callback);
-        return;
-      }
-
       // Check for binary plist format (bplist00 or Ibplist00)
       if (this.buffer.length >= BINARY_PLIST_HEADER_LENGTH) {
         const possibleBplistHeader = this.buffer.toString(
@@ -120,20 +112,14 @@ export class LengthBasedSplitter extends Transform {
           possibleBplistHeader === BINARY_PLIST_MAGIC ||
           possibleBplistHeader.includes(BINARY_PLIST_MAGIC)
         ) {
-          log.debug('Detected standard binary plist format');
-          this.push(this.buffer);
-          this.buffer = Buffer.alloc(0);
-          return callback();
+          log.debug('Detected standard binary plist format; proceeding with length-prefixed frame parsing');
         }
 
         if (
           possibleBplistHeader === IBINARY_PLIST_MAGIC ||
           possibleBplistHeader.includes(IBINARY_PLIST_MAGIC)
         ) {
-          log.debug('Detected non-standard Ibplist00 format');
-          this.push(this.buffer);
-          this.buffer = Buffer.alloc(0);
-          return callback();
+          log.debug('Detected non-standard Ibplist00 format; proceeding with length-prefixed frame parsing');
         }
       }
       // Process as many complete messages as possible for binary data
@@ -253,12 +239,6 @@ export class LengthBasedSplitter extends Transform {
               Math.min(MAX_PREVIEW_LENGTH, this.buffer.length),
             );
 
-            if (isXmlPlistContent(suspiciousData)) {
-              this.isXmlMode = true;
-              // Process as XML on next iteration
-              return callback();
-            }
-
             // Invalid length - skip one byte and try again
             this.buffer = this.buffer.slice(1);
             continue;
@@ -271,12 +251,6 @@ export class LengthBasedSplitter extends Transform {
             0,
             Math.min(MAX_PREVIEW_LENGTH, this.buffer.length),
           );
-
-          if (isXmlPlistContent(suspiciousData)) {
-            this.isXmlMode = true;
-            // Process as XML on next iteration
-            return callback();
-          }
 
           // Invalid length - skip one byte and try again
           this.buffer = this.buffer.slice(1);
@@ -298,20 +272,7 @@ export class LengthBasedSplitter extends Transform {
         // Extract the complete message
         const message = this.buffer.slice(0, totalLength);
 
-        // Check if this message is actually XML
-        const messageStart = message.toString(
-          UTF8_ENCODING,
-          0,
-          Math.min(MAX_PREVIEW_LENGTH, message.length),
-        );
-
-        if (isXmlPlistContent(messageStart)) {
-          // Switch to XML mode
-          this.isXmlMode = true;
-          return callback();
-        }
-
-        // Push the message
+        // Push the message (header + payload)
         this.push(message);
 
         // Remove the processed message from the buffer

--- a/src/lib/plist/plist-decoder.ts
+++ b/src/lib/plist/plist-decoder.ts
@@ -2,7 +2,7 @@ import { logger } from '@appium/support';
 import { Transform, type TransformCallback } from 'stream';
 
 import { UTF8_ENCODING } from './constants.js';
-import { parsePlist } from './plist-parser.js';
+import { parsePlist } from './unified-plist-parser.js';
 import {
   ensureString,
   findFirstReplacementCharacter,


### PR DESCRIPTION
Some RSD services (WebInspector, springboard) intermittently returned no messages and timed out on receive.

After debugging I found out that the `LengthBasedSplitter` emitted raw XML buffers without the 4‑byte length header which caused no response to be received/parsed from the service.

The plist decoder would attempt to slice off a header that wasn’t there, producing malformed XML. Due to this the response was empty and `receivePlist` timed out.

This issue was found out while implementing the webinspector and springboard service, both of which timed out, and this fix resolved the issue.

Also, we need to use `unified-plist-parser` in plist decoder to auto detect between binary and XML.

I have tested other services with this change and there is no regression.