### PR TITLE
chore(tss): remove unnecessary type conversion

### DIFF
--- a/src/lib/tss/index.ts
+++ b/src/lib/tss/index.ts
@@ -171,11 +171,7 @@ export class TSSRequest {
     log.debug('TSS Request:', this._request);
 
     try {
-      const requestDataStr = createPlist(this._request);
-      const requestData =
-        typeof requestDataStr === 'string'
-          ? Buffer.from(requestDataStr, 'utf8')
-          : requestDataStr;
+      const requestData = createPlist(this._request);
 
       const res = await axios.post(TSS_CONTROLLER_ACTION_URL, requestData, {
         headers,


### PR DESCRIPTION
Axios handles string and buffer automatically.

`createPlist(this._request)` returns string (XML) and we can send it directly to TSS server via axios.

Tested on device and is working fine.