### PR TITLE
fix(notification-proxy): add `close()` method

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -229,6 +229,10 @@ export interface NotificationProxyService extends BaseService {
    * @returns Promise resolving to the expected notification
    */
   expectNotification(timeout?: number): Promise<PlistMessage>;
+  /**
+   * Close the notification proxy service connection
+   */
+  close(): void;
 }
 
 /**

--- a/src/services/ios/notification-proxy/index.ts
+++ b/src/services/ios/notification-proxy/index.ts
@@ -118,6 +118,23 @@ class NotificationProxyService
   }
 
   /**
+   * Close the notification proxy service connection
+   */
+  close(): void {
+    try {
+      if (this._conn) {
+        this._conn.close();
+        log.debug('Notification proxy connection closed successfully');
+      }
+    } catch (error) {
+      log.error('Error closing notification proxy connection:', error);
+    } finally {
+      this._conn = null;
+      this._pendingNotificationsObservationSet.clear();
+    }
+  }
+
+  /**
    * Connect to the notification proxy service
    * @returns Promise resolving to the ServiceConnection instance
    */


### PR DESCRIPTION
Adds `close()` method to stop the notification proxy service connections.

Resolves https://github.com/appium/appium-xcuitest-driver/issues/2723

