### PR TITLE
fix(tunnel): resolve PacketStreamServer.stop() hang on Ctrl+C

### DIFF
--- a/src/lib/tunnel/packet-stream-server.ts
+++ b/src/lib/tunnel/packet-stream-server.ts
@@ -52,7 +52,7 @@ export class PacketStreamServer extends EventEmitter {
       const server = this.server;
       await new Promise<void>((resolve, reject) => {
         server.once('error', reject);
-        server.close(() => resolve);
+        server.close(() => resolve());
       });
       this.server = null;
     }


### PR DESCRIPTION
## Summary

Fixes an important regression where `PacketStreamServer.stop()` hangs forever, breaking SIGINT cleanup in `scripts/tunnel-creation.mjs` and leaving orphaned root `node` processes that hold the tunnel registry port.

## Root cause

In `src/lib/tunnel/packet-stream-server.ts`, the `stop()` method awaits a `Promise` whose `server.close()` callback was written as `() => resolve` instead of `() => resolve()`:

```ts
await new Promise<void>((resolve, reject) => {
  server.once('error', reject);
  server.close(() => resolve);   // returns the resolve function instead of calling it
});
```

Because `resolve()` is never invoked, the promise never settles, `stop()` hangs, and the SIGINT cleanup loop in `tunnel-creation.mjs` is stuck on `await server.stop()`. Each subsequent Ctrl+C re-fires the SIGINT handler and re-prints `Cleaning up (SIGINT (Ctrl+C))... Closing 1 packet stream server(s)...` without ever exiting. The orphaned `sudo node scripts/tunnel-creation.mjs` then keeps port `42314` (tunnel registry) and the packet stream port (`50000`) bound, so `npm run test:tunnel-creation` fails on the next run with `EADDRINUSE` until those processes are killed manually with `sudo kill`.

This was introduced in #196 ("fix: Linter warnings") which rewrote the original working `server.close(() => { this.server = null; resolve(); })` into the broken arrow form.

## Fix

One-character fix: change `() => resolve` to `() => resolve()` so the promise actually resolves when `server.close()` finishes.