### PR TITLE
implement springboard service 

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "test:diagnostics": "mocha test/integration/diagnostics-test.ts --exit --timeout 1m",
     "test:notification": "mocha test/integration/notification-proxy-test.ts --exit --timeout 1m",
     "test:image-mounter": "mocha test/integration/mobile-image-mounter-test.ts --exit --timeout 1m",
-    "test:springboard": "mocha test/integration/springboard-test.ts --exit --timeout 1m",
+    "test:mobile-config": "mocha test/integration/mobile-config-test.ts --exit --timeout 1m",
+    "test:springboard": "mocha test/integration/springboard-service-test.ts --exit --timeout 1m",
     "test:unit": "mocha 'test/unit/**/*.ts' --exit --timeout 2m",
     "test:tunnel-creation": "sudo tsx scripts/test-tunnel-creation.ts",
     "test:tunnel-creation:lsof": "sudo tsx scripts/test-tunnel-creation.ts --keep-open"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "test:diagnostics": "mocha test/integration/diagnostics-test.ts --exit --timeout 1m",
     "test:notification": "mocha test/integration/notification-proxy-test.ts --exit --timeout 1m",
     "test:image-mounter": "mocha test/integration/mobile-image-mounter-test.ts --exit --timeout 1m",
-    "test:mobile-config": "mocha test/integration/mobile-config-test.ts --exit --timeout 1m",
     "test:unit": "mocha 'test/unit/**/*.ts' --exit --timeout 2m",
     "test:tunnel-creation": "sudo tsx scripts/test-tunnel-creation.ts",
     "test:tunnel-creation:lsof": "sudo tsx scripts/test-tunnel-creation.ts --keep-open"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test:diagnostics": "mocha test/integration/diagnostics-test.ts --exit --timeout 1m",
     "test:notification": "mocha test/integration/notification-proxy-test.ts --exit --timeout 1m",
     "test:image-mounter": "mocha test/integration/mobile-image-mounter-test.ts --exit --timeout 1m",
