### PR TITLE
chore(dvt): rename test scripts for DVT services

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "test:afc": "mocha test/integration/afc-test.ts --exit --timeout 1m",
     "test:power-assertion": "mocha test/integration/power-assertion-test.ts --exit --timeout 1m",
     "test:dvt": "mocha test/integration/dvt-service-test.ts --exit --timeout 1m",
-    "test:location-simulation-dvt": "mocha test/integration/dvt_instruments/location-simulation-test.ts --exit --timeout 1m",
-    "test:condition-inducer-dvt": "mocha test/integration/dvt_instruments/condition-inducer-test.ts --exit --timeout 1m",
+    "test:dvt:location-simulation": "mocha test/integration/dvt_instruments/location-simulation-test.ts --exit --timeout 1m",
+    "test:dvt:condition-inducer": "mocha test/integration/dvt_instruments/condition-inducer-test.ts --exit --timeout 1m",
     "test:tunnel-creation": "sudo tsx scripts/test-tunnel-creation.ts",
     "test:tunnel-creation:lsof": "sudo tsx scripts/test-tunnel-creation.ts --keep-open"
   },


### PR DESCRIPTION
Scope test scripts to `dvt` namespace for better grouping of dvt instrument tests.

This will help in finding these test scripts more intuitively.