### PR TITLE
fix: Partial XPC services discovery

### DIFF
--- a/src/lib/remote-xpc/http2-frame-parser.ts
+++ b/src/lib/remote-xpc/http2-frame-parser.ts
@@ -1,4 +1,4 @@
-import { WindowUpdateFrame } from './handshake-frames.js';
+import { InvalidDataError, WindowUpdateFrame } from './handshake-frames.js';
 
 const FRAME_HEADER_SIZE = 9;
 const FRAME_TYPE_DATA = 0x00;
@@ -68,14 +68,35 @@ function parseFrame(buffer: Buffer): ParsedFrame {
     return { type: 'other' };
   }
 
-  let data = body;
-  if (flags & FLAG_PADDED) {
-    const padLength = body[0] ?? 0;
-    data = body.subarray(1, body.length - padLength);
-  }
+  const data = stripDataFramePadding(body, flags);
 
   return {
     type: 'data',
     frame: { streamId, data, bodyLen: length },
   };
+}
+
+/**
+ * Strip HTTP/2 DATA frame padding (RFC 7540 §6.1).
+ * @throws {InvalidDataError} when padding length is invalid
+ */
+function stripDataFramePadding(body: Buffer, flags: number): Buffer {
+  if (!(flags & FLAG_PADDED)) {
+    return body;
+  }
+
+  if (body.length === 0) {
+    throw new InvalidDataError(
+      'PROTOCOL_ERROR: PADDED DATA frame has empty payload',
+    );
+  }
+
+  const padLength = body.readUInt8(0);
+  if (padLength >= body.length) {
+    throw new InvalidDataError(
+      'PROTOCOL_ERROR: Padding exceeds frame size',
+    );
+  }
+
+  return body.subarray(1, body.length - padLength);
 }

--- a/src/lib/remote-xpc/http2-frame-parser.ts
+++ b/src/lib/remote-xpc/http2-frame-parser.ts
@@ -1,0 +1,84 @@
+import { WindowUpdateFrame } from './handshake-frames.js';
+
+const FRAME_HEADER_SIZE = 9;
+const FRAME_TYPE_DATA = 0x00;
+const FLAG_PADDED = 0x08;
+
+export interface ParsedDataFrame {
+  readonly streamId: number;
+  readonly data: Buffer;
+  readonly bodyLen: number;
+}
+
+export type ParsedFrame =
+  | { readonly type: 'data'; readonly frame: ParsedDataFrame }
+  | { readonly type: 'other' };
+
+/**
+ * Incrementally parse HTTP/2 frames from a byte stream (RFC 7540).
+ */
+export class Http2FrameParser {
+  private buffer: Buffer = Buffer.alloc(0);
+
+  append(chunk: Buffer): ParsedFrame[] {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+    const frames: ParsedFrame[] = [];
+
+    while (this.buffer.length >= FRAME_HEADER_SIZE) {
+      const length =
+        (this.buffer[0] << 16) |
+        (this.buffer[1] << 8) |
+        this.buffer[2];
+      const totalSize = FRAME_HEADER_SIZE + length;
+      if (this.buffer.length < totalSize) {
+        break;
+      }
+
+      const frameBuffer = this.buffer.subarray(0, totalSize);
+      this.buffer = this.buffer.subarray(totalSize);
+      frames.push(parseFrame(frameBuffer));
+    }
+
+    return frames;
+  }
+}
+
+/**
+ * Emit WINDOW_UPDATE frames for even-numbered streams, matching `remoted` behavior.
+ */
+export function buildWindowUpdateFrames(
+  streamId: number,
+  increment: number,
+): Buffer[] {
+  if (streamId % 2 !== 0 || increment <= 0) {
+    return [];
+  }
+  return [
+    new WindowUpdateFrame(0, increment).serialize(),
+    new WindowUpdateFrame(streamId, increment).serialize(),
+  ];
+}
+
+function parseFrame(buffer: Buffer): ParsedFrame {
+  const length =
+    (buffer[0] << 16) | (buffer[1] << 8) | buffer[2];
+  const type = buffer[3];
+  const flags = buffer[4];
+  const streamId = buffer.readUInt32BE(5) & 0x7fffffff;
+  const body = buffer.subarray(FRAME_HEADER_SIZE, FRAME_HEADER_SIZE + length);
+
+  if (type !== FRAME_TYPE_DATA) {
+    return { type: 'other' };
+  }
+
+  let data = body;
+  if (flags & FLAG_PADDED) {
+    const padLength = body[0] ?? 0;
+    data = body.subarray(1, body.length - padLength);
+  }
+
+  return {
+    type: 'data',
+    frame: { streamId, data, bodyLen: length },
+  };
+}