+    "test:springboard": "mocha test/integration/springboard-test.ts --exit --timeout 1m",
     "test:unit": "mocha 'test/unit/**/*.ts' --exit --timeout 2m",
     "test:tunnel-creation": "sudo tsx scripts/test-tunnel-creation.ts",
     "test:tunnel-creation:lsof": "sudo tsx scripts/test-tunnel-creation.ts --keep-open"

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export type {
   MobileImageMounterService,
   NotificationProxyService,
   MobileConfigService,
+  SpringboardService,
   SyslogService,
   SocketInfo,
   TunnelResult,
@@ -26,6 +27,7 @@ export type {
   MobileImageMounterServiceWithConnection,
   NotificationProxyServiceWithConnection,
   MobileConfigServiceWithConnection,
+  SpringboardServiceWithConnection,
 } from './lib/types.js';
 export {
   createUsbmux,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,6 +6,7 @@ import { EventEmitter } from 'events';
 
 import type { ServiceConnection } from '../service-connection.js';
 import type { BaseService, Service } from '../services/ios/base-service.js';
+import type { InterfaceOrientation } from '../services/ios/springboard-service/index.js';
 import type { RemoteXpcConnection } from './remote-xpc/remote-xpc-connection.js';
 import type { Device } from './usbmux/index.js';
 
@@ -519,6 +520,8 @@ export interface SpringboardService extends BaseService {
    */
   getIconState(): Promise<PlistDictionary>;
 
+  setIconState(newState: PlistDictionary[]): Promise<void>;
+
   /**
    * Gets the icon PNG data for a given bundle ID
    * @param bundleID The bundle ID of the app
@@ -538,6 +541,10 @@ export interface SpringboardService extends BaseService {
    * @returns Promise resolving to the homescreen icon metrics
    */
   getHomescreenIconMetrics(): Promise<PlistDictionary>;
+
+  getInterfaceOrientation(): Promise<InterfaceOrientation>;
+
+  getWallpaperPreviewImage(wallpaperName: string): Promise<Buffer>;
 }
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -520,6 +520,11 @@ export interface SpringboardService extends BaseService {
    */
   getIconState(): Promise<PlistDictionary>;
 
+  /**
+   * TODO: This does not work currently due to a bug in Apple protocol implementation (maybe?)
+   * Sets the icon state
+   * @param newState
+   */
   setIconState(newState: PlistDictionary[]): Promise<void>;
 
   /**
@@ -530,6 +535,7 @@ export interface SpringboardService extends BaseService {
   getIconPNGData(bundleID: string): Promise<Buffer>;
 
   /**
+   * TODO: This does not work currently due to a bug in Apple protocol implementation
    * Gets wallpaper info
    * @param wallpaperName The name of the wallpaper
    * @returns Promise resolving to the wallpaper info
@@ -542,9 +548,31 @@ export interface SpringboardService extends BaseService {
    */
   getHomescreenIconMetrics(): Promise<PlistDictionary>;
 
+  /**
+   * Gets the current interface orientation
+   * @returns Promise resolving to InterfaceOrientation
+   * 1 = Portrait
+   * 2 = PortraitUpsideDown
+   * 3 = Landscape
+   * 4 = LandscapeHomeToLeft
+   */
   getInterfaceOrientation(): Promise<InterfaceOrientation>;
 
+  /**
+   * Gets wallpaper preview image for homescreen and lockscreen
+   * @param wallpaperName
+   * @returns Promise resolving to the wallpaper preview image as a Buffer
+   */
   getWallpaperPreviewImage(wallpaperName: string): Promise<Buffer>;
+
+  /**
+   * TODO: This does not work currently due to a bug in Apple protocol implementation
+   * Use getWallpaperPreviewImage('homescreen') instead
+   * Gets wallpaper PNG data
+   * @param wallpaperName
+   * @returns Promise resolving to the wallpaper PNG data as a Buffer
+   */
+  getWallpaperPNGData(wallpaperName: string): Promise<Buffer>;
 }
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -508,3 +508,44 @@ export interface MobileImageMounterServiceWithConnection {
   /** The RemoteXPC connection for service management */
   remoteXPC: RemoteXpcConnection;
 }
+
+/**
+ * Represents the instance side of SpringboardService
+ */
+export interface SpringboardService extends BaseService {
+  /**
+   * Gets the icon state
+   * @returns Promise resolving to the icon state
+   */
+  getIconState(): Promise<PlistDictionary>;
+
+  /**
+   * Gets the icon PNG data for a given bundle ID
+   * @param bundleID The bundle ID of the app
+   * @returns Promise resolving to the icon PNG data
+   */
+  getIconPNGData(bundleID: string): Promise<Buffer>;
+
+  /**
+   * Gets wallpaper info
+   * @param wallpaperName The name of the wallpaper
+   * @returns Promise resolving to the wallpaper info
+   */
+  getWallpaperInfo(wallpaperName: string): Promise<PlistDictionary>;
+
+  /**
+   * Gets homescreen icon metrics
+   * @returns Promise resolving to the homescreen icon metrics
+   */
+  getHomescreenIconMetrics(): Promise<PlistDictionary>;
+}
+
+/**
+ * Represents a SpringboardService instance with its associated RemoteXPC connection
+ */
+export interface SpringboardServiceWithConnection {
+  /** The SpringboardService instance */
+  springboardService: SpringboardService;
+  /** The RemoteXPC connection for service management */
+  remoteXPC: RemoteXpcConnection;
+}

--- a/src/services.ts
+++ b/src/services.ts
@@ -3,7 +3,14 @@ import { strongbox } from '@appium/strongbox';
 import { RemoteXpcConnection } from './lib/remote-xpc/remote-xpc-connection.js';
 import { TunnelManager } from './lib/tunnel/index.js';
 import { TunnelApiClient } from './lib/tunnel/tunnel-api-client.js';
-import type { DiagnosticsServiceWithConnection, MobileConfigServiceWithConnection, MobileImageMounterServiceWithConnection, NotificationProxyServiceWithConnection, SpringboardServiceWithConnection, SyslogService as SyslogServiceType } from './lib/types.js';
+import type {
+  DiagnosticsServiceWithConnection,
+  MobileConfigServiceWithConnection,
+  MobileImageMounterServiceWithConnection,
+  NotificationProxyServiceWithConnection,
+  SpringboardServiceWithConnection,
+  SyslogService as SyslogServiceType,
+} from './lib/types.js';
 import DiagnosticsService from './services/ios/diagnostic-service/index.js';
 import { MobileConfigService } from './services/ios/mobile-config/index.js';
 import MobileImageMounterService from './services/ios/mobile-image-mounter/index.js';

--- a/src/services.ts
+++ b/src/services.ts
@@ -3,17 +3,12 @@ import { strongbox } from '@appium/strongbox';
 import { RemoteXpcConnection } from './lib/remote-xpc/remote-xpc-connection.js';
 import { TunnelManager } from './lib/tunnel/index.js';
 import { TunnelApiClient } from './lib/tunnel/tunnel-api-client.js';
-import type {
-  DiagnosticsServiceWithConnection,
-  MobileConfigServiceWithConnection,
-  MobileImageMounterServiceWithConnection,
-  NotificationProxyServiceWithConnection,
-  SyslogService as SyslogServiceType,
-} from './lib/types.js';
+import type { DiagnosticsServiceWithConnection, MobileConfigServiceWithConnection, MobileImageMounterServiceWithConnection, NotificationProxyServiceWithConnection, SpringboardServiceWithConnection, SyslogService as SyslogServiceType } from './lib/types.js';
 import DiagnosticsService from './services/ios/diagnostic-service/index.js';
 import { MobileConfigService } from './services/ios/mobile-config/index.js';
 import MobileImageMounterService from './services/ios/mobile-image-mounter/index.js';
 import { NotificationProxyService } from './services/ios/notification-proxy/index.js';
+import { SpringBoardService } from './services/ios/springboard-service/index.js';
 import SyslogService from './services/ios/syslog-service/index.js';
 
 const APPIUM_XCUITEST_DRIVER_NAME = 'appium-xcuitest-driver';
@@ -78,6 +73,22 @@ export async function startMobileImageMounterService(
     mobileImageMounterService: new MobileImageMounterService([
       tunnelConnection.host,
       parseInt(mobileImageMounterService.port, 10),
+    ]),
+  };
+}
+
+export async function startSpringboardService(
+  udid: string,
+): Promise<SpringboardServiceWithConnection> {
+  const { remoteXPC, tunnelConnection } = await createRemoteXPCConnection(udid);
+  const springboardService = remoteXPC.findService(
+    SpringBoardService.RSD_SERVICE_NAME,
+  );
+  return {
+    remoteXPC: remoteXPC as RemoteXpcConnection,
+    springboardService: new SpringBoardService([
+      tunnelConnection.host,
+      parseInt(springboardService.port, 10),
     ]),
   };
 }

--- a/src/services/ios/springboard-service/index.ts
+++ b/src/services/ios/springboard-service/index.ts
@@ -36,6 +36,10 @@ class SpringBoardService extends BaseService implements SpringboardInterface {
     }
   }
 
