### PR TITLE
chore(test): pin tsx to 4.21.0 to unblock unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "semantic-release": "^25.0.2",
     "sinon": "^22.0.0",
     "ts-node": "^10.9.2",
-    "tsx": "^4.7.0",
+    "tsx": "4.21.0",
     "typescript": "^6.0.2"
   },
   "dependencies": {


### PR DESCRIPTION
tsx 4.21.1 and 4.22.0 (both published 2026-05-14) break
`npm run test:unit` on fresh installs. 4.21.0 is the last good
release; pinning exact since CI uses `npm install` (not `npm ci`).

Verified: `npm run test:unit` -> 395 passing on Node 24.15.0.