### PR TITLE
refactor: remove deprecated discovery and WebInspector APIs

### DIFF
--- a/src/lib/apple-tv/devicectl-enrichment.ts
+++ b/src/lib/apple-tv/devicectl-enrichment.ts
@@ -32,9 +32,6 @@ function mergeMetadata(
     model: extra.model || base.model,
     version: extra.version || base.version,
     deviceType: extra.deviceType || base.deviceType,
-    minVersion: base.minVersion,
-    authTag: base.authTag,
-    serviceType: base.serviceType,
   };
 }
 

--- a/src/lib/apple-tv/discovered-device-mapper.ts
+++ b/src/lib/apple-tv/discovered-device-mapper.ts
@@ -17,9 +17,6 @@ export function toAppleTVDevice(
   const identifier = toStringValue(device.metadata.identifier) || device.id;
   const model = toStringValue(device.metadata.model);
   const version = toStringValue(device.metadata.version);
-  const minVersion = toStringValue(device.metadata.minVersion) || '17';
-  const authTag = toStringValue(device.metadata.authTag) || undefined;
-  const interfaceIndex: number | undefined = undefined;
 
   return {
     name: device.name,
@@ -29,9 +26,6 @@ export function toAppleTVDevice(
     port,
     model,
     version,
-    minVersion,
-    authTag,
-    interfaceIndex,
   };
 }
 

--- a/src/lib/apple-tv/types.ts
+++ b/src/lib/apple-tv/types.ts
@@ -35,12 +35,6 @@ export interface AppleTVDevice {
   port: number;
   model: string;
   version: string;
-  /** @deprecated Retained for backward compatibility; not actively used. */
-  minVersion: string;
-  /** @deprecated Retained for backward compatibility; not actively used. */
-  authTag?: string;
-  /** @deprecated Retained for backward compatibility; not actively used. */
-  interfaceIndex?: number;
 }
 
 // Configuration options for the pairing process

--- a/src/lib/discovery/dnssd-discovery-backend.ts
+++ b/src/lib/discovery/dnssd-discovery-backend.ts
@@ -56,7 +56,7 @@ export class DnssdDiscoveryBackend implements IDeviceDiscoveryBackend {
         return;
       }
       const key = `${service.name ?? hostname}:${hostname}:${service.port}`;
-      devices.set(key, resolveDiscoveredDevice(service, hostname, serviceType));
+      devices.set(key, resolveDiscoveredDevice(service, hostname));
     });
 
     browser.on('error', (err: Error) => {
@@ -91,7 +91,6 @@ export class DnssdDiscoveryBackend implements IDeviceDiscoveryBackend {
 async function resolveDiscoveredDevice(
   service: Service,
   hostname: string,
-  serviceType: string,
 ): Promise<DiscoveredDevice | null> {
   try {
     if (!service.port) {
@@ -104,9 +103,6 @@ async function resolveDiscoveredDevice(
       identifier,
       model: txt.model ?? '',
       version: txt.ver ?? '',
-      minVersion: txt.minVer ?? '17',
-      authTag: txt.authTag,
-      serviceType,
     };
     return {
       id: identifier,

--- a/src/lib/discovery/types.ts
+++ b/src/lib/discovery/types.ts
@@ -2,13 +2,7 @@ export interface DiscoveredDeviceMetadata {
   identifier?: string;
   model?: string;
   version?: string;
-  /** @deprecated Retained for backward compatibility; not actively used. */
-  minVersion?: string;
   deviceType?: string;
-  /** @deprecated Retained for backward compatibility; not actively used. */
-  authTag?: string;
-  /** @deprecated Retained for backward compatibility; not actively used. */
-  serviceType?: string;
 }
 
 export interface DiscoveredDevice {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1230,12 +1230,6 @@ export interface WebInspectorService extends BaseService {
 
   /**
    * Stop listening to messages
-   * @deprecated Use stopListeningAsync() instead for connecting with multiple connections
-   */
-  stopListening(): void;
-
-  /**
-   * Stop listening to messages
    */
   stopListeningAsync(): Promise<void>;
 

--- a/src/services/ios/webinspector/index.ts
+++ b/src/services/ios/webinspector/index.ts
@@ -146,15 +146,6 @@ export class WebInspectorService extends BaseService {
 
   /**
    * Stop listening to messages
-   * @deprecated Use stopListeningAsync() instead for connecting with multiple connections
-   */
-  stopListening(): void {
-    this.isReceiving = false;
-    this.messageEmitter.emit('stop');
-  }
-
-  /**
-   * Stop listening to messages
    */
   async stopListeningAsync(): Promise<void> {
     this.isReceiving = false;

--- a/test/unit/apple-tv/devicectl-enrichment.spec.ts
+++ b/test/unit/apple-tv/devicectl-enrichment.spec.ts
@@ -48,9 +48,6 @@ describe('devicectl-enrichment', function () {
           model: '',
           version: '',
           deviceType: '',
-          minVersion: '17',
-          authTag: 'base-auth-tag',
-          serviceType: '_remotepairing._tcp',
         },
       },
     ];
@@ -72,9 +69,6 @@ describe('devicectl-enrichment', function () {
     expect(enriched[0].metadata.model).to.equal('AppleTV6,2');
     expect(enriched[0].metadata.version).to.equal('17.4');
     expect(enriched[0].metadata.deviceType).to.equal('tv');
-    expect(enriched[0].metadata.minVersion).to.equal('17');
-    expect(enriched[0].metadata.authTag).to.equal('base-auth-tag');
-    expect(enriched[0].metadata.serviceType).to.equal('_remotepairing._tcp');
   });
 
   it('keeps device unchanged when hostnames do not match', async function () {


### PR DESCRIPTION
BREAKING CHANGE: DiscoveredDeviceMetadata no longer includes minVersion, authTag, or serviceType.
BREAKING CHANGE: AppleTVDevice no longer includes minVersion, authTag, or interfaceIndex.
BREAKING CHANGE: WebInspectorService.stopListening() removed; use stopListeningAsync() instead.