+  /**
+   * TODO: This does not work currently due to a bug in Apple protocol implementation (maybe?)
+   * Uncomment tests when it is fixed
+   */
   async setIconState(newState: PlistDictionary[] = []): Promise<void> {
     try {
       const req = {
@@ -69,7 +73,7 @@ class SpringBoardService extends BaseService implements SpringboardInterface {
   }
 
   /**
-   * TODO: This does not work due to a bug in Apple protocol implementation
+   * TODO: This does not work currently due to a bug in Apple protocol implementation
    * Add tests when it is fixed
    */
   async getWallpaperInfo(wallpaperName: string): Promise<PlistDictionary> {
@@ -144,6 +148,25 @@ class SpringBoardService extends BaseService implements SpringboardInterface {
       throw error;
     }
   }
+  /**
+   * TODO: This does not work currently due to a bug in Apple protocol implementation
+   * Add tests when it is fixed
+   */
+  async getWallpaperPNGData(wallpaperName: string): Promise<Buffer> {
+    try {
+      const req = {
+        command: 'getHomeScreenWallpaperPNGData',
+        wallpaperName,
+      };
+      const res = await this.sendRequestAndReceive(req);
+      return res.pngData as Buffer;
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(`Failed to get wallpaper PNG data: ${error.message}`);
+      }
+      throw error;
+    }
+  }
 
   async connectToSpringboardService(): Promise<ServiceConnection> {
     if (this._conn) {
@@ -160,6 +183,7 @@ class SpringBoardService extends BaseService implements SpringboardInterface {
     if (!this._conn) {
       this._conn = await this.connectToSpringboardService();
     }
+    // Skip StartService response
     await this._conn.sendAndReceive(request);
     return await this._conn.sendPlistRequest(request);
   }

--- a/src/services/ios/springboard-service/index.ts
+++ b/src/services/ios/springboard-service/index.ts
@@ -1,0 +1,111 @@
+import { BaseService } from '../base-service.js';
+import { ServiceConnection } from '../../../service-connection.js';
+import { type PlistDictionary } from '../../../lib/types.js';
+import { logger } from '@appium/support';
+
+const log = logger.getLogger('springboard-service');
+
+class SpringBoardService extends BaseService {
+  static readonly RSD_SERVICE_NAME =
+    'com.apple.springboardservices.shim.remote';
+  private _conn: ServiceConnection | null = null;
+
+  constructor(address: [string, number]) {
+    super(address);
+  }
+
+  async getIconState(): Promise<PlistDictionary> {
+    try {
+      const req = {
+        command: 'getIconState',
+        formatVersion: '2',
+      };
+      return await this.sendRequestAndReceive(req);
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(`Failed to get Icon state: ${error.message}`);
+      }
+      throw error;
+    }
+  }
+
+  async getIconPNGData(bundleID: string): Promise<Buffer> {
+    try {
+      const req = {
+        command: 'getIconPNGData',
+        bundleId: bundleID,
+      };
+      const res = await this.sendRequestAndReceive(req);
+      return res.pngData as Buffer;
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(`Failed to get Icon PNG data: ${error.message}`);
+      }
+      throw error;
+    }
+  }
+
+  async getWallpaperInfo(wallpaperName: string): Promise<PlistDictionary> {
+    try {
+      const req = {
+        command: 'getWallpaperInfo',
+        wallpaperName,
+      };
+      return await this.sendRequestAndReceive(req);
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(`Failed to get wallpaper info: ${error.message}`);
+      }
+      throw error;
+    }
+  }
+
+  async getHomescreenIconMetrics(): Promise<PlistDictionary> {
+    try {
+      const req = {
+        command: 'getHomeScreenIconMetrics',
+      };
+      return await this.sendRequestAndReceive(req);
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(`Failed to get homescreen icon metrics: ${error.message}`);
+      }
+      throw error;
+    }
+  }
+
+  async connectToSpringboardService(): Promise<ServiceConnection> {
+    if (this._conn) {
+      return this._conn;
+    }
+    const service = this.getServiceConfig();
+    this._conn = await this.startLockdownService(service);
+    return this._conn;
+  }
+
+  private async sendRequestAndReceive(
+    request: PlistDictionary,
+  ): Promise<PlistDictionary> {
+    if (!this._conn) {
+      this._conn = await this.connectToSpringboardService();
+    }
+    const _ = await this._conn.sendAndReceive(request);
+    const response = await this._conn.sendPlistRequest(request);
+
+    console.log(response);
+
+    return response;
+  }
+
+  private getServiceConfig(): {
+    serviceName: string;
+    port: string;
+  } {
+    return {
+      serviceName: SpringBoardService.RSD_SERVICE_NAME,
+      port: this.address[1].toString(),
+    };
+  }
+}
+
+export { SpringBoardService };

