### PR TITLE
fix(discovery): accept single-digit hour in dns-sd timestamps

### DIFF
--- a/src/lib/discovery/bonjour-output-parsers.ts
+++ b/src/lib/discovery/bonjour-output-parsers.ts
@@ -6,7 +6,7 @@
  */
 import { stripTrailingDot } from './discovery-utils.js';
 
-const BROWSE_TIMESTAMP = /^\d{2}:\d{2}:\d{2}\.\d+$/;
+const BROWSE_TIMESTAMP = /^\d{1,2}:\d{2}:\d{2}\.\d+$/;
 const BROWSE_FIXED_COLUMNS = 6;
 const TXT_PAIR = /(\S+?)=(\S+)/g;
 const REACHABLE = /can be reached at (\S+):(\d+)/;

--- a/test/unit/discovery/bonjour-output-parsers.spec.ts
+++ b/test/unit/discovery/bonjour-output-parsers.spec.ts
@@ -71,6 +71,16 @@ describe('bonjour-output-parsers', function () {
         'NOPE          Add        2  17 local. _remotepairing._tcp. Bedroom';
       expect(parseBrowseLine(line)).to.be.null;
     });
+
+    it('accepts space-padded single-digit hour timestamps', function () {
+      // dns-sd renders hours 0-9 with a leading space (e.g. " 8:25:13.882"),
+      // which becomes a single digit after trim() + split(/\s+/).
+      const line =
+        ' 8:25:13.882  Add        2  17 local. _remotepairing-manual-pairing._tcp. Bedroom';
+      const parsed = parseBrowseLine(line);
+      expect(parsed?.action).to.equal('Add');
+      expect(parsed?.service.name).to.equal('Bedroom');
+    });
   });
 
   describe('parseReachableLine', function () {


### PR DESCRIPTION
## Summary

`dns-sd` space-pads hours 0-9 (e.g. ` 8:25:13.882`), which becomes a single digit after `trim()` + `split(/\s+/)`. The `BROWSE_TIMESTAMP` regex in `parseBrowseLine` required `\d{2}` for the hour, so every line emitted between **00:00 and 09:59** local time was rejected → discovery silently saw 0 devices and pairing failed with `NO_DEVICES`.

Caught while running `npm run pair-appletv` at 8:25 AM:

\`\`\`
ERR! AppleTVPairingService No Apple TV pairing devices found.
PairingError: ... { code: 'NO_DEVICES' }
\`\`\`

The reason this slipped through #205: every existing test fixture uses an afternoon timestamp (e.g. ` 11:52:30.137`), so the 2-digit-hour assumption was never exercised.

## Changes

- `BROWSE_TIMESTAMP`: `\d{2}` → `\d{1,2}` for the hour (minutes/seconds stay strict because `dns-sd` always zero-pads them).
- New regression test using a real ` 8:25:13.882` sample.

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] New unit test fails on \`main\`, passes with the regex change
- [ ] Manually re-run \`npm run pair-appletv\` between 00:00 and 09:59 → device discovered (devicectl enrichment failure is a separate, unrelated issue)