### PR TITLE
fix: Tune remote xpc connect retry logic

### DIFF
--- a/src/lib/remote-xpc/remote-xpc-connection.ts
+++ b/src/lib/remote-xpc/remote-xpc-connection.ts
@@ -243,7 +243,7 @@ class RemoteXpcConnection {
     let accumulatedData = Buffer.alloc(0);
     let partialExtractionTimer: NodeJS.Timeout | undefined;
 
-    const schedulePartialExtractionTimeout = (data: Buffer): void => {
+    const schedulePartialExtractionTimeout = (): void => {
       if (partialExtractionTimer) {
         return;
       }
@@ -253,7 +253,7 @@ class RemoteXpcConnection {
         log.warn(
           'Service extraction timeout reached, resolving with current data',
         );
-        const finalResponse = extractServices(data.toString('utf8'));
+        const finalResponse = extractServices(accumulatedData.toString('utf8'));
         session.settleSuccess(finalResponse);
       }, SERVICE_EXTRACTION_TIMEOUT_MS);
       session.trackPartialExtractionTimer(partialExtractionTimer);
@@ -299,7 +299,7 @@ class RemoteXpcConnection {
   private tryResolveServicesFromPayload(
     session: ConnectSession,
     accumulatedData: Buffer,
-    schedulePartialExtractionTimeout: (data: Buffer) => void,
+    schedulePartialExtractionTimeout: () => void,
   ): void {
     const dataStr = accumulatedData.toString('utf8');
     if (!dataStr.includes('com.apple') || !dataStr.includes('Port')) {
@@ -313,7 +313,7 @@ class RemoteXpcConnection {
         return;
       }
 
-      schedulePartialExtractionTimeout(accumulatedData);
+      schedulePartialExtractionTimeout();
     } catch (error) {
       log.warn(
         `Error extracting services: ${error}, continuing to collect data`,

--- a/src/lib/remote-xpc/remote-xpc-connection.ts
+++ b/src/lib/remote-xpc/remote-xpc-connection.ts
@@ -86,9 +86,7 @@ class RemoteXpcConnection {
    * Connect to the remote device and perform handshake
    * @returns Promise that resolves with the list of available services
    */
-  async connect(
-    options?: RemoteXpcConnectOptions,
-  ): Promise<ServicesResponse> {
+  async connect(options?: RemoteXpcConnectOptions): Promise<ServicesResponse> {
     if (this._isConnected) {
       throw new Error('Already connected');
     }
@@ -271,9 +269,7 @@ class RemoteXpcConnection {
 
     socket.on('data', (data: Buffer | string) => {
       if (Buffer.isBuffer(data) || typeof data === 'string') {
-        const chunk = Buffer.isBuffer(data)
-          ? data
-          : Buffer.from(data, 'hex');
+        const chunk = Buffer.isBuffer(data) ? data : Buffer.from(data, 'hex');
         accumulatedData = Buffer.concat([accumulatedData, chunk]);
       }
 

--- a/src/lib/remote-xpc/remote-xpc-connection.ts
+++ b/src/lib/remote-xpc/remote-xpc-connection.ts
@@ -6,15 +6,34 @@ import Handshake from './handshake.js';
 const log = getLogger('RemoteXpcConnection');
 
 // Timeout constants
-const CONNECTION_TIMEOUT_MS = 3000; // 3 seconds
-const SERVICE_EXTRACTION_TIMEOUT_MS = 5000; // 5 seconds
-const HANDSHAKE_DELAY_MS = 100; // 100 milliseconds
-const SERVICE_AFTER_HANDSHAKE_TIMEOUT_MS = 10000; // 10 seconds
+/** Max time to wait for the TCP socket to connect. */
+export const CONNECTION_CONNECT_TIMEOUT_MS = 500;
+const HANDSHAKE_DELAY_MS = 100;
+/** Wait for service list after handshake before failing the connect attempt. */
+const SERVICE_AFTER_HANDSHAKE_TIMEOUT_MS = 10_000;
+/** Resolve with partial data if service parsing stalls mid-stream. */
+const SERVICE_EXTRACTION_TIMEOUT_MS = 5_000;
+/**
+ * Default max time for one connect attempt (TCP + handshake + service discovery).
+ * Must cover the longest connect-phase timeout plus earlier phases.
+ */
+export const CONNECTION_DEFAULT_OPERATION_TIMEOUT_MS = Math.max(
+  SERVICE_EXTRACTION_TIMEOUT_MS,
+  SERVICE_AFTER_HANDSHAKE_TIMEOUT_MS +
+    HANDSHAKE_DELAY_MS +
+    CONNECTION_CONNECT_TIMEOUT_MS,
+);
+/** TunnelManager retry budget; never shorter than a single connect attempt. */
+export const CONNECTION_OVERALL_TIMEOUT_MS =
+  CONNECTION_DEFAULT_OPERATION_TIMEOUT_MS;
 const SOCKET_CLOSE_TIMEOUT_MS = 1000; // 1 second
 const SOCKET_END_TIMEOUT_MS = 500; // 0.5 seconds
 const SOCKET_WRITE_TIMEOUT_MS = 500; // 0.5 seconds
 
-export const CONNECTION_MAX_RETRIES = 15;
+export interface RemoteXpcConnectOptions {
+  /** Max time for this connect attempt (TCP + handshake + services). */
+  timeoutMs?: number;
+}
 
 interface Service {
   serviceName: string;
@@ -25,8 +44,14 @@ interface ServicesResponse {
   services: Service[];
 }
 
-type ConnectionTimeout = NodeJS.Timeout;
-type ServiceExtractionTimeout = NodeJS.Timeout;
+/** Guards connect() resolve/reject and clears active connect-phase timers. */
+interface ConnectSession {
+  settleSuccess(response: ServicesResponse): void;
+  settleFailure(error: Error | unknown): void;
+  isSettled(): boolean;
+  clearTcpTimer(): void;
+  trackPartialExtractionTimer(timer: NodeJS.Timeout): void;
+}
 
 class RemoteXpcConnection {
   private readonly _address: [string, number];
@@ -61,155 +86,29 @@ class RemoteXpcConnection {
    * Connect to the remote device and perform handshake
    * @returns Promise that resolves with the list of available services
    */
-  async connect(): Promise<ServicesResponse> {
+  async connect(
+    options?: RemoteXpcConnectOptions,
+  ): Promise<ServicesResponse> {
     if (this._isConnected) {
       throw new Error('Already connected');
     }
 
+    const operationTimeoutMs =
+      options?.timeoutMs ?? CONNECTION_DEFAULT_OPERATION_TIMEOUT_MS;
+
     return new Promise<ServicesResponse>((resolve, reject) => {
-      // Set a timeout for the entire connection process
-      const connectionTimeout: ConnectionTimeout = setTimeout(() => {
-        if (this._socket) {
-          this._socket.destroy();
-        }
-        reject(
-          new Error(
-            `Connection timed out after ${CONNECTION_TIMEOUT_MS / 1000} seconds`,
-          ),
-        );
-      }, CONNECTION_TIMEOUT_MS);
-
-      // Set a timeout for service extraction
-      let serviceExtractionTimeout: ServiceExtractionTimeout;
-
-      const clearTimeouts = (): void => {
-        clearTimeout(connectionTimeout);
-        if (serviceExtractionTimeout) {
-          clearTimeout(serviceExtractionTimeout);
-        }
-      };
+      const session = this.createConnectSession(
+        operationTimeoutMs,
+        resolve,
+        reject,
+      );
 
       try {
-        this._socket = net.connect({
-          host: this._address[0],
-          port: this._address[1],
-          family: 6,
-        });
-
-        this._socket.setNoDelay(true);
-        this._socket.setKeepAlive(true);
-
-        // Buffer to accumulate data
-        let accumulatedData = Buffer.alloc(0);
-
-        this._socket.once('error', (error: Error) => {
-          if (!this._isClosing) {
-            log.error(`Connection error: ${error}`);
-          }
-          this._isConnected = false;
-          clearTimeouts();
-          reject(error);
-        });
-
-        // Handle incoming data
-        this._socket.on('data', (data: Buffer | string) => {
-          if (Buffer.isBuffer(data) || typeof data === 'string') {
-            const buffer = Buffer.isBuffer(data)
-              ? data
-              : Buffer.from(data, 'hex');
-
-            // Accumulate data
-            accumulatedData = Buffer.concat([accumulatedData, buffer]);
-
-            // Check if we have enough data to extract services
-            // Don't rely solely on buffer length, also check for service patterns
-            const dataStr = accumulatedData.toString('utf8');
-            if (dataStr.includes('com.apple') && dataStr.includes('Port')) {
-              try {
-                const servicesResponse = extractServices(dataStr);
-
-                // Only resolve if we found at least one service
-                if (servicesResponse.services.length > 0) {
-                  this._services = servicesResponse.services;
-                  clearTimeouts();
-                  resolve(servicesResponse);
-                } else if (!serviceExtractionTimeout) {
-                  // Set a timeout to resolve with whatever we have if no more data comes
-                  serviceExtractionTimeout = setTimeout(() => {
-                    log.warn(
-                      'Service extraction timeout reached, resolving with current data',
-                    );
-                    const finalResponse = extractServices(
-                      accumulatedData.toString('utf8'),
-                    );
-                    this._services = finalResponse.services;
-                    clearTimeouts();
-                    resolve(finalResponse);
-                  }, SERVICE_EXTRACTION_TIMEOUT_MS);
-                }
-              } catch (error) {
-                log.warn(
-                  `Error extracting services: ${error}, continuing to collect data`,
-                );
-              }
-            }
-          }
-        });
-
-        this._socket.once('close', () => {
-          this._isConnected = false;
-          clearTimeouts();
-
-          // If we haven't resolved yet, reject with an error
-          if (this._services === undefined) {
-            reject(
-              new Error('Connection closed before services were extracted'),
-            );
-          }
-        });
-
-        this._socket.once('connect', async () => {
-          try {
-            this._isConnected = true;
-            if (this._socket) {
-              this._handshake = new Handshake(this._socket);
-
-              // Add a small delay before performing handshake to ensure socket is ready
-              await new Promise<void>((resolve) =>
-                setTimeout(resolve, HANDSHAKE_DELAY_MS),
-              );
-
-              // Once handshake is successful we can get
-              // peer-info and get ports for lockdown in RSD
-              await this._handshake.perform();
-
-              // Set a timeout for service extraction (cleared on close())
-              this._serviceExtractionTimer = setTimeout(async () => {
-                this._serviceExtractionTimer = undefined;
-                if (this._services === undefined) {
-                  log.warn(
-                    'No services received after handshake, closing connection',
-                  );
-                  try {
-                    await this.close();
-                  } catch (err) {
-                    log.error(`Error closing connection: ${err}`);
-                  }
-                  reject(new Error('No services received after handshake'));
-                }
-              }, SERVICE_AFTER_HANDSHAKE_TIMEOUT_MS);
-            }
-          } catch (error) {
-            log.error(`Handshake failed: ${error}`);
-            clearTimeouts();
-            await this.close();
-            reject(error);
-          }
-        });
+        this._socket = this.createConnectSocket();
+        this.registerConnectSocketHandlers(session, this._socket);
       } catch (error) {
         log.error(`Failed to create connection: ${error}`);
-        clearTimeouts();
-        reject(error);
+        session.settleFailure(error);
       }
     });
   }
@@ -219,74 +118,15 @@ class RemoteXpcConnection {
    */
   async close(): Promise<void> {
     this._isClosing = true;
+    this.clearServiceExtractionTimer();
 
-    if (this._serviceExtractionTimer) {
-      clearTimeout(this._serviceExtractionTimer);
-      this._serviceExtractionTimer = undefined;
+    const socket = this._socket;
+    if (!socket) {
+      return;
     }
 
-    if (!this._socket) {
-      return Promise.resolve();
-    }
-
-    // Immediately mark as disconnected to prevent further operations
     this._isConnected = false;
-
-    return new Promise<void>((resolve) => {
-      // Set a shorter timeout for socket closing
-      const closeTimeout = setTimeout(() => {
-        log.warn('Socket close timed out, destroying socket');
-        this.forceCleanup();
-        resolve();
-      }, SOCKET_CLOSE_TIMEOUT_MS);
-
-      // Listen for the close event
-      if (this._socket) {
-        this._socket.once('close', () => {
-          clearTimeout(closeTimeout);
-          this.cleanupResources();
-          resolve();
-        });
-
-        // Swallow socket errors (e.g., ECONNRESET) to avoid
-        // uncaught socket errors during intentional shutdown.
-        this._socket.on('error', () => {});
-      }
-
-      try {
-        // First remove all data listeners to prevent parsing during close
-        this.cleanupSocket();
-
-        if (this._socket) {
-          // Set a small write timeout to prevent hanging
-          this._socket.setTimeout(SOCKET_WRITE_TIMEOUT_MS);
-
-          // End the socket with a small empty buffer to flush any pending data
-          this._socket.end(Buffer.alloc(0), () => {
-            // If end completes successfully, the 'close' event will handle cleanup
-            // But set a short timeout just in case 'close' doesn't fire
-            setTimeout(() => {
-              if (this._socket) {
-                clearTimeout(closeTimeout);
-                this.forceCleanup();
-                resolve();
-              }
-            }, SOCKET_END_TIMEOUT_MS);
-          });
-        } else {
-          clearTimeout(closeTimeout);
-          this.cleanupResources();
-          resolve();
-        }
-      } catch (error) {
-        log.error(
-          `Unexpected error during close: ${error instanceof Error ? error.message : String(error)}`,
-        );
-        clearTimeout(closeTimeout);
-        this.forceCleanup();
-        resolve();
-      }
-    });
+    await this.shutdownSocket(socket);
   }
 
   /**
@@ -323,6 +163,276 @@ class RemoteXpcConnection {
         Check if the device is locked.`);
     }
     return service;
+  }
+
+  private createConnectSession(
+    operationTimeoutMs: number,
+    resolve: (response: ServicesResponse) => void,
+    reject: (reason: Error) => void,
+  ): ConnectSession {
+    let settled = false;
+    let partialExtractionTimer: NodeJS.Timeout | undefined;
+
+    const clearAllTimers = (): void => {
+      clearTimeout(operationTimer);
+      clearTimeout(tcpTimer);
+      if (partialExtractionTimer) {
+        clearTimeout(partialExtractionTimer);
+        partialExtractionTimer = undefined;
+      }
+    };
+
+    const settleSuccess = (response: ServicesResponse): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearAllTimers();
+      this._services = response.services;
+      resolve(response);
+    };
+
+    const settleFailure = (error: Error | unknown): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearAllTimers();
+      reject(error instanceof Error ? error : new Error(String(error)));
+    };
+
+    const operationTimer = setTimeout(() => {
+      this._socket?.destroy();
+      settleFailure(
+        new Error(`Connection timed out after ${operationTimeoutMs}ms`),
+      );
+    }, operationTimeoutMs);
+
+    const tcpTimer = setTimeout(() => {
+      this._socket?.destroy();
+      settleFailure(
+        new Error(
+          `Connection timed out after ${CONNECTION_CONNECT_TIMEOUT_MS}ms`,
+        ),
+      );
+    }, CONNECTION_CONNECT_TIMEOUT_MS);
+
+    return {
+      settleSuccess,
+      settleFailure,
+      isSettled: () => settled,
+      clearTcpTimer: () => clearTimeout(tcpTimer),
+      trackPartialExtractionTimer: (timer) => {
+        partialExtractionTimer = timer;
+      },
+    };
+  }
+
+  private createConnectSocket(): net.Socket {
+    return net.connect({
+      host: this._address[0],
+      port: this._address[1],
+      family: 6,
+      noDelay: true,
+      keepAlive: true,
+    });
+  }
+
+  private registerConnectSocketHandlers(
+    session: ConnectSession,
+    socket: net.Socket,
+  ): void {
+    let accumulatedData = Buffer.alloc(0);
+    let partialExtractionTimer: NodeJS.Timeout | undefined;
+
+    const schedulePartialExtractionTimeout = (data: Buffer): void => {
+      if (partialExtractionTimer) {
+        return;
+      }
+
+      partialExtractionTimer = setTimeout(() => {
+        partialExtractionTimer = undefined;
+        log.warn(
+          'Service extraction timeout reached, resolving with current data',
+        );
+        const finalResponse = extractServices(data.toString('utf8'));
+        session.settleSuccess(finalResponse);
+      }, SERVICE_EXTRACTION_TIMEOUT_MS);
+      session.trackPartialExtractionTimer(partialExtractionTimer);
+    };
+
+    socket.once('error', (error: Error) => {
+      if (!this._isClosing) {
+        log.error(`Connection error: ${error}`);
+      }
+      this._isConnected = false;
+      session.settleFailure(error);
+    });
+
+    socket.on('data', (data: Buffer | string) => {
+      if (Buffer.isBuffer(data) || typeof data === 'string') {
+        const chunk = Buffer.isBuffer(data)
+          ? data
+          : Buffer.from(data, 'hex');
+        accumulatedData = Buffer.concat([accumulatedData, chunk]);
+      }
+
+      this.tryResolveServicesFromPayload(
+        session,
+        accumulatedData,
+        schedulePartialExtractionTimeout,
+      );
+    });
+
+    socket.once('close', () => {
+      this._isConnected = false;
+
+      if (!session.isSettled()) {
+        session.settleFailure(
+          new Error('Connection closed before services were extracted'),
+        );
+      }
+    });
+
+    socket.once('connect', () => {
+      session.clearTcpTimer();
+      void this.onConnectSocketReady(session, socket);
+    });
+  }
+
+  private tryResolveServicesFromPayload(
+    session: ConnectSession,
+    accumulatedData: Buffer,
+    schedulePartialExtractionTimeout: (data: Buffer) => void,
+  ): void {
+    const dataStr = accumulatedData.toString('utf8');
+    if (!dataStr.includes('com.apple') || !dataStr.includes('Port')) {
+      return;
+    }
+
+    try {
+      const servicesResponse = extractServices(dataStr);
+      if (servicesResponse.services.length > 0) {
+        session.settleSuccess(servicesResponse);
+        return;
+      }
+
+      schedulePartialExtractionTimeout(accumulatedData);
+    } catch (error) {
+      log.warn(
+        `Error extracting services: ${error}, continuing to collect data`,
+      );
+    }
+  }
+
+  private async onConnectSocketReady(
+    session: ConnectSession,
+    socket: net.Socket,
+  ): Promise<void> {
+    this._isConnected = true;
+
+    try {
+      await this.performHandshake(socket);
+      this.schedulePostHandshakeServiceTimeout(session);
+    } catch (error) {
+      log.error(`Handshake failed: ${error}`);
+      session.settleFailure(error);
+      await this.close();
+    }
+  }
+
+  private async performHandshake(socket: net.Socket): Promise<void> {
+    this._handshake = new Handshake(socket);
+
+    await new Promise<void>((resolve) =>
+      setTimeout(resolve, HANDSHAKE_DELAY_MS),
+    );
+
+    await this._handshake.perform();
+  }
+
+  private schedulePostHandshakeServiceTimeout(session: ConnectSession): void {
+    this.clearServiceExtractionTimer();
+
+    this._serviceExtractionTimer = setTimeout(() => {
+      void this.handlePostHandshakeServiceTimeout(session);
+    }, SERVICE_AFTER_HANDSHAKE_TIMEOUT_MS);
+  }
+
+  private async handlePostHandshakeServiceTimeout(
+    session: ConnectSession,
+  ): Promise<void> {
+    this._serviceExtractionTimer = undefined;
+
+    if (this._services !== undefined || session.isSettled()) {
+      return;
+    }
+
+    log.warn('No services received after handshake, closing connection');
+    try {
+      await this.close();
+    } catch (err) {
+      log.error(`Error closing connection: ${err}`);
+    }
+    session.settleFailure(new Error('No services received after handshake'));
+  }
+
+  private clearServiceExtractionTimer(): void {
+    if (!this._serviceExtractionTimer) {
+      return;
+    }
+
+    clearTimeout(this._serviceExtractionTimer);
+    this._serviceExtractionTimer = undefined;
+  }
+
+  private shutdownSocket(socket: net.Socket): Promise<void> {
+    return new Promise<void>((resolve) => {
+      let finished = false;
+      const finish = (): void => {
+        if (finished) {
+          return;
+        }
+        finished = true;
+        resolve();
+      };
+
+      const closeTimeout = setTimeout(() => {
+        log.warn('Socket close timed out, destroying socket');
+        this.forceCleanup();
+        finish();
+      }, SOCKET_CLOSE_TIMEOUT_MS);
+
+      const onClosed = (): void => {
+        clearTimeout(closeTimeout);
+        this.cleanupResources();
+        finish();
+      };
+
+      socket.once('close', onClosed);
+      socket.on('error', () => {});
+
+      try {
+        this.cleanupSocket();
+        socket.setTimeout(SOCKET_WRITE_TIMEOUT_MS);
+        socket.end(Buffer.alloc(0), () => {
+          setTimeout(() => {
+            if (!finished && this._socket) {
+              clearTimeout(closeTimeout);
+              this.forceCleanup();
+              finish();
+            }
+          }, SOCKET_END_TIMEOUT_MS);
+        });
+      } catch (error) {
+        log.error(
+          `Unexpected error during close: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        clearTimeout(closeTimeout);
+        this.forceCleanup();
+        finish();
+      }
+    });
   }
 
   /**

--- a/src/lib/tunnel/index.ts
+++ b/src/lib/tunnel/index.ts
@@ -91,8 +91,11 @@ class TunnelManagerService {
           return remoteXPC;
         } catch (error) {
           lastError = error;
+          const remainingAfterAttemptMs = Math.ceil(
+            Math.max(0, deadline - performance.now()),
+          );
           log.warn(
-            `RemoteXPC connection attempt failed (${remainingMs}ms left): ${error}`,
+            `RemoteXPC connection attempt failed (${remainingAfterAttemptMs}ms left): ${error}`,
           );
           await sleepIfNeeded(attemptStartedAt, deadline);
         }

--- a/src/lib/tunnel/index.ts
+++ b/src/lib/tunnel/index.ts
@@ -2,15 +2,22 @@ import {
   type TunnelConnection,
   connectToTunnelLockdown,
 } from 'appium-ios-tuntap';
+import { performance } from 'node:perf_hooks';
 import type { TLSSocket } from 'node:tls';
 
 import { getLogger } from '../logger.js';
 import {
-  CONNECTION_MAX_RETRIES,
+  CONNECTION_CONNECT_TIMEOUT_MS,
+  CONNECTION_OVERALL_TIMEOUT_MS,
   RemoteXpcConnection,
 } from '../remote-xpc/remote-xpc-connection.js';
 
 const log = getLogger('TunnelManager');
+
+/** Pause before retry when a connect attempt fails at or below this duration. */
+const FAST_CONNECT_FAILURE_THRESHOLD_MS = CONNECTION_CONNECT_TIMEOUT_MS;
+/** Backoff after a fast failure to avoid hammering an unavailable RSD endpoint. */
+const RECONNECT_BACKOFF_MS = 500;
 
 /**
  * Interface for tunnel registry entry
@@ -64,19 +71,18 @@ class TunnelManagerService {
     rsdPort: number,
   ): Promise<RemoteXpcConnection> {
     try {
-      const remoteXPC: RemoteXpcConnection = new RemoteXpcConnection([
-        address,
-        rsdPort,
-      ]);
+      const deadline = performance.now() + CONNECTION_OVERALL_TIMEOUT_MS;
+      let lastError: unknown;
 
-      // Connect to RemoteXPC with delay between retries
-      let retries = CONNECTION_MAX_RETRIES;
-      let lastError;
+      while (performance.now() < deadline) {
+        const remainingMs = Math.ceil(
+          Math.max(0, deadline - performance.now()),
+        );
+        const remoteXPC = new RemoteXpcConnection([address, rsdPort]);
+        const attemptStartedAt = performance.now();
 
-      while (retries > 0) {
         try {
-          await remoteXPC.connect();
-          // Update the registry entry with the RemoteXPC connection
+          await remoteXPC.connect({ timeoutMs: remainingMs });
           const entry = this.tunnelRegistry.get(address);
           if (entry) {
             entry.remoteXPC = remoteXPC;
@@ -86,18 +92,12 @@ class TunnelManagerService {
         } catch (error) {
           lastError = error;
           log.warn(
-            `RemoteXPC connection attempt failed (${retries} retries left): ${error}`,
+            `RemoteXPC connection attempt failed (${remainingMs}ms left): ${error}`,
           );
-          retries--;
-
-          // Wait before retrying
-          if (retries > 0) {
-            await new Promise((resolve) => setTimeout(resolve, 500));
-          }
+          await sleepIfNeeded(attemptStartedAt, deadline);
         }
       }
 
-      // All retries failed
       throw lastError || new Error('Failed to connect to RemoteXPC');
     } catch (error) {
       log.error(`Error for device ${address}: ${error}`);
@@ -244,6 +244,26 @@ class TunnelManagerService {
   async closeTunnel(): Promise<void> {
     return this.closeAllTunnels();
   }
+}
+
+async function sleepIfNeeded(
+  attemptStartedAt: number,
+  deadline: number,
+): Promise<void> {
+  const attemptMs = performance.now() - attemptStartedAt;
+  if (attemptMs >= FAST_CONNECT_FAILURE_THRESHOLD_MS) {
+    return;
+  }
+
+  const backoffMs = Math.min(
+    RECONNECT_BACKOFF_MS,
+    Math.ceil(Math.max(0, deadline - performance.now())),
+  );
+  if (backoffMs <= 0) {
+    return;
+  }
+
+  await new Promise<void>((resolve) => setTimeout(resolve, backoffMs));
 }
 
 // Create and export the singleton instance


### PR DESCRIPTION
## Summary

Improves RemoteXPC reconnect behavior when the tunnel/RSD endpoint is not ready: failed attempts fail faster, retries stay within a bounded window, and instant failures no longer hammer the endpoint.

### Problem

`TunnelManager.createRemoteXPCConnection` could block for **~50+ seconds** on reconnect (15 retries × 3s timeout + 500ms delay between attempts), even when the socket failed immediately.

### Solution

**Timeouts (`remote-xpc-connection.ts`)**
- **500ms TCP connect timeout** (`CONNECTION_CONNECT_TIMEOUT_MS`) — separate from the per-attempt operation budget
- **Per-attempt operation timeout** via `connect({ timeoutMs })` (default ~10.6s, derived from post-handshake wait + handshake delay + TCP connect)
- **Overall retry deadline** (`CONNECTION_OVERALL_TIMEOUT_MS`) aligned with connect-phase limits so one successful connect is not cut short by a shorter overall cap
- Removed fixed `CONNECTION_MAX_RETRIES` (15)

**Retry loop (`tunnel/index.ts`)**
- Deadline-based retries using `performance.now()` (monotonic, not affected by clock skew)
- Fresh `RemoteXpcConnection` per attempt (avoids stale socket/listener state after failed `connect()`)
- **500ms backoff** after fast failures (attempt &lt; 500ms), capped by remaining overall time — reduces load on an unavailable RSD endpoint without delaying slow failures
- Logs remaining budget (`…ms left`) instead of retry count

**Refactor (`remote-xpc-connection.ts`)**
- Split `connect()` / `close()` into focused helpers (`ConnectSession`, socket handlers, handshake, graceful shutdown)
- `noDelay` / `keepAlive` passed via `net.connect()` options

| Before | After |
|--------|-------|
| Up to ~52s on repeated failures | ~10.6s overall cap |
| 3s per failed attempt | 500ms if TCP never connects |
| 15 fixed retries + 500ms delay always | Retries until deadline; backoff only on fast failures |
