### PR TITLE
fix(services): close internal RemoteXpcConnection in start*Service helpers

### DIFF
--- a/src/lib/tunnel/tunnel-api-client.ts
+++ b/src/lib/tunnel/tunnel-api-client.ts
@@ -21,6 +21,19 @@ export interface TunnelApiClientOptions {
 }
 
 /**
+ * Resolved tunnel endpoint returned by the tunnel registry.
+ * Flat DTO describing where to reach the device's RSD service; intentionally
+ * distinct from the live `TunnelConnection` exported from `appium-ios-tuntap`,
+ * which models the active tunnel session.
+ */
+export interface TunnelEndpoint {
+  host: string;
+  port: number;
+  udid: string;
+  packetStreamPort: number | undefined;
+}
+
+/**
  * API client for tunnel registry operations
  * This client handles communication with the API server for tunnel data
  */
@@ -167,12 +180,7 @@ export class TunnelApiClient {
    * @param udid - Device UDID
    * @returns Connection details or null if tunnel not found
    */
-  async getTunnelConnection(udid: string): Promise<{
-    host: string;
-    port: number;
-    udid: string;
-    packetStreamPort: number | undefined;
-  } | null> {
+  async getTunnelConnection(udid: string): Promise<TunnelEndpoint | null> {
     const tunnel = await this.getTunnelByUdid(udid);
     if (!tunnel) {
       return null;

--- a/src/services.ts
+++ b/src/services.ts
@@ -201,8 +201,15 @@ export async function startPowerAssertionService(
 export async function startSyslogService(
   udid: string,
 ): Promise<SyslogServiceType> {
-  const { tunnelConnection } = await createRemoteXPCConnection(udid);
-  return new SyslogService([tunnelConnection.host, tunnelConnection.port]);
+  const { remoteXPC, tunnelConnection } = await createRemoteXPCConnection(udid);
+  try {
+    return new SyslogService([tunnelConnection.host, tunnelConnection.port]);
+  } finally {
+    // Release the discovery RSD eagerly so iOS's `remoted` daemon does not
+    // see this connection overlap with any subsequent RSD probe and reset
+    // it (the source of the ECONNRESET storm during driver startup).
+    await remoteXPC.close();
+  }
 }
 
 const RSD_SYSLOG_BINARY_SERVICE_NAME = 'com.apple.os_trace_relay.shim.remote';
@@ -242,11 +249,19 @@ export async function startSyslogTextService(
  */
 export async function startAfcService(udid: string): Promise<AfcService> {
   const { remoteXPC, tunnelConnection } = await createRemoteXPCConnection(udid);
-  const afcDescriptor = remoteXPC.findService(AfcService.RSD_SERVICE_NAME);
-  return new AfcService([
-    tunnelConnection.host,
-    parseInt(afcDescriptor.port, 10),
-  ]);
+  try {
+    const afcDescriptor = remoteXPC.findService(AfcService.RSD_SERVICE_NAME);
+    return new AfcService([
+      tunnelConnection.host,
+      parseInt(afcDescriptor.port, 10),
+    ]);
+  } finally {
+    // AfcService talks directly to the discovered service port, so the
+    // RemoteXPC discovery connection is no longer needed. Releasing it
+    // here avoids a duplicate RSD against `remoted` and the resulting
+    // ECONNRESET (mirrors the pattern used by startXCTestServices).
+    await remoteXPC.close();
+  }
 }
 
 /**
@@ -518,13 +533,19 @@ async function startSyslogWithServiceName(
   serviceName: string,
 ): Promise<{ syslogService: SyslogServiceType; serviceDescriptor: Service }> {
   const { remoteXPC, tunnelConnection } = await createRemoteXPCConnection(udid);
-  return {
-    syslogService: new SyslogService([
-      tunnelConnection.host,
-      tunnelConnection.port,
-    ]),
-    serviceDescriptor: remoteXPC.findService(serviceName),
-  };
+  try {
+    return {
+      syslogService: new SyslogService([
+        tunnelConnection.host,
+        tunnelConnection.port,
+      ]),
+      serviceDescriptor: remoteXPC.findService(serviceName),
+    };
+  } finally {
+    // Discovery RSD is no longer needed once we have the service descriptor;
+    // close it to keep at most one RSD open against `remoted` per call.
+    await remoteXPC.close();
+  }
 }
 
 // #region Private Functions

--- a/src/services.ts
+++ b/src/services.ts
@@ -1,7 +1,7 @@
 import { BaseItem, strongbox } from '@appium/strongbox';
 
 import { TUNNEL_CONTAINER_NAME } from './constants.js';
-import { RemoteXpcConnection } from './lib/remote-xpc/remote-xpc-connection.js';
+import type { RemoteXpcConnection } from './lib/remote-xpc/remote-xpc-connection.js';
 import { TunnelManager } from './lib/tunnel/index.js';
 import {
   TunnelApiClient,
@@ -201,15 +201,11 @@ export async function startPowerAssertionService(
 export async function startSyslogService(
   udid: string,
 ): Promise<SyslogServiceType> {
-  const { remoteXPC, tunnelConnection } = await createRemoteXPCConnection(udid);
-  try {
-    return new SyslogService([tunnelConnection.host, tunnelConnection.port]);
-  } finally {
-    // Release the discovery RSD eagerly so iOS's `remoted` daemon does not
-    // see this connection overlap with any subsequent RSD probe and reset
-    // it (the source of the ECONNRESET storm during driver startup).
-    await remoteXPC.close();
-  }
+  return withRemoteXpcConnection(
+    udid,
+    (_, tunnelConnection) =>
+      new SyslogService([tunnelConnection.host, tunnelConnection.port]),
+  );
 }
 
 const RSD_SYSLOG_BINARY_SERVICE_NAME = 'com.apple.os_trace_relay.shim.remote';
@@ -220,6 +216,10 @@ export interface StartXCTestServicesOptions {
   /** Also resolve and return an InstallationProxyService for app lookup. */
   includeInstallationProxy?: boolean;
 }
+
+type TunnelConnection = Awaited<
+  ReturnType<typeof createRemoteXPCConnection>
+>['tunnelConnection'];
 
 /**
  * Resolve the syslog binary service (os_trace_relay RemoteXPC shim).
@@ -248,20 +248,13 @@ export async function startSyslogTextService(
  * Resolves the AFC service port via RemoteXPC and returns a ready-to-use AfcService instance.
  */
 export async function startAfcService(udid: string): Promise<AfcService> {
-  const { remoteXPC, tunnelConnection } = await createRemoteXPCConnection(udid);
-  try {
+  return withRemoteXpcConnection(udid, (remoteXPC, tunnelConnection) => {
     const afcDescriptor = remoteXPC.findService(AfcService.RSD_SERVICE_NAME);
     return new AfcService([
       tunnelConnection.host,
       parseInt(afcDescriptor.port, 10),
     ]);
-  } finally {
-    // AfcService talks directly to the discovered service port, so the
-    // RemoteXPC discovery connection is no longer needed. Releasing it
-    // here avoids a duplicate RSD against `remoted` and the resulting
-    // ECONNRESET (mirrors the pattern used by startXCTestServices).
-    await remoteXPC.close();
-  }
+  });
 }
 
 /**
@@ -526,26 +519,41 @@ export async function getAvailableDevices(): Promise<string[]> {
 }
 
 /**
+ * Run `fn` with a freshly opened discovery `RemoteXpcConnection` and close
+ * that connection unconditionally when `fn` settles. Use this whenever a
+ * `start*Service` helper only needs the RSD to discover a service port:
+ * the discovery RSD is single-use, so leaking it would race with `remoted`
+ * and produce an `ECONNRESET` against any subsequent RSD probe.
+ */
+async function withRemoteXpcConnection<T>(
+  udid: string,
+  fn: (
+    remoteXPC: RemoteXpcConnection,
+    tunnelConnection: TunnelConnection,
+  ) => T | Promise<T>,
+): Promise<T> {
+  const { remoteXPC, tunnelConnection } = await createRemoteXPCConnection(udid);
+  try {
+    return await fn(remoteXPC, tunnelConnection);
+  } finally {
+    await remoteXPC.close();
+  }
+}
+
+/**
  * Resolve syslog service descriptor by RemoteXPC service name.
  */
 async function startSyslogWithServiceName(
   udid: string,
   serviceName: string,
 ): Promise<{ syslogService: SyslogServiceType; serviceDescriptor: Service }> {
-  const { remoteXPC, tunnelConnection } = await createRemoteXPCConnection(udid);
-  try {
-    return {
-      syslogService: new SyslogService([
-        tunnelConnection.host,
-        tunnelConnection.port,
-      ]),
-      serviceDescriptor: remoteXPC.findService(serviceName),
-    };
-  } finally {
-    // Discovery RSD is no longer needed once we have the service descriptor;
-    // close it to keep at most one RSD open against `remoted` per call.
-    await remoteXPC.close();
-  }
+  return withRemoteXpcConnection(udid, (remoteXPC, tunnelConnection) => ({
+    syslogService: new SyslogService([
+      tunnelConnection.host,
+      tunnelConnection.port,
+    ]),
+    serviceDescriptor: remoteXPC.findService(serviceName),
+  }));
 }
 
 // #region Private Functions

--- a/src/services.ts
+++ b/src/services.ts
@@ -6,6 +6,7 @@ import { TunnelManager } from './lib/tunnel/index.js';
 import {
   TunnelApiClient,
   type TunnelApiClientOptions,
+  type TunnelEndpoint,
 } from './lib/tunnel/tunnel-api-client.js';
 import type {
   CrashReportsServiceWithConnection,
@@ -216,10 +217,6 @@ export interface StartXCTestServicesOptions {
   /** Also resolve and return an InstallationProxyService for app lookup. */
   includeInstallationProxy?: boolean;
 }
-
-type TunnelConnection = Awaited<
-  ReturnType<typeof createRemoteXPCConnection>
->['tunnelConnection'];
 
 /**
  * Resolve the syslog binary service (os_trace_relay RemoteXPC shim).
@@ -529,7 +526,7 @@ async function withRemoteXpcConnection<T>(
   udid: string,
   fn: (
     remoteXPC: RemoteXpcConnection,
-    tunnelConnection: TunnelConnection,
+    tunnelConnection: TunnelEndpoint,
   ) => T | Promise<T>,
 ): Promise<T> {
   const { remoteXPC, tunnelConnection } = await createRemoteXPCConnection(udid);

--- a/test/unit/services/start-services-cleanup.spec.ts
+++ b/test/unit/services/start-services-cleanup.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import esmock from 'esmock';
-import sinon from 'sinon';
+import * as sinon from 'sinon';
 
 interface RemoteXpcStub {
   findService: sinon.SinonStub;
@@ -16,17 +16,12 @@ interface LoadedServices {
 
 /**
  * Load `src/services.ts` with `TunnelManager.createRemoteXPCConnection`,
- * the strongbox registry port, and the tunnel API client all stubbed.
- *
- * The returned `closeSpy` lets each test assert that the internally-created
- * `RemoteXpcConnection` was closed after port discovery, mirroring the
- * `try/finally { remoteXPC.close() }` pattern the file already uses inside
- * `startXCTestServices`.
+ * the strongbox registry port, and the tunnel API client all stubbed so
+ * we can exercise the `withRemoteXpcConnection` cleanup contract without
+ * a real device.
  */
 async function loadServicesWithStubs(
-  options: {
-    findServiceImpl?: (name: string) => unknown;
-  } = {},
+  options: { findServiceImpl?: (name: string) => unknown } = {},
 ): Promise<LoadedServices> {
   const closeSpy = sinon.spy(async () => {});
   const findServiceStub = sinon.stub();
@@ -44,8 +39,6 @@ async function loadServicesWithStubs(
     close: closeSpy,
   };
 
-  const tunnelConnection = { host: '127.0.0.1', port: 1234 };
-
   const services = await esmock('../../../src/services.js', {
     '@appium/strongbox': {
       strongbox: () => ({}),
@@ -61,7 +54,7 @@ async function loadServicesWithStubs(
           return true;
         }
         async getTunnelConnection() {
-          return tunnelConnection;
+          return { host: '127.0.0.1', port: 1234 };
         }
       },
     },
@@ -75,9 +68,9 @@ async function loadServicesWithStubs(
   return { services, remoteXPCStub, closeSpy, findServiceStub };
 }
 
-describe('start*Service — internal RemoteXpcConnection cleanup', function () {
-  describe('startAfcService', function () {
-    it('closes the internal remoteXPC after port discovery', async function () {
+describe('start*Service — discovery RemoteXpcConnection lifecycle', function () {
+  describe('withRemoteXpcConnection contract (via startAfcService)', function () {
+    it('closes the discovery connection after the helper returns', async function () {
       const { services, closeSpy, findServiceStub } =
         await loadServicesWithStubs();
 
@@ -87,14 +80,10 @@ describe('start*Service — internal RemoteXpcConnection cleanup', function () {
         closeSpy.calledOnce,
         `expected exactly one close() call, got ${closeSpy.callCount}`,
       ).to.equal(true);
-      expect(
-        findServiceStub.calledWith('com.apple.afc.shim.remote'),
-        'expected findService to be queried for the AFC RSD shim name',
-      ).to.equal(true);
       sinon.assert.callOrder(findServiceStub, closeSpy);
     });
 
-    it('still closes remoteXPC when findService throws (try/finally semantics)', async function () {
+    it('closes the discovery connection even when the body throws', async function () {
       const { services, closeSpy } = await loadServicesWithStubs({
         findServiceImpl: () => {
           throw new Error('Service not found');
@@ -108,92 +97,34 @@ describe('start*Service — internal RemoteXpcConnection cleanup', function () {
         caught = err as Error;
       }
 
-      expect(caught, 'expected findService error to propagate').to.exist;
+      expect(caught, 'expected the error to propagate').to.exist;
       expect(
         closeSpy.calledOnce,
-        `expected exactly one close() call even on error path, got ${closeSpy.callCount}`,
+        `expected exactly one close() call on the error path, got ${closeSpy.callCount}`,
       ).to.equal(true);
     });
   });
 
-  describe('startSyslogService', function () {
-    /**
-     * Special case: this helper does not call `findService` at all — it
-     * historically created a `RemoteXpcConnection` and dropped the
-     * reference on the floor. The fix wraps the unused connection in
-     * `try/finally` so it is always closed.
-     */
-    it('closes the internal remoteXPC even though it never calls findService', async function () {
-      const { services, closeSpy, findServiceStub } =
-        await loadServicesWithStubs();
+  describe('RSD service-name correctness', function () {
+    it('startAfcService queries the AFC RSD shim by name', async function () {
+      const { services, findServiceStub } = await loadServicesWithStubs();
 
-      await services.startSyslogService('test-udid');
+      await services.startAfcService('test-udid');
 
       expect(
-        closeSpy.calledOnce,
-        `expected exactly one close() call, got ${closeSpy.callCount}`,
+        findServiceStub.calledOnceWith('com.apple.afc.shim.remote'),
+        'expected findService("com.apple.afc.shim.remote")',
       ).to.equal(true);
-      expect(
-        findServiceStub.called,
-        'helper must not consult findService',
-      ).to.equal(false);
     });
-  });
 
-  describe('startSyslog{Binary,Text}Service', function () {
-    /**
-     * Both wrappers delegate to the private `startSyslogWithServiceName`
-     * helper with different RSD service names; one parameterized test
-     * covers both surfaces without duplicated assertion code.
-     */
-    const cases: { fn: string; expectedRsdName: string }[] = [
-      {
-        fn: 'startSyslogBinaryService',
-        expectedRsdName: 'com.apple.os_trace_relay.shim.remote',
-      },
-      {
-        fn: 'startSyslogTextService',
-        expectedRsdName: 'com.apple.syslog_relay.shim.remote',
-      },
-    ];
+    it('startSyslogBinaryService queries the os_trace_relay RSD shim by name', async function () {
+      const { services, findServiceStub } = await loadServicesWithStubs();
 
-    for (const { fn, expectedRsdName } of cases) {
-      it(`${fn} closes the internal remoteXPC after port discovery`, async function () {
-        const { services, closeSpy, findServiceStub } =
-          await loadServicesWithStubs();
+      await services.startSyslogBinaryService('test-udid');
 
-        await services[fn]('test-udid');
-
-        expect(
-          closeSpy.calledOnce,
-          `${fn}: expected exactly one close() call, got ${closeSpy.callCount}`,
-        ).to.equal(true);
-        expect(
-          findServiceStub.calledWith(expectedRsdName),
-          `${fn}: expected findService to be queried for ${expectedRsdName}`,
-        ).to.equal(true);
-        sinon.assert.callOrder(findServiceStub, closeSpy);
-      });
-    }
-
-    it('startSyslogBinaryService still closes remoteXPC when findService throws (try/finally semantics)', async function () {
-      const { services, closeSpy } = await loadServicesWithStubs({
-        findServiceImpl: () => {
-          throw new Error('Service not found');
-        },
-      });
-
-      let caught: Error | undefined;
-      try {
-        await services.startSyslogBinaryService('test-udid');
-      } catch (err) {
-        caught = err as Error;
-      }
-
-      expect(caught, 'expected findService error to propagate').to.exist;
       expect(
-        closeSpy.calledOnce,
-        `expected exactly one close() call even on error path, got ${closeSpy.callCount}`,
+        findServiceStub.calledOnceWith('com.apple.os_trace_relay.shim.remote'),
+        'expected findService("com.apple.os_trace_relay.shim.remote")',
       ).to.equal(true);
     });
   });

--- a/test/unit/services/start-services-cleanup.spec.ts
+++ b/test/unit/services/start-services-cleanup.spec.ts
@@ -1,0 +1,200 @@
+import { expect } from 'chai';
+import esmock from 'esmock';
+import sinon from 'sinon';
+
+interface RemoteXpcStub {
+  findService: sinon.SinonStub;
+  close: sinon.SinonSpy;
+}
+
+interface LoadedServices {
+  services: Record<string, any>;
+  remoteXPCStub: RemoteXpcStub;
+  closeSpy: sinon.SinonSpy;
+  findServiceStub: sinon.SinonStub;
+}
+
+/**
+ * Load `src/services.ts` with `TunnelManager.createRemoteXPCConnection`,
+ * the strongbox registry port, and the tunnel API client all stubbed.
+ *
+ * The returned `closeSpy` lets each test assert that the internally-created
+ * `RemoteXpcConnection` was closed after port discovery, mirroring the
+ * `try/finally { remoteXPC.close() }` pattern the file already uses inside
+ * `startXCTestServices`.
+ */
+async function loadServicesWithStubs(
+  options: {
+    findServiceImpl?: (name: string) => unknown;
+  } = {},
+): Promise<LoadedServices> {
+  const closeSpy = sinon.spy(async () => {});
+  const findServiceStub = sinon.stub();
+  if (options.findServiceImpl) {
+    findServiceStub.callsFake(options.findServiceImpl);
+  } else {
+    findServiceStub.callsFake((serviceName: string) => ({
+      serviceName,
+      port: '49374',
+    }));
+  }
+
+  const remoteXPCStub: RemoteXpcStub = {
+    findService: findServiceStub,
+    close: closeSpy,
+  };
+
+  const tunnelConnection = { host: '127.0.0.1', port: 1234 };
+
+  const services = await esmock('../../../src/services.js', {
+    '@appium/strongbox': {
+      strongbox: () => ({}),
+      BaseItem: class {
+        async read() {
+          return '12345';
+        }
+      },
+    },
+    '../../../src/lib/tunnel/tunnel-api-client.js': {
+      TunnelApiClient: class {
+        async hasTunnel() {
+          return true;
+        }
+        async getTunnelConnection() {
+          return tunnelConnection;
+        }
+      },
+    },
+    '../../../src/lib/tunnel/index.js': {
+      TunnelManager: {
+        createRemoteXPCConnection: async () => remoteXPCStub,
+      },
+    },
+  });
+
+  return { services, remoteXPCStub, closeSpy, findServiceStub };
+}
+
+describe('start*Service — internal RemoteXpcConnection cleanup', function () {
+  describe('startAfcService', function () {
+    it('closes the internal remoteXPC after port discovery', async function () {
+      const { services, closeSpy, findServiceStub } =
+        await loadServicesWithStubs();
+
+      await services.startAfcService('test-udid');
+
+      expect(
+        closeSpy.calledOnce,
+        `expected exactly one close() call, got ${closeSpy.callCount}`,
+      ).to.equal(true);
+      expect(
+        findServiceStub.calledWith('com.apple.afc.shim.remote'),
+        'expected findService to be queried for the AFC RSD shim name',
+      ).to.equal(true);
+      sinon.assert.callOrder(findServiceStub, closeSpy);
+    });
+
+    it('still closes remoteXPC when findService throws (try/finally semantics)', async function () {
+      const { services, closeSpy } = await loadServicesWithStubs({
+        findServiceImpl: () => {
+          throw new Error('Service not found');
+        },
+      });
+
+      let caught: Error | undefined;
+      try {
+        await services.startAfcService('test-udid');
+      } catch (err) {
+        caught = err as Error;
+      }
+
+      expect(caught, 'expected findService error to propagate').to.exist;
+      expect(
+        closeSpy.calledOnce,
+        `expected exactly one close() call even on error path, got ${closeSpy.callCount}`,
+      ).to.equal(true);
+    });
+  });
+
+  describe('startSyslogService', function () {
+    /**
+     * Special case: this helper does not call `findService` at all — it
+     * historically created a `RemoteXpcConnection` and dropped the
+     * reference on the floor. The fix wraps the unused connection in
+     * `try/finally` so it is always closed.
+     */
+    it('closes the internal remoteXPC even though it never calls findService', async function () {
+      const { services, closeSpy, findServiceStub } =
+        await loadServicesWithStubs();
+
+      await services.startSyslogService('test-udid');
+
+      expect(
+        closeSpy.calledOnce,
+        `expected exactly one close() call, got ${closeSpy.callCount}`,
+      ).to.equal(true);
+      expect(
+        findServiceStub.called,
+        'helper must not consult findService',
+      ).to.equal(false);
+    });
+  });
+
+  describe('startSyslog{Binary,Text}Service', function () {
+    /**
+     * Both wrappers delegate to the private `startSyslogWithServiceName`
+     * helper with different RSD service names; one parameterized test
+     * covers both surfaces without duplicated assertion code.
+     */
+    const cases: { fn: string; expectedRsdName: string }[] = [
+      {
+        fn: 'startSyslogBinaryService',
+        expectedRsdName: 'com.apple.os_trace_relay.shim.remote',
+      },
+      {
+        fn: 'startSyslogTextService',
+        expectedRsdName: 'com.apple.syslog_relay.shim.remote',
+      },
+    ];
+
+    for (const { fn, expectedRsdName } of cases) {
+      it(`${fn} closes the internal remoteXPC after port discovery`, async function () {
+        const { services, closeSpy, findServiceStub } =
+          await loadServicesWithStubs();
+
+        await services[fn]('test-udid');
+
+        expect(
+          closeSpy.calledOnce,
+          `${fn}: expected exactly one close() call, got ${closeSpy.callCount}`,
+        ).to.equal(true);
+        expect(
+          findServiceStub.calledWith(expectedRsdName),
+          `${fn}: expected findService to be queried for ${expectedRsdName}`,
+        ).to.equal(true);
+        sinon.assert.callOrder(findServiceStub, closeSpy);
+      });
+    }
+
+    it('startSyslogBinaryService still closes remoteXPC when findService throws (try/finally semantics)', async function () {
+      const { services, closeSpy } = await loadServicesWithStubs({
+        findServiceImpl: () => {
+          throw new Error('Service not found');
+        },
+      });
+
+      let caught: Error | undefined;
+      try {
+        await services.startSyslogBinaryService('test-udid');
+      } catch (err) {
+        caught = err as Error;
+      }
+
+      expect(caught, 'expected findService error to propagate').to.exist;
+      expect(
+        closeSpy.calledOnce,
+        `expected exactly one close() call even on error path, got ${closeSpy.callCount}`,
+      ).to.equal(true);
+    });
+  });
+});


### PR DESCRIPTION
`startAfcService`, `startSyslogService`, `startSyslogBinaryService` and `startSyslogTextService` each opened a RemoteXpcConnection for port discovery and never closed it. Combined with a caller that opens its own RSD, the leaked discovery RSD overlapped and `remoted` reset one of them, producing the `Connection error: read ECONNRESET` storm at
driver startup.

Wrap discovery + return in `try/finally { await remoteXPC.close() }`, mirroring the existing startXCTestServices pattern in the same file.