### PR TITLE
feat(installation-proxy): support returning all attributes in browse

### DIFF
--- a/src/services/ios/installation-proxy/index.ts
+++ b/src/services/ios/installation-proxy/index.ts
@@ -77,9 +77,8 @@ export class InstallationProxyService extends BaseService {
       ApplicationType: applicationType,
     };
 
-    // When returnAttributes includes '*', don't set ReturnAttributes
-    // to let iOS return all available attributes
-    if (!returnAttributes.includes('*')) {
+    // Only set ReturnAttributes when it's an array.
+    if (Array.isArray(returnAttributes)) {
       clientOptions.ReturnAttributes = returnAttributes;
     }
 

--- a/src/services/ios/installation-proxy/types.ts
+++ b/src/services/ios/installation-proxy/types.ts
@@ -8,8 +8,8 @@ export type ProgressCallback = (
 export interface BrowseOptions {
   applicationType?: ApplicationType;
   /**
-   * Array of attribute names to return.
-   * Use ['*'] to get all available attributes.
+   * Attribute name(s) to return.
+   * - Use '*' to get all available attributes
    */
   returnAttributes?: string[] | '*';
 }


### PR DESCRIPTION
Adds support for returning all attributes from the ios device by passing `*` as `returnAttributes`

Useful to match the result of ios-device for `listApps` in https://github.com/appium/appium-xcuitest-driver/pull/2714.