--- a/src/lib/remote-xpc/http2-frame-parser.ts
+++ b/src/lib/remote-xpc/http2-frame-parser.ts
@@ -26,9 +26,7 @@ export class Http2FrameParser {
 
     while (this.buffer.length >= FRAME_HEADER_SIZE) {
       const length =
-        (this.buffer[0] << 16) |
-        (this.buffer[1] << 8) |
-        this.buffer[2];
+        (this.buffer[0] << 16) | (this.buffer[1] << 8) | this.buffer[2];
       const totalSize = FRAME_HEADER_SIZE + length;
       if (this.buffer.length < totalSize) {
         break;
@@ -60,8 +58,7 @@ export function buildWindowUpdateFrames(
 }
 
 function parseFrame(buffer: Buffer): ParsedFrame {
-  const length =
-    (buffer[0] << 16) | (buffer[1] << 8) | buffer[2];
+  const length = (buffer[0] << 16) | (buffer[1] << 8) | buffer[2];
   const type = buffer[3];
   const flags = buffer[4];
   const streamId = buffer.readUInt32BE(5) & 0x7fffffff;

--- a/src/lib/remote-xpc/http2-frame-parser.ts
+++ b/src/lib/remote-xpc/http2-frame-parser.ts
@@ -93,9 +93,7 @@ function stripDataFramePadding(body: Buffer, flags: number): Buffer {
 
   const padLength = body.readUInt8(0);
   if (padLength >= body.length) {
-    throw new InvalidDataError(
-      'PROTOCOL_ERROR: Padding exceeds frame size',
-    );
+    throw new InvalidDataError('PROTOCOL_ERROR: Padding exceeds frame size');
   }
 
   return body.subarray(1, body.length - padLength);

--- a/src/lib/remote-xpc/remote-xpc-connection.ts
+++ b/src/lib/remote-xpc/remote-xpc-connection.ts
@@ -264,7 +264,14 @@ class RemoteXpcConnection {
       return;
     }
 
-    const frames = frameParser.append(chunk);
+    let frames;
+    try {
+      frames = frameParser.append(chunk);
+    } catch (error) {
+      session.settleFailure(error);
+      return;
+    }
+
     for (const frame of frames) {
       if (frame.type !== 'data') {
         continue;

--- a/src/lib/remote-xpc/remote-xpc-connection.ts
+++ b/src/lib/remote-xpc/remote-xpc-connection.ts
@@ -22,13 +22,12 @@ const HANDSHAKE_DELAY_MS = 100;
 const SERVICE_AFTER_HANDSHAKE_TIMEOUT_MS = 10_000;
 /**
  * Default max time for one connect attempt (TCP + handshake + service discovery).
- * Must cover the longest connect-phase timeout plus earlier phases.
+ * Sum of connect, handshake delay, and post-handshake service wait.
  */
-export const CONNECTION_DEFAULT_OPERATION_TIMEOUT_MS = Math.max(
+export const CONNECTION_DEFAULT_OPERATION_TIMEOUT_MS =
   SERVICE_AFTER_HANDSHAKE_TIMEOUT_MS +
-    HANDSHAKE_DELAY_MS +
-    CONNECTION_CONNECT_TIMEOUT_MS,
-);
+  HANDSHAKE_DELAY_MS +
+  CONNECTION_CONNECT_TIMEOUT_MS;
 /** TunnelManager retry budget; never shorter than a single connect attempt. */
 export const CONNECTION_OVERALL_TIMEOUT_MS =
   CONNECTION_DEFAULT_OPERATION_TIMEOUT_MS;

--- a/src/lib/remote-xpc/remote-xpc-connection.ts
+++ b/src/lib/remote-xpc/remote-xpc-connection.ts
@@ -7,8 +7,8 @@ import {
   buildWindowUpdateFrames,
 } from './http2-frame-parser.js';
 import {
-  ServiceCatalogCollector,
   type Service,
+  ServiceCatalogCollector,
   type ServicesResponse,
 } from './service-catalog.js';
 

--- a/src/lib/remote-xpc/remote-xpc-connection.ts
+++ b/src/lib/remote-xpc/remote-xpc-connection.ts
@@ -2,6 +2,15 @@ import net from 'node:net';
 
 import { getLogger } from '../logger.js';
 import Handshake from './handshake.js';
+import {
+  Http2FrameParser,
+  buildWindowUpdateFrames,
+} from './http2-frame-parser.js';
+import {
+  ServiceCatalogCollector,
+  type Service,
+  type ServicesResponse,
+} from './service-catalog.js';
 
 const log = getLogger('RemoteXpcConnection');
 
@@ -11,14 +20,11 @@ export const CONNECTION_CONNECT_TIMEOUT_MS = 3_000;
 const HANDSHAKE_DELAY_MS = 100;
 /** Wait for service list after handshake before failing the connect attempt. */
 const SERVICE_AFTER_HANDSHAKE_TIMEOUT_MS = 10_000;
-/** Resolve with partial data if service parsing stalls mid-stream. */
-const SERVICE_EXTRACTION_TIMEOUT_MS = 5_000;
 /**
  * Default max time for one connect attempt (TCP + handshake + service discovery).
  * Must cover the longest connect-phase timeout plus earlier phases.
  */
 export const CONNECTION_DEFAULT_OPERATION_TIMEOUT_MS = Math.max(
-  SERVICE_EXTRACTION_TIMEOUT_MS,
   SERVICE_AFTER_HANDSHAKE_TIMEOUT_MS +
     HANDSHAKE_DELAY_MS +
     CONNECTION_CONNECT_TIMEOUT_MS,
@@ -35,21 +41,11 @@ export interface RemoteXpcConnectOptions {
   timeoutMs?: number;
 }
 
-interface Service {
-  serviceName: string;
-  port: string;
-}
-
-interface ServicesResponse {
-  services: Service[];
-}
-
 /** Guards connect() resolve/reject and clears active connect-phase timers. */
 interface ConnectSession {
   settleSuccess(response: ServicesResponse): void;
   settleFailure(error: Error | unknown): void;
   isSettled(): boolean;
-  trackPartialExtractionTimer(timer: NodeJS.Timeout): void;
 }
 
 class RemoteXpcConnection {
@@ -168,14 +164,9 @@ class RemoteXpcConnection {
     reject: (reason: Error) => void,
   ): ConnectSession {
     let settled = false;
-    let partialExtractionTimer: NodeJS.Timeout | undefined;
 
     const clearAllTimers = (): void => {
       clearTimeout(operationTimer);
-      if (partialExtractionTimer) {
-        clearTimeout(partialExtractionTimer);
-        partialExtractionTimer = undefined;
-      }
     };
 
     const settleSuccess = (response: ServicesResponse): void => {
@@ -208,9 +199,6 @@ class RemoteXpcConnection {
       settleSuccess,
       settleFailure,
       isSettled: () => settled,
-      trackPartialExtractionTimer: (timer) => {
-        partialExtractionTimer = timer;
-      },
     };
   }
 
@@ -228,24 +216,8 @@ class RemoteXpcConnection {
     session: ConnectSession,
     socket: net.Socket,
   ): void {
-    let accumulatedData = Buffer.alloc(0);
-    let partialExtractionTimer: NodeJS.Timeout | undefined;
-
-    const schedulePartialExtractionTimeout = (): void => {
-      if (partialExtractionTimer) {
-        return;
-      }
-
-      partialExtractionTimer = setTimeout(() => {
-        partialExtractionTimer = undefined;
-        log.warn(
-          'Service extraction timeout reached, resolving with current data',
-        );
-        const finalResponse = extractServices(accumulatedData.toString('utf8'));
-        session.settleSuccess(finalResponse);
-      }, SERVICE_EXTRACTION_TIMEOUT_MS);
-      session.trackPartialExtractionTimer(partialExtractionTimer);
-    };
+    const frameParser = new Http2FrameParser();
+    const catalogCollector = new ServiceCatalogCollector();
 
     socket.once('error', (error: Error) => {
       if (!this._isClosing) {
@@ -256,15 +228,13 @@ class RemoteXpcConnection {
     });
 
     socket.on('data', (data: Buffer | string) => {
-      if (Buffer.isBuffer(data) || typeof data === 'string') {
-        const chunk = Buffer.isBuffer(data) ? data : Buffer.from(data, 'hex');
-        accumulatedData = Buffer.concat([accumulatedData, chunk]);
-      }
-
-      this.tryResolveServicesFromPayload(
+      const chunk = Buffer.isBuffer(data) ? data : Buffer.from(data, 'hex');
+      this.processIncomingData(
         session,
-        accumulatedData,
-        schedulePartialExtractionTimeout,
+        socket,
+        frameParser,
+        catalogCollector,
+        chunk,
       );
     });
 
@@ -283,28 +253,33 @@ class RemoteXpcConnection {
     });
   }
 
-  private tryResolveServicesFromPayload(
+  private processIncomingData(
     session: ConnectSession,
-    accumulatedData: Buffer,
-    schedulePartialExtractionTimeout: () => void,
+    socket: net.Socket,
+    frameParser: Http2FrameParser,
+    catalogCollector: ServiceCatalogCollector,
+    chunk: Buffer,
   ): void {
-    const dataStr = accumulatedData.toString('utf8');
-    if (!dataStr.includes('com.apple') || !dataStr.includes('Port')) {
+    if (session.isSettled()) {
       return;
     }
 
-    try {
-      const servicesResponse = extractServices(dataStr);
-      if (servicesResponse.services.length > 0) {
+    const frames = frameParser.append(chunk);
+    for (const frame of frames) {
+      if (frame.type !== 'data') {
+        continue;
+      }
+
+      const { streamId, data, bodyLen } = frame.frame;
+      for (const windowUpdate of buildWindowUpdateFrames(streamId, bodyLen)) {
+        socket.write(windowUpdate);
+      }
+
+      const servicesResponse = catalogCollector.ingestDataPayload(data);
+      if (servicesResponse) {
         session.settleSuccess(servicesResponse);
         return;
       }
-
-      schedulePartialExtractionTimeout();
-    } catch (error) {
-      log.warn(
-        `Error extracting services: ${error}, continuing to collect data`,
-      );
     }
   }
 
@@ -470,81 +445,6 @@ class RemoteXpcConnection {
       this.cleanupResources();
     }
   }
-}
-
-/**
- * Extract services from the response
- * @param response The response string to parse
- * @returns Object containing the extracted services
- */
-function extractServices(response: string): ServicesResponse {
-  // More robust regex that handles various formats of service names and port specifications
-  const serviceRegex = /com\.apple(?:\.[\w-]+)+/g;
-  const portRegex = /Port[^0-9]*(\d+)/g;
-
-  interface Match {
-    value: string;
-    index: number;
-  }
-
-  // First, collect all service names
-  const serviceMatches: Match[] = [];
-  let match: RegExpExecArray | null;
-  while ((match = serviceRegex.exec(response)) !== null) {
-    serviceMatches.push({ value: match[0], index: match.index });
-  }
-
-  // Then, collect all port numbers
-  const portMatches: Match[] = [];
-  while ((match = portRegex.exec(response)) !== null) {
-    if (match[1]) {
-      // Ensure we have a captured port number
-      portMatches.push({ value: match[1], index: match.index });
-    }
-  }
-
-  // Sort both arrays by index to maintain order
-  serviceMatches.sort((a, b) => a.index - b.index);
-  portMatches.sort((a, b) => a.index - b.index);
-
-  // Create a mapping of services to ports
-  const services: Service[] = [];
-
-  // Assign a port to each service based on proximity in the response
-  for (let i = 0; i < serviceMatches.length; i++) {
-    const serviceName = serviceMatches[i].value;
-    const serviceIndex = serviceMatches[i].index;
-
-    // Find the closest port after this service
-    let closestPort = '';
-    let closestDistance = Number.MAX_SAFE_INTEGER;
-
-    for (const portMatch of portMatches) {
-      // Only consider ports that come after the service in the response
-      if (portMatch.index > serviceIndex) {
-        const distance = portMatch.index - serviceIndex;
-
-        // If this port is closer than the current closest, update
-        if (distance < closestDistance) {
-          closestDistance = distance;
-          closestPort = portMatch.value;
-
-          // If the port is very close (within 200 chars), we can be confident it's the right one
-          if (distance < 200) {
-            break;
-          }
-        }
-      }
-    }
-
-    // Add the service with its port (or empty string if no port found)
-    services.push({
-      serviceName,
-      port: closestPort || '',
-    });
-  }
-
-  return { services };
 }
 
 export { RemoteXpcConnection, type Service, type ServicesResponse };

--- a/src/lib/remote-xpc/service-catalog.ts
+++ b/src/lib/remote-xpc/service-catalog.ts
@@ -22,21 +22,30 @@ export class ServiceCatalogCollector {
    * message containing `Services` has been decoded.
    */
   ingestDataPayload(chunk: Buffer): ServicesResponse | null {
-    const combined = Buffer.concat([this.previousFrameData, chunk]);
+    let pending = Buffer.concat([this.previousFrameData, chunk]);
+    this.previousFrameData = Buffer.alloc(0);
 
-    try {
-      const message = decodeMessage(combined);
-      this.previousFrameData = Buffer.alloc(0);
+    while (pending.length > 0) {
+      try {
+        const { message, bytesConsumed } = decodeMessage(pending);
+        pending = pending.subarray(bytesConsumed);
 
-      if (message.body === null || message.body === undefined) {
+        if (message.body === null || message.body === undefined) {
+          continue;
+        }
+
+        const catalog = servicesFromXpcBody(message.body);
+        if (catalog) {
+          this.previousFrameData = pending;
+          return catalog;
+        }
+      } catch {
+        this.previousFrameData = pending;
         return null;
       }
-
-      return servicesFromXpcBody(message.body);
-    } catch {
-      this.previousFrameData = combined;
-      return null;
     }
+
+    return null;
   }
 }
 

--- a/src/lib/remote-xpc/service-catalog.ts
+++ b/src/lib/remote-xpc/service-catalog.ts
@@ -1,0 +1,76 @@
+import type { XPCDictionary } from '../types.js';
+import { decodeMessage } from './xpc-protocol.js';
+
+export interface Service {
+  serviceName: string;
+  port: string;
+}
+
+export interface ServicesResponse {
+  services: Service[];
+}
+
+/**
+ * Reassemble length-prefixed XPC payloads from HTTP/2 DATA frames and extract
+ * the service catalog once the full handshake message is available.
+ */
+export class ServiceCatalogCollector {
+  private previousFrameData: Buffer = Buffer.alloc(0);
+
+  /**
+   * Feed one DATA frame payload. Returns the catalog when a complete XPC
+   * message containing `Services` has been decoded.
+   */
+  ingestDataPayload(chunk: Buffer): ServicesResponse | null {
+    const combined = Buffer.concat([this.previousFrameData, chunk]);
+
+    try {
+      const message = decodeMessage(combined);
+      this.previousFrameData = Buffer.alloc(0);
+
+      if (message.body === null || message.body === undefined) {
+        return null;
+      }
+
+      return servicesFromXpcBody(message.body);
+    } catch {
+      this.previousFrameData = combined;
+      return null;
+    }
+  }
+}
+
+/**
+ * Build the service list from a decoded RSD handshake body (`peer_info`).
+ */
+export function servicesFromXpcBody(
+  body: XPCDictionary | null | undefined,
+): ServicesResponse | null {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return null;
+  }
+
+  const servicesDict = body.Services;
+  if (
+    !servicesDict ||
+    typeof servicesDict !== 'object' ||
+    Array.isArray(servicesDict)
+  ) {
+    return null;
+  }
+
+  const services: Service[] = [];
+  for (const [serviceName, info] of Object.entries(servicesDict)) {
+    if (!info || typeof info !== 'object' || Array.isArray(info)) {
+      continue;
+    }
+    const portValue = (info as XPCDictionary).Port;
+    services.push({
+      serviceName,
+      port:
+        portValue !== undefined && portValue !== null ? String(portValue) : '',
+    });
+  }
+
+  return services.length > 0 ? { services } : null;
+}

--- a/src/lib/remote-xpc/xpc-protocol.ts
+++ b/src/lib/remote-xpc/xpc-protocol.ts
@@ -28,6 +28,12 @@ export interface XPCMessage {
   size?: number;
 }
 
+export interface DecodedXpcMessage {
+  message: XPCMessage;
+  /** Bytes consumed from `buffer` (may be less than `buffer.length`). */
+  bytesConsumed: number;
+}
+
 // A simple binary writer that collects Buffer chunks.
 class Writer {
   private chunks: Buffer[] = [];
@@ -171,12 +177,6 @@ export function encodeMessage(message: XPCMessage): Buffer {
   // Write the actual body payload.
   writer.writeBuffer(bodyBuffer);
   return writer.concat();
-}
-
-export interface DecodedXpcMessage {
-  message: XPCMessage;
-  /** Bytes consumed from `buffer` (may be less than `buffer.length`). */
-  bytesConsumed: number;
 }
 
 const XPC_WRAPPER_HEADER_SIZE = 24;

--- a/src/lib/remote-xpc/xpc-protocol.ts
+++ b/src/lib/remote-xpc/xpc-protocol.ts
@@ -367,15 +367,21 @@ function decodeObject(reader: Reader): XPCValue {
       return uuidBuf.toString('hex'); // Return UUID as hex string.
     }
     case XPC_TYPES.array: {
-      const numElements = reader.readUInt32LE();
+      const payloadLen = reader.readUInt32LE();
+      const payload = reader.readBytes(payloadLen);
+      const payloadReader = new Reader(payload);
+      const numElements = payloadReader.readUInt32LE();
       const arr: XPCArray = [];
       for (let i = 0; i < numElements; i++) {
-        arr.push(decodeObject(reader));
+        arr.push(decodeObject(payloadReader));
       }
       return arr;
     }
-    case XPC_TYPES.dictionary:
-      return decodeDictionary(reader);
+    case XPC_TYPES.dictionary: {
+      const payloadLen = reader.readUInt32LE();
+      const payload = reader.readBytes(payloadLen);
+      return decodeDictionary(new Reader(payload));
+    }
     // Note: fileTransfer type is not implemented here.
     default:
       throw new TypeError(`Unsupported xpc type: 0x${type.toString(16)}`);

--- a/src/lib/remote-xpc/xpc-protocol.ts
+++ b/src/lib/remote-xpc/xpc-protocol.ts
@@ -126,6 +126,10 @@ class Reader {
   skip(n: number): void {
     this.offset += n;
   }
+
+  getOffset(): number {
+    return this.offset;
+  }
 }
 
 /**
@@ -169,11 +173,40 @@ export function encodeMessage(message: XPCMessage): Buffer {
   return writer.concat();
 }
 
+export interface DecodedXpcMessage {
+  message: XPCMessage;
+  /** Bytes consumed from `buffer` (may be less than `buffer.length`). */
+  bytesConsumed: number;
+}
+
+const XPC_WRAPPER_HEADER_SIZE = 24;
+
+/**
+ * Returns the total byte length of one length-prefixed XPC wrapper in `buffer`.
+ * @throws if the header is missing, invalid, or the buffer is shorter than the message
+ */
+export function getXpcMessageByteLength(buffer: Buffer): number {
+  if (buffer.length < XPC_WRAPPER_HEADER_SIZE) {
+    throw new Error('Incomplete XPC wrapper');
+  }
+  const magic = buffer.readUInt32LE(0);
+  if (magic !== WRAPPER_MAGIC) {
+    throw new Error(`Invalid wrapper magic: 0x${magic.toString(16)}`);
+  }
+  const bodyLen = Number(buffer.readBigUInt64LE(8));
+  const total = XPC_WRAPPER_HEADER_SIZE + bodyLen;
+  if (buffer.length < total) {
+    throw new Error('Incomplete XPC wrapper');
+  }
+  return total;
+}
+
 /**
  * Decodes an XPC Buffer into a message object.
  * (Keep this function if you plan to handle incoming messages.)
  */
-export function decodeMessage(buffer: Buffer): XPCMessage {
+export function decodeMessage(buffer: Buffer): DecodedXpcMessage {
+  const bytesConsumed = getXpcMessageByteLength(buffer);
   const reader = new Reader(buffer);
   const magic = reader.readUInt32LE();
   if (magic !== WRAPPER_MAGIC) {
@@ -183,7 +216,10 @@ export function decodeMessage(buffer: Buffer): XPCMessage {
   const bodyLen = reader.readBigUInt64LE();
   const msgId = reader.readBigUInt64LE();
   if (bodyLen === BigInt(0)) {
-    return { flags, id: msgId, body: null };
+    return {
+      message: { flags, id: msgId, body: null },
+      bytesConsumed,
+    };
   }
   // Read body header.
   const objMagic = reader.readUInt32LE();
@@ -208,7 +244,10 @@ export function decodeMessage(buffer: Buffer): XPCMessage {
     throw new TypeError('Expected dictionary as message body');
   }
 
-  return { flags, id: msgId, body: decodedValue as XPCDictionary };
+  return {
+    message: { flags, id: msgId, body: decodedValue as XPCDictionary },
+    bytesConsumed,
+  };
 }
 
 /**

--- a/test/unit/remote-xpc/service-catalog.spec.ts
+++ b/test/unit/remote-xpc/service-catalog.spec.ts
@@ -70,6 +70,51 @@ describe('RSD service catalog discovery', function () {
         .null;
     });
 
+    it('parses multiple back-to-back XPC messages in one chunk', function () {
+      const prelude = encodeMessage({
+        flags: 0x0201,
+        id: BigInt(0),
+        body: null,
+      });
+      const catalog = buildCatalogXpcPayload(3);
+      const collector = new ServiceCatalogCollector();
+
+      const result = collector.ingestDataPayload(
+        Buffer.concat([prelude, catalog]),
+      );
+
+      expect(result).not.to.be.null;
+      expect(
+        result!.services.some(
+          (s) =>
+            s.serviceName ===
+            'com.apple.mobile.diagnostics_relay.shim.remote',
+        ),
+      ).to.be.true;
+    });
+
+    it('preserves trailing bytes after a decoded non-catalog message', function () {
+      const prelude = encodeMessage({
+        flags: 0x0201,
+        id: BigInt(0),
+        body: { MessageType: 'Handshake' },
+      });
+      const catalog = buildCatalogXpcPayload(2);
+      const collector = new ServiceCatalogCollector();
+
+      expect(
+        collector.ingestDataPayload(prelude.subarray(0, prelude.length - 4)),
+      ).to.be.null;
+      expect(
+        collector.ingestDataPayload(
+          Buffer.concat([
+            prelude.subarray(prelude.length - 4),
+            catalog,
+          ]),
+        ),
+      ).to.not.be.null;
+    });
+
     it('returns the complete catalog across many TCP-sized chunks', function () {
       const payload = buildCatalogXpcPayload(50);
       const collector = new ServiceCatalogCollector();

--- a/test/unit/remote-xpc/service-catalog.spec.ts
+++ b/test/unit/remote-xpc/service-catalog.spec.ts
@@ -48,8 +48,7 @@ describe('RSD service catalog discovery', function () {
       expect(
         result!.services.find(
           (s) =>
-            s.serviceName ===
-            'com.apple.mobile.diagnostics_relay.shim.remote',
+            s.serviceName === 'com.apple.mobile.diagnostics_relay.shim.remote',
         )?.port,
       ).to.equal('52299');
     });
@@ -67,9 +66,8 @@ describe('RSD service catalog discovery', function () {
 
       expect(collector.ingestDataPayload(payload.subarray(0, splitAt))).to.be
         .null;
-      expect(
-        collector.ingestDataPayload(payload.subarray(splitAt)),
-      ).to.not.be.null;
+      expect(collector.ingestDataPayload(payload.subarray(splitAt))).to.not.be
+        .null;
     });
 
     it('returns the complete catalog across many TCP-sized chunks', function () {
@@ -91,8 +89,7 @@ describe('RSD service catalog discovery', function () {
       expect(
         result!.services.some(
           (s) =>
-            s.serviceName ===
-            'com.apple.mobile.diagnostics_relay.shim.remote',
+            s.serviceName === 'com.apple.mobile.diagnostics_relay.shim.remote',
         ),
       ).to.be.true;
     });

--- a/test/unit/remote-xpc/service-catalog.spec.ts
+++ b/test/unit/remote-xpc/service-catalog.spec.ts
@@ -141,6 +141,21 @@ describe('RSD service catalog discovery', function () {
   });
 
   describe('Http2FrameParser', function () {
+    it('rejects DATA frames whose padding exceeds the payload', function () {
+      const parser = new Http2FrameParser();
+      // PADDED flag (0x08), 1-byte body: pad length 0 with no room for data
+      const header = Buffer.alloc(9);
+      header[2] = 1; // length = 1
+      header[3] = 0x00; // DATA
+      header[4] = 0x08; // PADDED
+      header.writeUInt32BE(1, 5); // stream 1
+      const body = Buffer.from([5]); // pad length 5 >= body length 1
+
+      expect(() => parser.append(Buffer.concat([header, body]))).to.throw(
+        /PROTOCOL_ERROR: Padding exceeds frame size/,
+      );
+    });
+
     it('reassembles a DATA frame split across multiple socket reads', function () {
       const xpcPayload = buildCatalogXpcPayload(5);
       const dataFrame = new DataFrame(1, xpcPayload, []).serialize();

--- a/test/unit/remote-xpc/service-catalog.spec.ts
+++ b/test/unit/remote-xpc/service-catalog.spec.ts
@@ -87,8 +87,7 @@ describe('RSD service catalog discovery', function () {
       expect(
         result!.services.some(
           (s) =>
-            s.serviceName ===
-            'com.apple.mobile.diagnostics_relay.shim.remote',
+            s.serviceName === 'com.apple.mobile.diagnostics_relay.shim.remote',
         ),
       ).to.be.true;
     });
@@ -107,10 +106,7 @@ describe('RSD service catalog discovery', function () {
       ).to.be.null;
       expect(
         collector.ingestDataPayload(
-          Buffer.concat([
-            prelude.subarray(prelude.length - 4),
-            catalog,
-          ]),
+          Buffer.concat([prelude.subarray(prelude.length - 4), catalog]),
         ),
       ).to.not.be.null;
     });

--- a/test/unit/remote-xpc/service-catalog.spec.ts
+++ b/test/unit/remote-xpc/service-catalog.spec.ts
@@ -1,0 +1,130 @@
+import { expect } from 'chai';
+
+import { DataFrame } from '../../../src/lib/remote-xpc/handshake-frames.js';
+import {
+  Http2FrameParser,
+  buildWindowUpdateFrames,
+} from '../../../src/lib/remote-xpc/http2-frame-parser.js';
+import {
+  ServiceCatalogCollector,
+  servicesFromXpcBody,
+} from '../../../src/lib/remote-xpc/service-catalog.js';
+import { encodeMessage } from '../../../src/lib/remote-xpc/xpc-protocol.js';
+
+function buildCatalogXpcPayload(serviceCount: number): Buffer {
+  const services: Record<string, { Port: string }> = {};
+  for (let i = 0; i < serviceCount; i++) {
+    services[`com.apple.example.service_${i}`] = { Port: String(52000 + i) };
+  }
+  services['com.apple.mobile.diagnostics_relay.shim.remote'] = {
+    Port: '59999',
+  };
+
+  return encodeMessage({
+    flags: 0x00000001,
+    id: BigInt(0),
+    body: {
+      MessageType: 'Handshake',
+      Services: services,
+    },
+  });
+}
+
+describe('RSD service catalog discovery', function () {
+  describe('servicesFromXpcBody', function () {
+    it('extracts all services including late-alphabet names', function () {
+      const body = {
+        Services: {
+          'com.apple.afc.shim.remote': { Port: '52280' },
+          'com.apple.mobile.diagnostics_relay.shim.remote': {
+            Port: '52299',
+          },
+        },
+      };
+
+      const result = servicesFromXpcBody(body);
+      expect(result).not.to.be.null;
+      expect(result!.services).to.have.lengthOf(2);
+      expect(
+        result!.services.find(
+          (s) =>
+            s.serviceName ===
+            'com.apple.mobile.diagnostics_relay.shim.remote',
+        )?.port,
+      ).to.equal('52299');
+    });
+
+    it('returns null when Services is missing', function () {
+      expect(servicesFromXpcBody({ MessageType: 'Handshake' })).to.be.null;
+    });
+  });
+
+  describe('ServiceCatalogCollector', function () {
+    it('does not settle until the full XPC message arrives', function () {
+      const payload = buildCatalogXpcPayload(45);
+      const splitAt = Math.floor(payload.length / 3);
+      const collector = new ServiceCatalogCollector();
+
+      expect(collector.ingestDataPayload(payload.subarray(0, splitAt))).to.be
+        .null;
+      expect(
+        collector.ingestDataPayload(payload.subarray(splitAt)),
+      ).to.not.be.null;
+    });
+
+    it('returns the complete catalog across many TCP-sized chunks', function () {
+      const payload = buildCatalogXpcPayload(50);
+      const collector = new ServiceCatalogCollector();
+      const chunkSize = 512;
+      let result = null;
+
+      for (let offset = 0; offset < payload.length; offset += chunkSize) {
+        const chunk = payload.subarray(
+          offset,
+          Math.min(offset + chunkSize, payload.length),
+        );
+        result = collector.ingestDataPayload(chunk) ?? result;
+      }
+
+      expect(result).not.to.be.null;
+      expect(result!.services.length).to.be.at.least(50);
+      expect(
+        result!.services.some(
+          (s) =>
+            s.serviceName ===
+            'com.apple.mobile.diagnostics_relay.shim.remote',
+        ),
+      ).to.be.true;
+    });
+  });
+
+  describe('Http2FrameParser', function () {
+    it('reassembles a DATA frame split across multiple socket reads', function () {
+      const xpcPayload = buildCatalogXpcPayload(5);
+      const dataFrame = new DataFrame(1, xpcPayload, []).serialize();
+      const parser = new Http2FrameParser();
+
+      const mid = Math.floor(dataFrame.length / 2);
+      const first = parser.append(dataFrame.subarray(0, mid));
+      const second = parser.append(dataFrame.subarray(mid));
+
+      expect(first).to.have.lengthOf(0);
+      expect(second).to.have.lengthOf(1);
+      expect(second[0].type).to.equal('data');
+      expect(second[0].type === 'data' && second[0].frame.data.length).to.equal(
+        xpcPayload.length,
+      );
+    });
+  });
+
+  describe('buildWindowUpdateFrames', function () {
+    it('emits window updates for even-numbered streams', function () {
+      const frames = buildWindowUpdateFrames(2, 1024);
+      expect(frames).to.have.lengthOf(2);
+    });
+
+    it('skips window updates for odd-numbered streams', function () {
+      expect(buildWindowUpdateFrames(1, 1024)).to.have.lengthOf(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes [#215](https://github.com/appium/appium-ios-remotexpc/issues/215): RSD service discovery could settle on a **partial** service catalog, causing intermittent `Service <name> not found` errors (e.g. `com.apple.mobile.diagnostics_relay.shim.remote`) even when the device exposes the service.

**Root cause:** After the HTTP/2 handshake, `RemoteXpcConnection` scraped raw socket bytes with a regex and resolved as soon as any `com.apple.*` names appeared. The catalog arrives as one large XPC message split across multiple TCP segments, so the first chunk often contained only early services (`afc`, `installation_proxy`, `springboard`, …) while later entries were never included.

**Approach (aligned with [pymobiledevice3 `RemoteXPCConnection`](https://github.com/doronz88/pymobiledevice3/blob/master/pymobiledevice3/remote/remotexpc.py)):**

- Parse incoming **HTTP/2 DATA frames** incrementally (`http2-frame-parser.ts`) instead of treating the socket as UTF-8 text.
- **Reassemble** partial XPC payloads before decode (`ServiceCatalogCollector`), matching pymobiledevice3’s `_previous_frame_data` pattern.
- Extract services from the decoded `Services` dictionary (`servicesFromXpcBody`) instead of regex matching.
- Send **WINDOW_UPDATE** on even streams when receiving data so the device can finish sending the catalog.
- Fix **XPC dictionary/array decode** to read length-prefixed payloads (required for real handshake messages).

Removes the “settle on first non-empty scrape” behavior and the partial-extraction timeout fallback.

## Test plan

- [x] `npm run test:unit -- --grep "RSD service catalog"` — partial XPC, multi-chunk catalog, split HTTP/2 frame
- [x] `npm run test:unit` — full unit suite (410 tests)
- [x] `npm run build` && `npm run lint`
- [ ] Manual: connect to a device/tunnel and log `remoteXPC.getServices().length` — expect full catalog (40+ services), including `com.apple.mobile.diagnostics_relay.shim.remote`
- [ ] Manual: `npm run test:diagnostics` (or other previously flaky RSD service tests) on the same device/tunnel