### PR TITLE
chore(logger): fix `build:es` error

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,8 +1,9 @@
 import { logger } from '@appium/support';
+import { type AppiumLogger } from '@appium/types';
 
 const LOG_LEVEL = (process.env.APPIUM_IOS_REMOTEXPC_LOG_LEVEL || 'info') as any;
 
-export function getLogger(name: string) {
+export function getLogger(name: string): AppiumLogger {
   const log = logger.getLogger(name);
   log.level = LOG_LEVEL;
   return log;


### PR DESCRIPTION
Fix `logger.ts` error when using `build:es`. 

`src/lib/logger.ts(5,17): error TS2742: The inferred type of 'getLogger' cannot be named without a reference to '@appium/support/node_modules/@appium/types'. This is likely not portable. A type annotation is necessary.`

This needs to be fixed in order to run `npm link`

<img width="1426" height="550" alt="image" src="https://github.com/user-attachments/assets/47850883-d51b-4976-ac61-d1a1d0aaa348" />