--- a/test/integration/diagnostics-test.ts
+++ b/test/integration/diagnostics-test.ts
@@ -9,7 +9,7 @@ describe('Diagnostics Service', function () {
 
   let remoteXPC: any;
   let diagService: DiagnosticsService;
-  const udid = process.env.UDID || '00008030-000318693E32402E';
+  const udid = process.env.UDID || '';
 
   before(async function () {
     let { diagnosticsService, remoteXPC } =

--- a/test/integration/diagnostics-test.ts
+++ b/test/integration/diagnostics-test.ts
@@ -9,7 +9,7 @@ describe('Diagnostics Service', function () {
 
   let remoteXPC: any;
   let diagService: DiagnosticsService;
-  const udid = process.env.UDID || '';
+  const udid = process.env.UDID || '00008030-000318693E32402E';
 
   before(async function () {
     let { diagnosticsService, remoteXPC } =

--- a/test/integration/springboard-service-test.ts
+++ b/test/integration/springboard-service-test.ts
@@ -1,0 +1,222 @@
+import { logger } from '@appium/support';
+import { expect } from 'chai';
+
+import type { SpringboardService } from '../../src/lib/types.js';
+import * as Services from '../../src/services.js';
+
+const log = logger.getLogger('SpringBoardService.test');
+// Set SpringBoardService logger to info level
+log.level = 'info';
+
+describe('SpringBoardService', function () {
+  this.timeout(60000);
+
+  let remoteXPC: any;
+  let springboardService: SpringboardService;
+  const udid = process.env.UDID || '00008030-000318693E32402E';
+
+  before(async function () {
+    try {
+      const result = await Services.startSpringboardService(udid);
+      springboardService = result.springboardService;
+      remoteXPC = result.remoteXPC;
+      log.info('SpringBoard service initialized successfully');
+    } catch (error) {
+      log.error('Failed to initialize SpringBoard service:', error);
+      throw error;
+    }
+  });
+
+  after(async function () {
+    if (remoteXPC) {
+      try {
+        await remoteXPC.close();
+        log.info('SpringBoard service connection closed');
+      } catch (error) {
+        log.warn('Error during cleanup:', error);
+        // Ignore cleanup errors in tests
+      }
+    }
+  });
+
+  describe('getIconState', function () {
+    it('should retrieve the current icon state', async function () {
+      try {
+        const iconState = await springboardService.getIconState();
+        log.debug('Retrieved icon state:', JSON.stringify(iconState, null, 2));
+
+        expect(iconState).to.be.an('object');
+        expect(iconState).to.not.be.empty;
+
+        console.log(iconState);
+
+        // Icon state typically contains iconLists array
+        if (iconState.iconLists) {
+          expect(iconState.iconLists).to.be.an('array');
+        }
+      } catch (error) {
+        log.error('Error getting icon state:', (error as Error).message);
+        throw error;
+      }
+    });
+
+    // it('should handle errors gracefully when service is unavailable', async function () {
+    //   // This test simulates error handling - we expect the method to throw with a descriptive error
+    //   try {
+    //     // Force an error by creating a service with invalid address
+    //     const invalidService = new (await import('../../src/services/ios/springboard-service/index.js')).SpringBoardService(['invalid', 0]);
+    //     await invalidService.getIconState();
+    //
+    //     // If we reach here, the test should fail
+    //     expect.fail('Expected method to throw an error');
+    //   } catch (error) {
+    //     expect(error).to.be.an('error');
+    //     expect((error as Error).message).to.include('Failed to get Icon state');
+    //   }
+    // });
+  });
+
+  describe('getIconPNGData', function () {
+    it('should retrieve PNG data for a valid bundle ID', async function () {
+      // Use a common system app bundle ID that should exist on most devices
+      const bundleId = 'com.apple.weather'; // Messages app
+
+      try {
+        const pngData = await springboardService.getIconPNGData(bundleId);
+        log.debug(`Retrieved PNG data for ${bundleId}, size: ${pngData.length} bytes`);
+
+        expect(pngData).to.be.instanceOf(Buffer);
+        expect(pngData.length).to.be.greaterThan(0);
+
+        // Verify it's actually PNG data by checking the PNG signature
+        const pngSignature = Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
+        expect(pngData.subarray(0, 8)).to.deep.equal(pngSignature);
+      } catch (error) {
+        log.error(`Error getting PNG data for ${bundleId}:`, (error as Error).message);
+        throw error;
+      }
+    });
+
+    // it('should handle invalid bundle ID gracefully', async function () {
+    //   const invalidBundleId = 'com.invalid.nonexistent.app';
+    //
+    //   try {
+    //     await springboardService.getIconPNGData(invalidBundleId);
+    //     // If we reach here without error, that's also acceptable - some implementations might return empty data
+    //   } catch (error) {
+    //     expect(error).to.be.an('error');
+    //     expect((error as Error).message).to.include('Failed to get Icon PNG data');
+    //   }
+    // });
+    //
+    // it('should handle empty bundle ID', async function () {
+    //   try {
+    //     await springboardService.getIconPNGData('');
+    //   } catch (error) {
+    //     expect(error).to.be.an('error');
+    //     expect((error as Error).message).to.include('Failed to get Icon PNG data');
+    //   }
+    // });
+  });
+
+  describe('getWallpaperInfo', function () {
+    it('should retrieve wallpaper info for lock screen', async function () {
+      const wallpaperName = 'LockBackground';
+
+      try {
+        const wallpaperInfo = await springboardService.getWallpaperInfo(wallpaperName);
+        log.debug(`Retrieved wallpaper info for ${wallpaperName}:`, JSON.stringify(wallpaperInfo, null, 2));
+
+        expect(wallpaperInfo).to.be.an('object');
+        // Wallpaper info might contain properties like imageData, cropRect, etc.
+      } catch (error) {
+        log.error(`Error getting wallpaper info for ${wallpaperName}:`, (error as Error).message);
+        throw error;
+      }
+    });
+
+    it('should retrieve wallpaper info for home screen', async function () {
+      const wallpaperName = 'HomeBackground';
+
+      try {
+        const wallpaperInfo = await springboardService.getWallpaperInfo(wallpaperName);
+        log.debug(`Retrieved wallpaper info for ${wallpaperName}:`, JSON.stringify(wallpaperInfo, null, 2));
+
+        expect(wallpaperInfo).to.be.an('object');
+      } catch (error) {
+        log.error(`Error getting wallpaper info for ${wallpaperName}:`, (error as Error).message);
+        throw error;
+      }
+    });
+
+    it('should handle invalid wallpaper name', async function () {
+      const invalidWallpaperName = 'InvalidWallpaper';
+
+      try {
+        const result = await springboardService.getWallpaperInfo(invalidWallpaperName);
+        // Some implementations might return empty object for invalid names
+        expect(result).to.be.an('object');
+      } catch (error) {
+        expect(error).to.be.an('error');
+        expect((error as Error).message).to.include('Failed to get wallpaper info');
+      }
+    });
+  });
+
+  describe('getHomescreenIconMetrics', function () {
+    it('should retrieve homescreen icon metrics', async function () {
+      try {
+        const metrics = await springboardService.getHomescreenIconMetrics();
+        log.debug('Retrieved homescreen icon metrics:', JSON.stringify(metrics, null, 2));
+
+        expect(metrics).to.be.an('object');
+        expect(metrics).to.not.be.empty;
+
+        // Icon metrics typically contain information about icon layout, sizes, etc.
+        // Common properties might include iconImageSize, iconSpacing, etc.
+      } catch (error) {
+        log.error('Error getting homescreen icon metrics:', (error as Error).message);
+        throw error;
+      }
+    });
+  });
+
+  describe('service connection management', function () {
+    it('should maintain connection across multiple requests', async function () {
+      try {
+        // Make multiple requests to ensure connection is maintained
+        const iconState1 = await springboardService.getIconState();
+        const metrics = await springboardService.getHomescreenIconMetrics();
+        const iconState2 = await springboardService.getIconState();
+
+        expect(iconState1).to.be.an('object');
+        expect(metrics).to.be.an('object');
+        expect(iconState2).to.be.an('object');
+
+        // Verify that we get consistent results
+        expect(iconState1).to.deep.equal(iconState2);
+      } catch (error) {
+        log.error('Error testing connection persistence:', (error as Error).message);
+        throw error;
+      }
+    });
+  });
+
+  describe('error handling', function () {
+    it('should provide meaningful error messages', async function () {
+      try {
+        // Test with a service that has invalid configuration
+        const invalidService = new (await import('../../src/services/ios/springboard-service/index.js')).SpringBoardService(['127.0.0.1', 99999]);
+        await invalidService.getIconState();
+
+        expect.fail('Expected method to throw an error');
+      } catch (error) {
+        expect(error).to.be.an('error');
+        const errorMessage = (error as Error).message;
+        expect(errorMessage).to.be.a('string');
+        expect(errorMessage.length).to.be.greaterThan(0);
+        expect(errorMessage).to.include('Failed to get Icon state');
+      }
+    });
+  });
+});

--- a/test/integration/springboard-service-test.ts
+++ b/test/integration/springboard-service-test.ts
@@ -14,7 +14,7 @@ describe('SpringBoardService', function () {
 
   let remoteXPC: any;
   let springboardService: SpringboardService;
-  const udid = process.env.UDID || '00008030-000318693E32402E';
+  const udid = process.env.UDID || '';
 
   before(async function () {
     try {
@@ -53,6 +53,36 @@ describe('SpringBoardService', function () {
       }
     });
   });
+
+  // TODO: this test does not pass due to some connection issue
+  // Investigate and fix later
+  //
+  // describe('setIconState', function () {
+  //   it('should set the icon state without errors', async function () {
+  //     try {
+  //       const iconState = await springboardService.getIconState();
+  //       // Check if iconState is not null and has at least one element
+  //       if (iconState && Array.isArray(iconState) && iconState.length > 0) {
+  //         // Reverse the first page of icons
+  //         const firstPage = iconState[1];
+  //         if (Array.isArray(firstPage)) {
+  //           iconState[1] = firstPage.reverse();
+  //         }
+  //
+  //         // Set the modified icon state
+  //         await springboardService.setIconState(iconState);
+  //
+  //         // Verify the change was applied
+  //         const newIconState = await springboardService.getIconState();
+  //         expect(newIconState).to.deep.equal(iconState);
+  //       }
+  //
+  //     } catch (error) {
+  //       log.error('Error setting icon state:', (error as Error).message);
+  //       throw error;
+  //     }
+  //   });
+  // });
 
   describe('getIconPNGData', function () {
     it('should retrieve PNG data for a valid bundle ID', async function () {


### PR DESCRIPTION
This PR implements springboard service which works through RSD `com.apple.springboardservices.shim.remote`. 

This service is used for getting iconData, IconState, wallpapers and several other things

Fixes issue https://github.com/appium/appium-ios-remotexpc/issues/77

Note: `setIconState`, `getWallpaperInfo` and `getWallpaperPNGData` don't work due to a bug in Apple's protocol. This is already being tracked through [`pymobildevice3`](https://github.com/doronz88/pymobiledevice3/issues/1450)