### PR TITLE
fix: AFC connection desync

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ export type {
 } from './lib/port-forwarding/index.js';
 export type { RemoteXpcConnection } from './lib/remote-xpc/remote-xpc-connection.js';
 export type { AfcService } from './services/ios/afc/index.js';
+export { AfcConnectionError } from './services/ios/afc/errors.js';
 export type { InstallationProxyService } from './services/ios/installation-proxy/index.js';
 export type {
   SyslogEntry,

--- a/src/services/ios/afc/codec.ts
+++ b/src/services/ios/afc/codec.ts
@@ -8,6 +8,7 @@ import {
   AFC_OPERATION_TIMEOUT_MS,
   NULL_BYTE,
 } from './constants.js';
+import { AfcConnectionError } from './errors.js';
 import { AfcError, AfcFopenMode, AfcOpcode } from './enums.js';
 
 export interface AfcHeader {
@@ -94,15 +95,30 @@ export function encodeHeader(
 }
 
 const SOCKET_STATES = new WeakMap<net.Socket, SocketState>();
+const FATAL_SOCKETS = new WeakSet<net.Socket>();
+
+/**
+ * Tear down buffered-reader state and destroy the socket after a fatal read error.
+ * Late-arriving bytes must not be left for a subsequent readExact on the same socket.
+ */
+export function fatalizeAfcSocket(socket: net.Socket, error: Error): void {
+  FATAL_SOCKETS.add(socket);
+  cleanupSocketState(socket, error);
+  if (!socket.destroyed) {
+    socket.destroy();
+  }
+}
 
 /**
  * Read exactly `n` bytes from a socket, waiting up to timeoutMs.
+ * On timeout the socket is destroyed; further reads throw AfcConnectionError.
  */
 export async function readExact(
   socket: net.Socket,
   n: number,
   timeoutMs = 30000,
 ): Promise<Buffer> {
+  assertSocketReadable(socket);
   const state = ensureSocketState(socket);
 
   if (state.buffer.length >= n) {
@@ -118,7 +134,11 @@ export async function readExact(
       const idx = state.waiters.indexOf(waiter);
       if (idx >= 0) {
         state.waiters.splice(idx, 1);
-        reject(new Error(`readExact timeout after ${timeoutMs}ms`));
+        const err = new AfcConnectionError(
+          `readExact timeout after ${timeoutMs}ms`,
+        );
+        fatalizeAfcSocket(socket, err);
+        reject(err);
       }
     }, timeoutMs);
   });
@@ -134,7 +154,11 @@ export async function readAfcHeader(
   const buf = await readExact(socket, AFC_HEADER_SIZE, timeoutMs);
   const magic = buf.subarray(0, 8);
   if (!magic.equals(AFCMAGIC)) {
-    throw new Error(`Invalid AFC magic: ${magic.toString('hex')}`);
+    const err = new AfcConnectionError(
+      `Invalid AFC magic: ${magic.toString('hex')}`,
+    );
+    fatalizeAfcSocket(socket, err);
+    throw err;
   }
   const entireLength = readUInt64LE(buf, 8);
   const thisLength = readUInt64LE(buf, 16);
@@ -411,6 +435,17 @@ export function cleanupServiceSocket(socket: net.Socket, error?: Error): void {
   cleanupSocketState(socket, error);
 }
 
+function assertSocketReadable(socket: net.Socket): void {
+  if (FATAL_SOCKETS.has(socket)) {
+    throw new AfcConnectionError(
+      'AFC connection is closed (prior read timeout or fatal I/O error)',
+    );
+  }
+  if (socket.destroyed) {
+    throw new AfcConnectionError('AFC socket is destroyed');
+  }
+}
+
 function cleanupSocketState(socket: net.Socket, error?: Error): void {
   const state = SOCKET_STATES.get(socket);
   if (!state) {
@@ -444,6 +479,7 @@ function cleanupSocketState(socket: net.Socket, error?: Error): void {
  * Ensure per-socket buffered reader state and listeners are initialized.
  */
 function ensureSocketState(socket: net.Socket): SocketState {
+  assertSocketReadable(socket);
   let state = SOCKET_STATES.get(socket);
   if (state) {
     return state;

--- a/src/services/ios/afc/codec.ts
+++ b/src/services/ios/afc/codec.ts
@@ -118,7 +118,6 @@ export async function readExact(
   n: number,
   timeoutMs = 30000,
 ): Promise<Buffer> {
-  assertSocketReadable(socket);
   const state = ensureSocketState(socket);
 
   if (state.buffer.length >= n) {

--- a/src/services/ios/afc/codec.ts
+++ b/src/services/ios/afc/codec.ts
@@ -8,8 +8,8 @@ import {
   AFC_OPERATION_TIMEOUT_MS,
   NULL_BYTE,
 } from './constants.js';
-import { AfcConnectionError } from './errors.js';
 import { AfcError, AfcFopenMode, AfcOpcode } from './enums.js';
+import { AfcConnectionError } from './errors.js';
 
 export interface AfcHeader {
   magic: Buffer;

--- a/src/services/ios/afc/errors.ts
+++ b/src/services/ios/afc/errors.ts
@@ -1,0 +1,9 @@
+/**
+ * Raised when an AFC socket is no longer usable (timeout, desync, or close).
+ */
+export class AfcConnectionError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'AfcConnectionError';
+  }
+}

--- a/src/services/ios/afc/index.ts
+++ b/src/services/ios/afc/index.ts
@@ -30,8 +30,8 @@ import {
   AFC_LOCK_UN,
   AFC_WRITE_THIS_LENGTH,
 } from './constants.js';
-import { AfcConnectionError } from './errors.js';
 import { AfcError, AfcFileMode, AfcOpcode } from './enums.js';
+import { AfcConnectionError } from './errors.js';
 import { createAfcReadStream, createAfcWriteStream } from './stream-utils.js';
 
 const log = getLogger('AfcService');

--- a/src/services/ios/afc/index.ts
+++ b/src/services/ios/afc/index.ts
@@ -16,6 +16,7 @@ import {
   buildStatPayload,
   cleanupServiceSocket,
   createRawServiceSocket,
+  fatalizeAfcSocket,
   nanosecondsToMilliseconds,
   parseCStringArray,
   parseKeyValueNullList,
@@ -29,6 +30,7 @@ import {
   AFC_LOCK_UN,
   AFC_WRITE_THIS_LENGTH,
 } from './constants.js';
+import { AfcConnectionError } from './errors.js';
 import { AfcError, AfcFileMode, AfcOpcode } from './enums.js';
 import { createAfcReadStream, createAfcWriteStream } from './stream-utils.js';
 
@@ -94,6 +96,8 @@ export class AfcService {
   private socket: net.Socket | null = null;
   private packetNum: bigint = 0n;
   private silent: boolean = false;
+  /** Set when the AFC byte stream is no longer safe to reuse on this instance. */
+  private connectionError: Error | null = null;
 
   constructor(
     private readonly address: [string, number],
@@ -563,6 +567,7 @@ export class AfcService {
     log.debug('Closing AFC service connection');
     const socket = this.socket;
     this.socket = null;
+    this.connectionError = null;
     if (!socket || socket.destroyed) {
       return;
     }
@@ -730,7 +735,43 @@ export class AfcService {
    * Connect to RSD port and perform RSDCheckin.
    * Keeps the underlying socket for raw AFC I/O.
    */
+  private _assertConnectionAlive(): void {
+    if (this.connectionError) {
+      throw this.connectionError;
+    }
+  }
+
+  private _markConnectionDead(error: Error): void {
+    if (this.connectionError) {
+      return;
+    }
+    this.connectionError =
+      error instanceof AfcConnectionError
+        ? error
+        : new AfcConnectionError(error.message, { cause: error });
+    const sock = this.socket;
+    this.socket = null;
+    if (sock && !sock.destroyed) {
+      fatalizeAfcSocket(sock, this.connectionError);
+    } else if (sock) {
+      cleanupServiceSocket(sock, this.connectionError);
+    }
+  }
+
+  private async _withAfcConnection<T>(fn: () => Promise<T>): Promise<T> {
+    this._assertConnectionAlive();
+    try {
+      return await fn();
+    } catch (err) {
+      if (err instanceof AfcConnectionError) {
+        this._markConnectionDead(err);
+      }
+      throw err;
+    }
+  }
+
   private async _connect(): Promise<net.Socket> {
+    this._assertConnectionAlive();
     if (this.socket && !this.socket.destroyed) {
       return this.socket;
     }
@@ -779,14 +820,18 @@ export class AfcService {
     payload: Buffer = Buffer.alloc(0),
     thisLenOverride?: number,
   ): Promise<void> {
-    const sock = await this._connect();
-    await sendAfcPacket(sock, op, this.packetNum++, payload, thisLenOverride);
+    return await this._withAfcConnection(async () => {
+      const sock = await this._connect();
+      await sendAfcPacket(sock, op, this.packetNum++, payload, thisLenOverride);
+    });
   }
 
   private async _receive(): Promise<{ status: AfcError; data: Buffer }> {
-    const sock = await this._connect();
-    const res = await readAfcResponse(sock);
-    return { status: res.status, data: res.data };
+    return await this._withAfcConnection(async () => {
+      const sock = await this._connect();
+      const res = await readAfcResponse(sock);
+      return { status: res.status, data: res.data };
+    });
   }
 
   /**

--- a/test/unit/afc/codec-read-timeout.spec.ts
+++ b/test/unit/afc/codec-read-timeout.spec.ts
@@ -1,0 +1,68 @@
+import { expect } from 'chai';
+import { once } from 'node:events';
+import { type AddressInfo, createConnection, createServer } from 'node:net';
+
+import { readExact } from '../../../src/services/ios/afc/codec.js';
+import { AfcConnectionError } from '../../../src/services/ios/afc/errors.js';
+
+describe('AFC readExact timeout handling', function () {
+  let server: ReturnType<typeof createServer>;
+  let port: number;
+
+  before(async function () {
+    server = createServer();
+    await new Promise<void>((resolve, reject) => {
+      server.listen(0, '127.0.0.1', resolve);
+      server.once('error', reject);
+    });
+    port = (server.address() as AddressInfo).port;
+  });
+
+  after(async function () {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it('should destroy the socket and reject subsequent reads after timeout', async function () {
+    const client = createConnection({ host: '127.0.0.1', port });
+    await once(client, 'connect');
+
+    try {
+      await readExact(client, 40, 50);
+      expect.fail('expected readExact to time out');
+    } catch (err) {
+      expect(err).to.be.instanceof(AfcConnectionError);
+      expect((err as Error).message).to.include('readExact timeout');
+    }
+
+    expect(client.destroyed).to.be.true;
+
+    try {
+      await readExact(client, 40);
+      expect.fail('expected second readExact to fail');
+    } catch (err) {
+      expect(err).to.be.instanceof(AfcConnectionError);
+      expect((err as Error).message).to.match(/closed|destroyed/i);
+    }
+  });
+
+  it('should not leave stale bytes for the next read after a late response', async function () {
+    const client = createConnection({ host: '127.0.0.1', port });
+    await once(client, 'connect');
+
+    const readPromise = readExact(client, 40, 50).catch((err) => err);
+
+    await new Promise((r) => setTimeout(r, 60));
+    client.write(Buffer.alloc(40, 0xab));
+
+    const firstErr = await readPromise;
+    expect(firstErr).to.be.instanceof(AfcConnectionError);
+    expect(client.destroyed).to.be.true;
+
+    try {
+      await readExact(client, 40);
+      expect.fail('expected reuse after timeout to fail');
+    } catch (err) {
+      expect(err).to.be.instanceof(AfcConnectionError);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes [#216](https://github.com/appium/appium-ios-remotexpc/issues/216).

AFC uses a sequential byte stream with no request/response correlation. When `readExact` timed out, it removed the waiter but kept appending late response bytes to the shared buffer. The next operation then read misaligned data and failed with `Invalid AFC magic`, permanently poisoning the connection.

This change makes abandoned or timed-out reads fatal for the connection:

- **`readExact` timeout** — tears down buffered-reader state, destroys the socket, and rejects with `AfcConnectionError`.
- **Invalid AFC magic** — treated as stream desync; same fatal teardown.
- **`AfcService`** — records a terminal error on `AfcConnectionError` so later operations on the same instance fail immediately instead of silently reusing a desynced socket.
- **`AfcConnectionError`** — exported for callers that need to detect a dead connection and create a new `AfcService`.

## Test plan

- [x] `NODE_ENV=test npx mocha 'test/unit/afc/**/*.ts'`
  - New: timeout destroys socket; late bytes cannot poison the next read
  - Existing codec utility tests still pass
- [ ] `npm run lint`
- [ ] `npm run test:afc` (integration, requires device/tunnel)