### PR TITLE
chore: Remove tinyexec pin

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "rimraf": "^6.0.1",
     "semantic-release": "^25.0.2",
     "sinon": "^21.0.0",
-    "tinyexec": "1.0.2",
     "ts-node": "^10.9.2",
     "tsx": "^4.7.0",
     "typescript": "^5.2.2"
@@ -103,9 +102,6 @@
     "axios": "^1.12.0",
     "minimatch": "^10.1.1",
     "npm-run-all2": "^8.0.4"
-  },
-  "overrides": {
-    "tinyexec": "1.0.2"
   },
   "files": [
     "src",


### PR DESCRIPTION
The bug https://github.com/tinylibs/tinyexec/issues/90 is fixed