### PR TITLE
feat: Add XCTestAttachment wrapper

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -100,6 +100,7 @@ export {
   createXCTestRunner,
   runXCTest,
 } from './services/ios/testmanagerd/xcuitest.js';
+export { XCTestAttachment } from './services/ios/testmanagerd/xctest-attachment.js';
 export {
   XCTestRunError,
   XCTestEventType,

--- a/src/services/ios/dvt/nskeyedarchiver-encoder.ts
+++ b/src/services/ios/dvt/nskeyedarchiver-encoder.ts
@@ -59,6 +59,8 @@ export class NSKeyedArchiverEncoder {
 
     if (Buffer.isBuffer(value)) {
       index = this.archiveBuffer(value);
+    } else if (value instanceof Set) {
+      index = this.archiveSet(value);
     } else if (Array.isArray(value)) {
       index = this.archiveArray(value);
     } else if (typeof value === 'object') {
@@ -89,6 +91,26 @@ export class NSKeyedArchiverEncoder {
     const classUid = this.getClassUid('NSArray', 'NSObject');
 
     // Create array structure
+    this.objects[index] = {
+      'NS.objects': itemUids,
+      $class: new PlistUID(classUid),
+    };
+
+    return index;
+  }
+
+  /** NSSet — same `NS.objects` layout as NSArray; matches NSKeyedArchiver on Apple platforms. */
+  protected archiveSet(set: Set<any>): number {
+    const index = this.objects.length;
+    this.objects.push(null); // Placeholder
+    this.objectCache.set(set, index);
+
+    const items = Array.from(set);
+    const itemUids = items.map(
+      (item) => new PlistUID(this.archiveObject(item)),
+    );
+    const classUid = this.getClassUid('NSSet', 'NSObject');
+
     this.objects[index] = {
       'NS.objects': itemUids,
       $class: new PlistUID(classUid),

--- a/src/services/ios/testmanagerd/testmanagerd-encoder.ts
+++ b/src/services/ios/testmanagerd/testmanagerd-encoder.ts
@@ -7,6 +7,9 @@ import { NSKeyedArchiverEncoder } from '../dvt/nskeyedarchiver-encoder.js';
  *
  * Marker objects use a `__type` discriminator field so the encoder can
  * distinguish them from plain dictionaries.
+ *
+ * Callers must pass **canonical** UUID strings for `NSUUID` markers; this
+ * encoder does not validate or normalize (see {@link archiveNSUUID}).
  */
 export class TestmanagerdEncoder extends NSKeyedArchiverEncoder {
   protected override archiveObject(value: any): number {
@@ -26,6 +29,12 @@ export class TestmanagerdEncoder extends NSKeyedArchiverEncoder {
     return super.archiveObject(value);
   }
 
+  /**
+   * @param uuidString Canonical RFC-4122 string with dashes (32 hex digits when
+   * dashes are stripped). Callers should use `crypto.randomUUID()` or
+   * `canonicalizeUuidString` from `./uuid.js` before encoding; this method does
+   * not validate.
+   */
   private archiveNSUUID(uuidString: string): number {
     const index = this.objects.length;
     this.objects.push(null); // Placeholder

--- a/src/services/ios/testmanagerd/uuid.ts
+++ b/src/services/ios/testmanagerd/uuid.ts
@@ -1,0 +1,20 @@
+/**
+ * Parse and normalize a UUID string for testmanagerd payloads (NSString lists,
+ * NSKeyedArchiver NSUUID). Accepts optional `{…}` braces and dashes; returns
+ * lowercase RFC-4122 `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`.
+ */
+export function canonicalizeUuidString(raw: string): string {
+  if (typeof raw !== 'string' || !raw.trim()) {
+    throw new Error('UUID must be a non-empty string');
+  }
+  let s = raw.trim();
+  if (s.startsWith('{') && s.endsWith('}')) {
+    s = s.slice(1, -1).trim();
+  }
+  const hex = s.replace(/-/g, '');
+  if (!/^[0-9a-fA-F]{32}$/.test(hex)) {
+    throw new Error(`Invalid UUID (expected 32 hex digits): ${raw}`);
+  }
+  const low = hex.toLowerCase();
+  return `${low.slice(0, 8)}-${low.slice(8, 12)}-${low.slice(12, 16)}-${low.slice(16, 20)}-${low.slice(20)}`;
+}

--- a/src/services/ios/testmanagerd/xctest-attachment.ts
+++ b/src/services/ios/testmanagerd/xctest-attachment.ts
@@ -8,11 +8,13 @@ import {
   extractNSKeyedArchiverObjects,
   hasNSErrorIndicators,
 } from '../dvt/utils.js';
+import { canonicalizeUuidString } from './uuid.js';
 import {
   DEFAULT_EXEC_CAPABILITIES,
   SELECTOR,
   TESTMANAGERD_CHANNEL,
 } from './xctest-common.js';
+import { createNSUUID } from './xctestconfiguration.js';
 
 const log = getLogger('XCTestAttachment');
 
@@ -55,7 +57,7 @@ export class XCTestAttachment {
 
       const sessionId = crypto.randomUUID();
       const initArgs = new MessageAux();
-      initArgs.appendObj({ __type: 'NSUUID', uuid: sessionId });
+      initArgs.appendObj(createNSUUID(sessionId));
       initArgs.appendObj({
         __type: 'XCTCapabilities',
         capabilities: DEFAULT_EXEC_CAPABILITIES,
@@ -124,13 +126,12 @@ async function deleteAttachmentsOnChannel(
     throw new Error('deleteAttachmentsOnChannel requires at least one UUID');
   }
 
+  const normalized = uuids.map((u) => canonicalizeUuidString(u));
+  const unique = [...new Set(normalized)];
+
   const args = new MessageAux();
-  args.appendObj(
-    uuids.map((u) => ({
-      __type: 'NSUUID' as const,
-      uuid: u,
-    })),
-  );
+  // NSSet<NSUUID> — matches `_IDE_deleteAttachmentsWithUUIDs:` on the IDE side.
+  args.appendObj(new Set(unique.map((u) => createNSUUID(u))));
 
   await connection.sendMessage(
     channelCode,

--- a/src/services/ios/testmanagerd/xctest-attachment.ts
+++ b/src/services/ios/testmanagerd/xctest-attachment.ts
@@ -1,0 +1,144 @@
+import crypto from 'node:crypto';
+
+import { getLogger } from '../../../lib/logger.js';
+import type { TestmanagerdService } from '../../../lib/types.js';
+import * as Services from '../../../services.js';
+import { MessageAux } from '../dvt/dtx-message.js';
+import {
+  extractNSKeyedArchiverObjects,
+  hasNSErrorIndicators,
+} from '../dvt/utils.js';
+import {
+  DEFAULT_EXEC_CAPABILITIES,
+  SELECTOR,
+  TESTMANAGERD_CHANNEL,
+} from './xctest-common.js';
+
+const log = getLogger('XCTestAttachment');
+
+const MIN_NSERROR_DESCRIPTION_LEN = 20;
+
+/**
+ * IDE-side XCTest attachment management for a device (e.g. delete screen
+ * recordings by UUID under testmanagerd's Attachments). Opens a short-lived
+ * testmanagerd session; private Apple API.
+ */
+export class XCTestAttachment {
+  private readonly udid: string;
+
+  constructor(udid: string) {
+    if (!udid?.trim()) {
+      throw new Error('udid is required');
+    }
+    this.udid = udid;
+  }
+
+  /** Device UDID passed to the constructor. */
+  get deviceId(): string {
+    return this.udid;
+  }
+
+  /**
+   * Delete attachments by UUID (`_IDE_deleteAttachmentsWithUUIDs:`).
+   * Opens testmanagerd, initiates an IDE exec session, sends delete, then closes.
+   */
+  async delete(uuids: string[]): Promise<unknown> {
+    if (!uuids?.length) {
+      throw new Error('delete requires at least one UUID');
+    }
+
+    const conn = await Services.startTestmanagerdService(this.udid);
+    try {
+      const channel =
+        await conn.testmanagerdService.makeChannel(TESTMANAGERD_CHANNEL);
+      const channelCode = channel.getCode();
+
+      const sessionId = crypto.randomUUID();
+      const initArgs = new MessageAux();
+      initArgs.appendObj({ __type: 'NSUUID', uuid: sessionId });
+      initArgs.appendObj({
+        __type: 'XCTCapabilities',
+        capabilities: DEFAULT_EXEC_CAPABILITIES,
+      });
+
+      await conn.testmanagerdService.sendMessage(
+        channelCode,
+        SELECTOR.initiateSession,
+        { args: initArgs },
+      );
+      const [initResult] =
+        await conn.testmanagerdService.recvPlist(channelCode);
+      log.debug('Exec session for attachment delete:', initResult);
+
+      return await deleteAttachmentsOnChannel(
+        conn.testmanagerdService,
+        channelCode,
+        uuids,
+      );
+    } finally {
+      try {
+        await conn.testmanagerdService.close();
+      } catch {
+        /* ignore */
+      }
+      try {
+        await conn.remoteXPC.close();
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}
+
+function throwIfNSErrorReply(result: unknown, context: string): void {
+  if (result == null || typeof result !== 'object') {
+    return;
+  }
+  const objects = extractNSKeyedArchiverObjects(result);
+  if (objects) {
+    const hasErr = objects.some((o) => hasNSErrorIndicators(o));
+    if (hasErr) {
+      const msg =
+        objects.find(
+          (o: any) =>
+            typeof o === 'string' && o.length > MIN_NSERROR_DESCRIPTION_LEN,
+        ) ?? 'NSError from testmanagerd';
+      throw new Error(`${context}: ${msg}`);
+    }
+  }
+  if (hasNSErrorIndicators(result)) {
+    throw new Error(`${context}: ${JSON.stringify(result)}`);
+  }
+}
+
+/**
+ * Send `_IDE_deleteAttachmentsWithUUIDs:` on an existing testmanagerd channel.
+ * Used by {@link XCTestAttachment.delete}.
+ */
+async function deleteAttachmentsOnChannel(
+  connection: TestmanagerdService,
+  channelCode: number,
+  uuids: string[],
+): Promise<unknown> {
+  if (!uuids.length) {
+    throw new Error('deleteAttachmentsOnChannel requires at least one UUID');
+  }
+
+  const args = new MessageAux();
+  args.appendObj(
+    uuids.map((u) => ({
+      __type: 'NSUUID' as const,
+      uuid: u,
+    })),
+  );
+
+  await connection.sendMessage(
+    channelCode,
+    SELECTOR.deleteAttachmentsWithUUIDs,
+    { args, expectsReply: true },
+  );
+
+  const [result] = await connection.recvPlist(channelCode);
+  throwIfNSErrorReply(result, 'deleteAttachmentsOnChannel');
+  return result;
+}

--- a/src/services/ios/testmanagerd/xctest-common.ts
+++ b/src/services/ios/testmanagerd/xctest-common.ts
@@ -33,6 +33,9 @@ export const SELECTOR = {
   initiateControlSession: '_IDE_initiateControlSessionWithCapabilities:',
   authorizeTestSession: '_IDE_authorizeTestSessionWithProcessID:',
 
+  /** IDE → daemon: remove attachments by UUID (XCTMessagingRole_AttachmentsDeleting). */
+  deleteAttachmentsWithUUIDs: '_IDE_deleteAttachmentsWithUUIDs:',
+
   // Device → IDE (exec callbacks)
   logDebugMessage: '_XCT_logDebugMessage:',
   testRunnerReady: '_XCT_testRunnerReadyWithCapabilities:',

--- a/src/services/ios/testmanagerd/xctestconfiguration.ts
+++ b/src/services/ios/testmanagerd/xctestconfiguration.ts
@@ -197,6 +197,7 @@ export interface XCTestConfigurationParams {
 
 export interface NSUUIDMarker {
   __type: 'NSUUID';
+  /** Canonical RFC-4122 string with dashes (e.g. `crypto.randomUUID()`). */
   uuid: string;
 }
 
@@ -207,7 +208,9 @@ export interface NSURLMarker {
 }
 
 /**
- * Helper to create an NSUUID marker object
+ * Helper to create an NSUUID marker object.
+ * `uuid` must already be canonical (e.g. from `crypto.randomUUID()` or
+ * `canonicalizeUuidString` from `./uuid.js`).
  */
 export function createNSUUID(uuid: string): NSUUIDMarker {
   return { __type: 'NSUUID', uuid };

--- a/src/services/ios/testmanagerd/xcuitest.ts
+++ b/src/services/ios/testmanagerd/xcuitest.ts
@@ -22,7 +22,6 @@ import {
   XCTestEventType,
   XCTestRunError,
   type XCTestRunResult,
-  type XCTestRunStage,
   type XCTestRunnerEvents,
   type XCTestRunnerOptions,
   type XCTestSummary,

--- a/test/integration/testmanagerd-test.ts
+++ b/test/integration/testmanagerd-test.ts
@@ -24,7 +24,11 @@ log.level = 'debug';
 const XCODE_VERSION = 36;
 
 const UDID = process.env.UDID || '';
-/** Set to a real attachment UUID to run the optional delete smoke test. */
+/**
+ * Set to a real attachment UUID to run the optional delete smoke test.
+ * Must be a full RFC-4122 string (32 hex digits, with or without dashes), e.g.
+ * `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`.
+ */
 const XCTEST_DELETE_ATTACHMENT_TEST_UUID =
   process.env.XCTEST_DELETE_ATTACHMENT_TEST_UUID || '';
 const TEST_RUNNER_BUNDLE_ID = process.env.TEST_RUNNER_BUNDLE_ID;

--- a/test/integration/testmanagerd-test.ts
+++ b/test/integration/testmanagerd-test.ts
@@ -6,7 +6,11 @@ import type {
   HouseArrestServiceWithConnection,
   TestmanagerdServiceWithConnection,
 } from '../../src/index.js';
-import { XCTestConfigurationEncoder, runXCTest } from '../../src/index.js';
+import {
+  XCTestAttachment,
+  XCTestConfigurationEncoder,
+  runXCTest,
+} from '../../src/index.js';
 import {
   createBinaryPlist,
   parseBinaryPlist,
@@ -20,6 +24,9 @@ log.level = 'debug';
 const XCODE_VERSION = 36;
 
 const UDID = process.env.UDID || '';
+/** Set to a real attachment UUID to run the optional delete smoke test. */
+const XCTEST_DELETE_ATTACHMENT_TEST_UUID =
+  process.env.XCTEST_DELETE_ATTACHMENT_TEST_UUID || '';
 const TEST_RUNNER_BUNDLE_ID = process.env.TEST_RUNNER_BUNDLE_ID;
 const APP_UNDER_TEST_BUNDLE_ID = process.env.APP_UNDER_TEST_BUNDLE_ID;
 const XCTEST_BUNDLE_ID = process.env.XCTEST_BUNDLE_ID;
@@ -301,6 +308,20 @@ describe('Testmanagerd Service', function () {
       expect(result.sessionIdentifier).to.be.a('string');
       expect(result.testRunnerPid).to.be.greaterThan(0);
       expect(result.durationMs).to.be.greaterThan(0);
+    });
+  });
+
+  describe('IDE delete attachments (optional)', function () {
+    before(function () {
+      if (!XCTEST_DELETE_ATTACHMENT_TEST_UUID) {
+        this.skip();
+      }
+    });
+
+    it('should delete attachments via XCTestAttachment', async function () {
+      const attachments = new XCTestAttachment(UDID);
+      expect(attachments.deviceId).to.equal(UDID);
+      await attachments.delete([XCTEST_DELETE_ATTACHMENT_TEST_UUID]);
     });
   });
 });

--- a/test/unit/testmanagerd-test.ts
+++ b/test/unit/testmanagerd-test.ts
@@ -11,6 +11,8 @@ import {
   readPrimitiveDictEntry,
 } from '../../src/services/ios/testmanagerd/index.js';
 import { TestmanagerdEncoder } from '../../src/services/ios/testmanagerd/testmanagerd-encoder.js';
+import { canonicalizeUuidString } from '../../src/services/ios/testmanagerd/uuid.js';
+import { createNSUUID } from '../../src/services/ios/testmanagerd/xctestconfiguration.js';
 
 /**
  * Testable subclass that exposes private methods for unit testing.
@@ -60,6 +62,29 @@ function buildPrimitiveDictEntry(type: number, value: Buffer): Buffer {
 
 // #endregion
 
+describe('canonicalizeUuidString', function () {
+  it('should normalize dashed, brace, and undashed forms', function () {
+    const expected = 'aabbccdd-1122-3344-5566-778899aabbcc';
+    expect(
+      canonicalizeUuidString('AABBCCDD-1122-3344-5566-778899AABBCC'),
+    ).to.equal(expected);
+    expect(
+      canonicalizeUuidString('{aabbccdd-1122-3344-5566-778899aabbcc}'),
+    ).to.equal(expected);
+    expect(canonicalizeUuidString('aabbccdd112233445566778899aabbcc')).to.equal(
+      expected,
+    );
+  });
+
+  it('should reject invalid input', function () {
+    expect(() => canonicalizeUuidString('')).to.throw();
+    expect(() => canonicalizeUuidString('not-a-uuid')).to.throw();
+    expect(() =>
+      canonicalizeUuidString('11111111-1111-1111-1111-111'),
+    ).to.throw();
+  });
+});
+
 describe('TestmanagerdEncoder', function () {
   let encoder: TestmanagerdEncoder;
 
@@ -69,7 +94,7 @@ describe('TestmanagerdEncoder', function () {
 
   it('should encode NSUUID with correct bytes and class', function () {
     const uuid = 'AABBCCDD-1122-3344-5566-778899AABBCC';
-    const result = encoder.encode({ __type: 'NSUUID', uuid });
+    const result = encoder.encode(createNSUUID(uuid));
     const objects = result.$objects;
 
     const nsUuidObj = objects.find(
@@ -89,25 +114,34 @@ describe('TestmanagerdEncoder', function () {
     expect(classObj.$classes).to.deep.equal(['NSUUID', 'NSObject']);
   });
 
-  it('should encode NSArray of NSUUID for _IDE_deleteAttachmentsWithUUIDs payload', function () {
+  it('should encode NSSet of NSUUID for _IDE_deleteAttachmentsWithUUIDs payload', function () {
     const uuids = [
       '11111111-1111-1111-1111-111111111111',
       '22222222-2222-2222-2222-222222222222',
     ];
-    const result = encoder.encode(
-      uuids.map((u) => ({ __type: 'NSUUID' as const, uuid: u })),
-    );
+    const result = encoder.encode(new Set(uuids.map((u) => createNSUUID(u))));
     const objects = result.$objects as any[];
-    const arrObj = objects.find(
-      (o: any) =>
-        o &&
-        typeof o === 'object' &&
-        !('NS.keys' in o) &&
-        Array.isArray(o['NS.objects']) &&
-        o['NS.objects'].length === 2,
-    );
-    expect(arrObj, 'NSArray root').to.not.be.undefined;
-    expect(arrObj!['NS.objects']).to.have.length(2);
+    const rootIdx = result.$top.root.value;
+    const setObj = objects[rootIdx];
+    expect(setObj['NS.objects']).to.have.length(2);
+    const classDef = objects[setObj.$class.value];
+    expect(classDef).to.have.property('$classname', 'NSSet');
+    expect(classDef.$classes).to.deep.equal(['NSSet', 'NSObject']);
+
+    const hexSorted = (buf: Buffer) => buf.toString('hex');
+    const expectedHex = uuids
+      .map((u) => hexSorted(Buffer.from(u.replace(/-/g, ''), 'hex')))
+      .sort();
+    const gotHex = setObj['NS.objects']
+      .map((uid: PlistUID) =>
+        hexSorted(objects[uid.value]['NS.uuidbytes'] as Buffer),
+      )
+      .sort();
+    expect(gotHex).to.deep.equal(expectedHex);
+    for (const uid of setObj['NS.objects'] as PlistUID[]) {
+      const uuidClass = objects[objects[uid.value].$class.value];
+      expect(uuidClass.$classname).to.equal('NSUUID');
+    }
   });
 
   it('should encode XCTCapabilities with referenced dictionary', function () {

--- a/test/unit/testmanagerd-test.ts
+++ b/test/unit/testmanagerd-test.ts
@@ -89,6 +89,27 @@ describe('TestmanagerdEncoder', function () {
     expect(classObj.$classes).to.deep.equal(['NSUUID', 'NSObject']);
   });
 
+  it('should encode NSArray of NSUUID for _IDE_deleteAttachmentsWithUUIDs payload', function () {
+    const uuids = [
+      '11111111-1111-1111-1111-111111111111',
+      '22222222-2222-2222-2222-222222222222',
+    ];
+    const result = encoder.encode(
+      uuids.map((u) => ({ __type: 'NSUUID' as const, uuid: u })),
+    );
+    const objects = result.$objects as any[];
+    const arrObj = objects.find(
+      (o: any) =>
+        o &&
+        typeof o === 'object' &&
+        !('NS.keys' in o) &&
+        Array.isArray(o['NS.objects']) &&
+        o['NS.objects'].length === 2,
+    );
+    expect(arrObj, 'NSArray root').to.not.be.undefined;
+    expect(arrObj!['NS.objects']).to.have.length(2);
+  });
+
   it('should encode XCTCapabilities with referenced dictionary', function () {
     const result = encoder.encode({
       __type: 'XCTCapabilities',


### PR DESCRIPTION
## Description

Adds **`XCTestAttachment`** (`udid` in the constructor) with **`delete(uuids)`**, which opens a short-lived testmanagerd connection, creates the IDE proxy channel, runs **`_IDE_initiateSessionWithIdentifier:capabilities:`**, then sends **`_IDE_deleteAttachmentsWithUUIDs:`** with an `NSArray` of `NSUUID` payloads (same encoding path as the rest of testmanagerd).

- New selector on **`SELECTOR`**: `deleteAttachmentsWithUUIDs` → `_IDE_deleteAttachmentsWithUUIDs:` ([`xctest-common.ts`](src/services/ios/testmanagerd/xctest-common.ts)).
- Deletion logic is encapsulated in this module; **`deleteAttachmentsOnChannel`** is an internal helper (not part of the public API).
- **`XCUITestService`** no longer exposes attachment deletion or an exec-channel getter; use **`XCTestAttachment`** when deletion should not be tied to the full XCTest runner lifecycle.

This matches the **IDE → daemon** attachment API (see `XCTMessagingRole_AttachmentsDeleting` in XCTest headers). 

## Testing

- **Unit** ([`test/unit/testmanagerd-test.ts`](test/unit/testmanagerd-test.ts)): `TestmanagerdEncoder` encodes an `NSArray` of two `NSUUID`s for the delete payload.
- **Integration** (optional): with `UDID` set, set **`XCTEST_DELETE_ATTACHMENT_TEST_UUID`** to a real attachment UUID and run **`npm run test:testmanagerd`** — exercises **`new XCTestAttachment(UDID).delete([uuid])`**. Omit the env var to skip that case.

---

## Notes for later **appium-xcuitest-driver** integration

- **Dependency**: consume **`XCTestAttachment`** (and types) from a released **appium-ios-remotexpc** version that includes this PR.
- **When to call**: after WDA **`POST /wda/video/stop`** (or equivalent), when you have the recording **`uuid`** (same value used for devicectl **`Attachments/<uuid>`**).
- **Manual QA**: real device, iOS **17+** where XCTest screen recording applies; confirm delete + devicectl list or device storage before/after as needed.