### PR TITLE
fix(usbmux): stop swallowing `_receivePlistPromise` rejections

### DIFF
--- a/src/lib/usbmux/index.ts
+++ b/src/lib/usbmux/index.ts
@@ -350,9 +350,6 @@ export class Usbmux extends BaseSocketService {
             );
           }, timeout);
         });
-      } catch (error) {
-        log.debug(`Receive failed for tag ${tag}: ${error}`);
-        return undefined as T;
       } finally {
         if (timeoutId) {
           clearTimeout(timeoutId);


### PR DESCRIPTION
#196 rewrote `Usbmux._receivePlistPromise` as an async IIFE and added a catch-all that swallows every rejection and returns undefined.

This results in error when running WDA and remotexpc tunnel is not started (fallback path):

```
info XCUITestDriver@d3c5 Launching WebDriverAgent on the device without xcodebuild
file:///Users/navinchandra/Documents/Projects/appium-mcp/node_modules/appium-xcuitest-driver/node_modules/appium-ios-remotexpc/build/src/lib/port-forwarding/device-port-forwarder.js:105
        upstreamSocket.once('close', teardown);
                       ^

TypeError: Cannot read properties of undefined (reading 'once')
    at DevicePortForwarder.handleLocalConnection (file:///Users/navinchandra/Documents/Projects/appium-mcp/node_modules/appium-xcuitest-driver/node_modules/appium-ios-remotexpc/build/src/lib/port-forwarding/device-port-forwarder.js:105:24)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)

```