### PR TITLE
fix: Force pin tinyexec

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,9 +89,9 @@
     "rimraf": "^6.0.1",
     "semantic-release": "^25.0.2",
     "sinon": "^21.0.0",
+    "tinyexec": "1.0.2",
     "ts-node": "^10.9.2",
     "tsx": "^4.7.0",
-    "tinyexec": "^1.0.3",
     "typescript": "^5.2.2"
   },
   "dependencies": {
@@ -103,6 +103,9 @@
     "axios": "^1.12.0",
     "minimatch": "^10.1.1",
     "npm-run-all2": "^8.0.4"
+  },
+  "overrides": {
+    "tinyexec": "1.0.2"
   },
   "files": [
     "src",


### PR DESCRIPTION
Needed to unblock publishing. See https://github.com/tinylibs/tinyexec/issues/90