### PR TITLE
chore: Reduce noisy logs

### DIFF
--- a/src/lib/plist/plist-decoder.ts
+++ b/src/lib/plist/plist-decoder.ts
@@ -3,12 +3,7 @@ import { Transform, type TransformCallback } from 'node:stream';
 import { getLogger } from '../logger.js';
 import { UTF8_ENCODING } from './constants.js';
 import { parsePlist } from './unified-plist-parser.js';
-import {
-  ensureString,
-  findFirstReplacementCharacter,
-  fixMultipleXmlDeclarations,
-  hasUnicodeReplacementCharacter,
-} from './utils.js';
+import { ensureString, fixMultipleXmlDeclarations } from './utils.js';
 
 const log = getLogger('Plist');
 
@@ -54,21 +49,6 @@ export class PlistServiceDecoder extends Transform {
 
       // Check for multiple XML declarations which can cause parsing errors
       const fullDataStr = ensureString(plistData);
-
-      // Check for potential corruption indicators and handle them
-      if (hasUnicodeReplacementCharacter(plistData)) {
-        log.debug(
-          'Detected Unicode replacement characters in plist data, which may indicate encoding issues',
-        );
-
-        // Try to find and clean the corrupted data
-        const firstReplacementPos = findFirstReplacementCharacter(fullDataStr);
-        if (firstReplacementPos >= 0) {
-          log.debug(
-            `Found replacement character at position ${firstReplacementPos}, attempting to clean data`,
-          );
-        }
-      }
       const xmlDeclMatches = fullDataStr.match(/(<\?xml[^>]*\?>)/g) || [];
       if (xmlDeclMatches.length > 1) {
         log.debug(

--- a/src/lib/remote-xpc/remote-xpc-connection.ts
+++ b/src/lib/remote-xpc/remote-xpc-connection.ts
@@ -131,9 +131,6 @@ class RemoteXpcConnection {
                 // Only resolve if we found at least one service
                 if (servicesResponse.services.length > 0) {
                   this._services = servicesResponse.services;
-                  log.info(
-                    `Extracted ${servicesResponse.services.length} services`,
-                  );
                   clearTimeouts();
                   resolve(servicesResponse);
                 } else if (!serviceExtractionTimeout) {
@@ -160,9 +157,6 @@ class RemoteXpcConnection {
         });
 
         this._socket.once('close', () => {
-          if (!this._isClosing) {
-            log.info('Socket closed');
-          }
           this._isConnected = false;
           clearTimeouts();
 
@@ -249,7 +243,6 @@ class RemoteXpcConnection {
       // Listen for the close event
       if (this._socket) {
         this._socket.once('close', () => {
-          log.debug('Socket closed successfully');
           clearTimeout(closeTimeout);
           this.cleanupResources();
           resolve();
@@ -274,9 +267,6 @@ class RemoteXpcConnection {
             // But set a short timeout just in case 'close' doesn't fire
             setTimeout(() => {
               if (this._socket) {
-                log.debug(
-                  'Socket end completed but close event not fired, forcing cleanup',
-                );
                 clearTimeout(closeTimeout);
                 this.forceCleanup();
                 resolve();
@@ -347,7 +337,6 @@ class RemoteXpcConnection {
         // Stop the service-discovery parser from processing additional frames
         // while shutdown is in progress.
         this._socket.removeAllListeners('data');
-        log.debug('Successfully removed socket data listeners');
       } catch (error) {
         log.error(
           `Error removing socket data listeners: ${error instanceof Error ? error.message : String(error)}`,
@@ -379,7 +368,6 @@ class RemoteXpcConnection {
       if (this._socket) {
         // Destroy the socket forcefully
         this._socket.destroy();
-        log.debug('Socket forcefully destroyed');
       }
     } catch (error) {
       log.error(
@@ -425,11 +413,6 @@ function extractServices(response: string): ServicesResponse {
   // Sort both arrays by index to maintain order
   serviceMatches.sort((a, b) => a.index - b.index);
   portMatches.sort((a, b) => a.index - b.index);
-
-  // Log the extracted data for debugging
-  log.debug(
-    `Found ${serviceMatches.length} services and ${portMatches.length} ports`,
-  );
 
   // Create a mapping of services to ports
   const services: Service[] = [];


### PR DESCRIPTION
## Summary

Reduce noisy routine logging during RSD discovery and plist decoding. Normal connect/teardown and successful service extraction no longer emit debug/info lines on every operation.

**`RemoteXpcConnection`**
- Removed routine `info`/`debug` logs for service extraction counts, socket close/teardown, listener cleanup, and service/port regex match stats.
- Kept `warn` and `error` logs for timeouts, handshake failures, and real connection problems.

**`PlistServiceDecoder`**
- Removed a no-op block that only logged Unicode replacement-character detection (`Found replacement character at position N…` and related messages). Actual cleanup still happens in `plist-parser.ts` via `cleanXmlWithReplacementChar`.