### PR TITLE
chore(dvt): refactor initialization to `base-instrument.ts`

### DIFF
--- a/src/services/ios/dvt/instruments/application-listing.ts
+++ b/src/services/ios/dvt/instruments/application-listing.ts
@@ -1,7 +1,6 @@
 import { getLogger } from '../../../../lib/logger.js';
-import type { Channel } from '../channel.js';
 import { MessageAux } from '../dtx-message.js';
-import type { DVTSecureSocketProxyService } from '../index.js';
+import { BaseInstrument } from './base-instrument.js';
 
 const log = getLogger('ApplicationListing');
 
@@ -46,23 +45,9 @@ export interface iOSApplication {
 /**
  * Application Listing service for retrieving installed applications
  */
-export class ApplicationListing {
+export class ApplicationListing extends BaseInstrument {
   static readonly IDENTIFIER =
     'com.apple.instruments.server.services.device.applictionListing';
-
-  private channel: Channel | null = null;
-
-  constructor(private readonly dvt: DVTSecureSocketProxyService) {}
-
-  /**
-   * Initialize the application listing channel
-   */
-  async initialize(): Promise<void> {
-    if (this.channel) {
-      return;
-    }
-    this.channel = await this.dvt.makeChannel(ApplicationListing.IDENTIFIER);
-  }
 
   /**
    * Get the list of installed applications from the device

--- a/src/services/ios/dvt/instruments/base-instrument.ts
+++ b/src/services/ios/dvt/instruments/base-instrument.ts
@@ -1,0 +1,27 @@
+import type { Channel } from '../channel.js';
+import type { DVTSecureSocketProxyService } from '../index.js';
+
+/**
+ * Base class for DVT instrument services.
+ *
+ * Subclasses must define a static `IDENTIFIER` property.
+ */
+export abstract class BaseInstrument {
+  static readonly IDENTIFIER: string;
+
+  protected channel: Channel | null = null;
+  constructor(protected readonly dvt: DVTSecureSocketProxyService) {}
+
+  protected get identifier(): string {
+    return (this.constructor as typeof BaseInstrument).IDENTIFIER;
+  }
+
+  /**
+   * Initialize the instrument channel.
+   */
+  async initialize(): Promise<void> {
+    if (!this.channel) {
+      this.channel = await this.dvt.makeChannel(this.identifier);
+    }
+  }
+}

--- a/src/services/ios/dvt/instruments/condition-inducer.ts
+++ b/src/services/ios/dvt/instruments/condition-inducer.ts
@@ -1,8 +1,7 @@
 import { getLogger } from '../../../../lib/logger.js';
 import type { ConditionGroup } from '../../../../lib/types.js';
-import type { Channel } from '../channel.js';
 import { MessageAux } from '../dtx-message.js';
-import type { DVTSecureSocketProxyService } from '../index.js';
+import { BaseInstrument } from './base-instrument.js';
 
 const log = getLogger('ConditionInducer');
 
@@ -10,23 +9,9 @@ const log = getLogger('ConditionInducer');
  * Condition Inducer service for simulating various device conditions
  * such as network conditions, thermal states, etc.
  */
-export class ConditionInducer {
+export class ConditionInducer extends BaseInstrument {
   static readonly IDENTIFIER =
     'com.apple.instruments.server.services.ConditionInducer';
-
-  private channel: Channel | null = null;
-
-  constructor(private readonly dvt: DVTSecureSocketProxyService) {}
-
-  /**
-   * Initialize the condition inducer channel
-   */
-  async initialize(): Promise<void> {
-    if (this.channel) {
-      return;
-    }
-    this.channel = await this.dvt.makeChannel(ConditionInducer.IDENTIFIER);
-  }
 
   /**
    * List all available condition inducers and their profiles

--- a/src/services/ios/dvt/instruments/device-info.ts
+++ b/src/services/ios/dvt/instruments/device-info.ts
@@ -1,9 +1,8 @@
 import { getLogger } from '../../../../lib/logger.js';
 import { parseBinaryPlist } from '../../../../lib/plist/index.js';
 import type { ProcessInfo } from '../../../../lib/types.js';
-import type { Channel } from '../channel.js';
 import { MessageAux } from '../dtx-message.js';
-import type { DVTSecureSocketProxyService } from '../index.js';
+import { BaseInstrument } from './base-instrument.js';
 
 const log = getLogger('DeviceInfo');
 
@@ -25,21 +24,9 @@ const log = getLogger('DeviceInfo');
  * - nameForUid(uid): Get username for UID
  * - nameForGid(gid): Get group name for GID
  */
-export class DeviceInfo {
+export class DeviceInfo extends BaseInstrument {
   static readonly IDENTIFIER =
     'com.apple.instruments.server.services.deviceinfo';
-
-  private channel: Channel | null = null;
-  constructor(private readonly dvt: DVTSecureSocketProxyService) {}
-
-  /**
-   * Initialize the device info channel
-   */
-  async initialize(): Promise<void> {
-    if (!this.channel) {
-      this.channel = await this.dvt.makeChannel(DeviceInfo.IDENTIFIER);
-    }
-  }
 
   /**
    * List directory contents at the specified path.

--- a/src/services/ios/dvt/instruments/graphics.ts
+++ b/src/services/ios/dvt/instruments/graphics.ts
@@ -1,23 +1,12 @@
 import { getLogger } from '../../../../lib/logger.js';
-import type { Channel } from '../channel.js';
 import { MessageAux } from '../dtx-message.js';
-import type { DVTSecureSocketProxyService } from '../index.js';
+import { BaseInstrument } from './base-instrument.js';
 
 const log = getLogger('Graphics');
 
-export class Graphics {
+export class Graphics extends BaseInstrument {
   static readonly IDENTIFIER =
     'com.apple.instruments.server.services.graphics.opengl';
-
-  private channel: Channel | null = null;
-
-  constructor(private readonly dvt: DVTSecureSocketProxyService) {}
-
-  async initialize(): Promise<void> {
-    if (!this.channel) {
-      this.channel = await this.dvt.makeChannel(Graphics.IDENTIFIER);
-    }
-  }
 
   async start(): Promise<void> {
     await this.initialize();

--- a/src/services/ios/dvt/instruments/location-simulation.ts
+++ b/src/services/ios/dvt/instruments/location-simulation.ts
@@ -1,7 +1,6 @@
 import { getLogger } from '../../../../lib/logger.js';
-import type { Channel } from '../channel.js';
 import { MessageAux } from '../dtx-message.js';
-import type { DVTSecureSocketProxyService } from '../index.js';
+import { BaseInstrument } from './base-instrument.js';
 
 const log = getLogger('LocationSimulation');
 
@@ -16,24 +15,9 @@ export interface LocationCoordinates {
 /**
  * Location simulation service for simulating device GPS location
  */
-export class LocationSimulation {
+export class LocationSimulation extends BaseInstrument {
   static readonly IDENTIFIER =
     'com.apple.instruments.server.services.LocationSimulation';
-
-  private channel: Channel | null = null;
-
-  constructor(private readonly dvt: DVTSecureSocketProxyService) {}
-
-  /**
-   * Initialize the location simulation channel
-   */
-  async initialize(): Promise<void> {
-    if (this.channel) {
-      return;
-    }
-
-    this.channel = await this.dvt.makeChannel(LocationSimulation.IDENTIFIER);
-  }
 
   /**
    * Set the simulated GPS location

--- a/src/services/ios/dvt/instruments/screenshot.ts
+++ b/src/services/ios/dvt/instruments/screenshot.ts
@@ -1,25 +1,14 @@
 import { getLogger } from '../../../../lib/logger.js';
-import type { Channel } from '../channel.js';
-import type { DVTSecureSocketProxyService } from '../index.js';
+import { BaseInstrument } from './base-instrument.js';
 
 const log = getLogger('Screenshot');
 
 /**
  * Screenshot service for capturing device screenshots
  */
-export class Screenshot {
+export class Screenshot extends BaseInstrument {
   static readonly IDENTIFIER =
     'com.apple.instruments.server.services.screenshot';
-
-  private channel: Channel | null = null;
-
-  constructor(private readonly dvt: DVTSecureSocketProxyService) {}
-
-  async initialize(): Promise<void> {
-    if (!this.channel) {
-      this.channel = await this.dvt.makeChannel(Screenshot.IDENTIFIER);
-    }
-  }
 
   /**
    * Capture a screenshot from the device


### PR DESCRIPTION
As suggested in https://github.com/appium/appium-ios-remotexpc/pull/110#discussion_r2602307373, we can reuse the `initialize()` method for all instruments to avoid duplication.

`base-instrument.ts` handles the constructor and instrument initialization.
New instruments just need to define the static `IDENTIFIER` property and it will create a channel for the identifier.