### PR TITLE
fix: Respect local file system limitations while pulling remote files

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   },
   "dependencies": {
     "@appium/strongbox": "^1.0.0-rc.1",
-    "@appium/support": "^7.0.0-rc.1",
+    "@appium/support": "^7.2.2",
     "@xmldom/xmldom": "^0.x",
     "appium-ios-tuntap": "^0.x",
     "async-lock": "^1.4.1",

--- a/src/services/ios/afc/index.ts
+++ b/src/services/ios/afc/index.ts
@@ -397,10 +397,15 @@ export class AfcService {
     const pullSingleFile = async (
       remoteFilePath: string,
       localFilePath: string,
+      nameAllocated = false,
     ): Promise<void> => {
       log.debug(`Pulling file from '${remoteFilePath}' to '${localFilePath}'`);
 
-      if (!overwrite && (await this._localPathExists(localFilePath))) {
+      if (
+        !nameAllocated &&
+        !overwrite &&
+        (await this._localPathExists(localFilePath))
+      ) {
         throw new Error(`Local file already exists: ${localFilePath}`);
       }
 
@@ -428,7 +433,7 @@ export class AfcService {
           )
         : localDst;
 
-      await pullSingleFile(remoteSrc, targetPath);
+      await pullSingleFile(remoteSrc, targetPath, localDstIsDirectory);
       return;
     }
 
@@ -716,10 +721,6 @@ export class AfcService {
         await ensureLocalDir();
 
         const targetPath = path.join(localDirPath, localEntryName);
-        if (!overwrite && (await this._localPathExists(targetPath))) {
-          throw new Error(`Local file already exists: ${targetPath}`);
-        }
-
         await this._pullFile(entryPath, targetPath);
 
         if (onPullProgress) {

--- a/src/services/ios/afc/index.ts
+++ b/src/services/ios/afc/index.ts
@@ -32,6 +32,7 @@ import {
 } from './constants.js';
 import { AfcError, AfcFileMode, AfcOpcode } from './enums.js';
 import { AfcConnectionError } from './errors.js';
+import { PullLocalNameAllocator } from './pull-local-name-allocator.js';
 import { createAfcReadStream, createAfcWriteStream } from './stream-utils.js';
 
 const log = getLogger('AfcService');
@@ -388,6 +389,10 @@ export class AfcService {
       throw new Error(`Remote path does not exist: ${remoteSrc}`);
     }
 
+    const localNames = new PullLocalNameAllocator((localPath) =>
+      this._localPathExists(localPath),
+    );
+
     const pullSingleFile = async (
       remoteFilePath: string,
       localFilePath: string,
@@ -408,15 +413,18 @@ export class AfcService {
     const isDir = await this.isdir(remoteSrc);
 
     if (!isDir) {
-      const baseName = path.posix.basename(remoteSrc);
+      const remoteBaseName = path.posix.basename(remoteSrc);
 
-      if (match && !minimatch(baseName, match)) {
+      if (match && !minimatch(remoteBaseName, match)) {
         return;
       }
 
       const localDstIsDirectory = await this._isLocalDirectory(localDst);
       const targetPath = localDstIsDirectory
-        ? path.join(localDst, baseName)
+        ? path.join(
+            localDst,
+            await localNames.allocate(localDst, remoteBaseName),
+          )
         : localDst;
 
       await pullSingleFile(remoteSrc, targetPath);
@@ -435,6 +443,7 @@ export class AfcService {
       match,
       overwrite,
       callback: onPullProgress,
+      localNames,
     });
   }
 
@@ -618,10 +627,21 @@ export class AfcService {
   private async _pullRecursiveInternal(
     remoteSrcDir: string,
     localDstDir: string,
-    options?: Omit<PullOptions, 'recursive'>,
+    options?: Omit<PullOptions, 'recursive'> & {
+      localNames: PullLocalNameAllocator;
+    },
     relativePath = '',
   ): Promise<void> {
-    const { match, overwrite = true, callback: onPullProgress } = options ?? {};
+    const {
+      match,
+      overwrite = true,
+      callback: onPullProgress,
+      localNames,
+    } = options ?? {};
+
+    if (!localNames) {
+      throw new Error('PullLocalNameAllocator is required for recursive pull');
+    }
 
     let localDirPath: string;
     if (!relativePath) {
@@ -643,9 +663,12 @@ export class AfcService {
         }
       }
 
-      const baseName = path.posix.basename(remoteSrcDir);
+      const remoteBaseName = path.posix.basename(remoteSrcDir);
       localDirPath = localDstIsDirectory
-        ? path.join(localDstDir, baseName)
+        ? path.join(
+            localDstDir,
+            await localNames.allocate(localDstDir, remoteBaseName),
+          )
         : localDstDir;
     } else {
       localDirPath = localDstDir;
@@ -675,11 +698,12 @@ export class AfcService {
       const entryRelativePath = relativePath
         ? path.posix.join(relativePath, entry)
         : entry;
+      const localEntryName = await localNames.allocate(localDirPath, entry);
 
       if (await this.isdir(entryPath)) {
         await this._pullRecursiveInternal(
           entryPath,
-          path.join(localDirPath, entry),
+          path.join(localDirPath, localEntryName),
           options,
           entryRelativePath,
         );
@@ -690,7 +714,7 @@ export class AfcService {
 
         await ensureLocalDir();
 
-        const targetPath = path.join(localDirPath, entry);
+        const targetPath = path.join(localDirPath, localEntryName);
         if (!overwrite && (await this._localPathExists(targetPath))) {
           throw new Error(`Local file already exists: ${targetPath}`);
         }

--- a/src/services/ios/afc/index.ts
+++ b/src/services/ios/afc/index.ts
@@ -389,8 +389,9 @@ export class AfcService {
       throw new Error(`Remote path does not exist: ${remoteSrc}`);
     }
 
-    const localNames = new PullLocalNameAllocator((localPath) =>
-      this._localPathExists(localPath),
+    const localNames = new PullLocalNameAllocator(
+      (localPath) => this._localPathExists(localPath),
+      overwrite,
     );
 
     const pullSingleFile = async (

--- a/src/services/ios/afc/local-filesystem-case.ts
+++ b/src/services/ios/afc/local-filesystem-case.ts
@@ -84,7 +84,10 @@ export function parseDiskutilInfoPlist(info: DiskutilInfoPlist): boolean {
     }
   }
 
-  if (filesystemName?.includes('HFS') && !/case-sensitive/i.test(filesystemName)) {
+  if (
+    filesystemName?.includes('HFS') &&
+    !/case-sensitive/i.test(filesystemName)
+  ) {
     return false;
   }
 
@@ -109,10 +112,14 @@ async function getDarwinCaseSensitivity(dir: string): Promise<boolean> {
     return cached;
   }
 
-  const { stdout } = await execFileAsync('diskutil', ['info', '-plist', device], {
-    encoding: 'utf8',
-    maxBuffer: 4 * 1024 * 1024,
-  });
+  const { stdout } = await execFileAsync(
+    'diskutil',
+    ['info', '-plist', device],
+    {
+      encoding: 'utf8',
+      maxBuffer: 4 * 1024 * 1024,
+    },
+  );
 
   const diskInfo = plist.parsePlist(stdout) as DiskutilInfoPlist;
   const caseSensitive = parseDiskutilInfoPlist(diskInfo);

--- a/src/services/ios/afc/local-filesystem-case.ts
+++ b/src/services/ios/afc/local-filesystem-case.ts
@@ -1,0 +1,166 @@
+import { plist } from '@appium/support';
+import { execFile } from 'node:child_process';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import { getLogger } from '../../../lib/logger.js';
+
+const log = getLogger('LocalFilesystemCase');
+
+const execFileAsync = promisify(execFile);
+
+const caseSensitivityByDevice = new Map<string, boolean>();
+
+/** Subset of keys returned by `diskutil info -plist`. */
+export interface DiskutilInfoPlist {
+  FilesystemName?: string;
+  FilesystemUserVisibleName?: string;
+  VolumeName?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Whether distinct path segments that differ only by letter case collide on `dir`.
+ *
+ * On macOS, uses `diskutil info -plist` for the volume backing `dir`. Results are
+ * cached per device identifier.
+ */
+export async function isCaseSensitiveDirectory(dir: string): Promise<boolean> {
+  const resolved = await fsp.realpath(dir).catch(() => path.resolve(dir));
+
+  let caseSensitive: boolean;
+  switch (os.platform()) {
+    case 'win32':
+      caseSensitive = false;
+      break;
+    case 'linux':
+      caseSensitive = true;
+      break;
+    case 'darwin':
+      try {
+        caseSensitive = await getDarwinCaseSensitivity(resolved);
+      } catch (err) {
+        log.info(
+          `Could not determine case sensitivity for '${resolved}'; assuming case-insensitive:`,
+          err,
+        );
+        caseSensitive = false;
+      }
+      break;
+    default:
+      caseSensitive = true;
+  }
+
+  return caseSensitive;
+}
+
+/**
+ * Derive case sensitivity from a parsed `diskutil info -plist` object.
+ *
+ * Case-sensitive APFS reports `FilesystemName: Case-sensitive APFS` and/or
+ * `FilesystemUserVisibleName: APFS (Case-sensitive)`. Default APFS/HFS+ installs are
+ * case-insensitive when not labeled otherwise.
+ */
+export function parseDiskutilInfoPlist(info: DiskutilInfoPlist): boolean {
+  const explicit = getExplicitCaseSensitiveField(info);
+  if (explicit !== undefined) {
+    return explicit;
+  }
+
+  const filesystemName = stringField(info.FilesystemName);
+  const visibleName = stringField(info.FilesystemUserVisibleName);
+
+  for (const value of [filesystemName, visibleName]) {
+    if (!value) {
+      continue;
+    }
+    if (/case-insensitive/i.test(value)) {
+      return false;
+    }
+    if (/case-sensitive/i.test(value)) {
+      return true;
+    }
+  }
+
+  if (filesystemName?.includes('HFS') && !/case-sensitive/i.test(filesystemName)) {
+    return false;
+  }
+
+  if (filesystemName === 'APFS' || visibleName === 'APFS') {
+    return false;
+  }
+
+  throw new Error(
+    'diskutil info plist did not include recognizable case-sensitivity details',
+  );
+}
+
+/** @internal Reset cached probe results (unit tests only). */
+export function clearCaseSensitivityCache(): void {
+  caseSensitivityByDevice.clear();
+}
+
+async function getDarwinCaseSensitivity(dir: string): Promise<boolean> {
+  const device = await getDeviceIdentifierForPath(dir);
+  const cached = caseSensitivityByDevice.get(device);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const { stdout } = await execFileAsync('diskutil', ['info', '-plist', device], {
+    encoding: 'utf8',
+    maxBuffer: 4 * 1024 * 1024,
+  });
+
+  const diskInfo = plist.parsePlist(stdout) as DiskutilInfoPlist;
+  const caseSensitive = parseDiskutilInfoPlist(diskInfo);
+  caseSensitivityByDevice.set(device, caseSensitive);
+  return caseSensitive;
+}
+
+async function getDeviceIdentifierForPath(dir: string): Promise<string> {
+  const { stdout } = await execFileAsync('df', ['-P', dir], {
+    encoding: 'utf8',
+  });
+  const lines = stdout.trim().split('\n');
+  const dataLine = lines[lines.length - 1];
+  if (!dataLine) {
+    throw new Error(`df produced no output for '${dir}'`);
+  }
+
+  const devicePath = dataLine.split(/\s+/)[0];
+  if (!devicePath?.startsWith('/dev/')) {
+    throw new Error(`Unexpected df device for '${dir}': ${devicePath ?? ''}`);
+  }
+
+  return devicePath.slice('/dev/'.length);
+}
+
+function getExplicitCaseSensitiveField(
+  info: DiskutilInfoPlist,
+): boolean | undefined {
+  for (const [key, value] of Object.entries(info)) {
+    if (!/case-sensitive/i.test(key)) {
+      continue;
+    }
+    if (typeof value === 'boolean') {
+      return value;
+    }
+    if (typeof value === 'string') {
+      const normalized = value.toLowerCase();
+      if (normalized === 'yes' || normalized === 'true') {
+        return true;
+      }
+      if (normalized === 'no' || normalized === 'false') {
+        return false;
+      }
+    }
+  }
+  return undefined;
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}

--- a/src/services/ios/afc/pull-local-name-allocator.ts
+++ b/src/services/ios/afc/pull-local-name-allocator.ts
@@ -9,9 +9,7 @@ import {
 
 const MAX_ALLOCATION_ATTEMPTS = 100;
 
-export type CaseSensitiveDirectoryCheck = (
-  dir: string,
-) => Promise<boolean>;
+export type CaseSensitiveDirectoryCheck = (dir: string) => Promise<boolean>;
 
 /**
  * Resolves sanitized local path segment names during a single AFC pull.

--- a/src/services/ios/afc/pull-local-name-allocator.ts
+++ b/src/services/ios/afc/pull-local-name-allocator.ts
@@ -1,0 +1,105 @@
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
+
+import { isCaseSensitiveDirectory } from './local-filesystem-case.js';
+import {
+  appendUniqueSuffix,
+  sanitizeLocalFilename,
+} from './sanitize-local-filename.js';
+
+const MAX_ALLOCATION_ATTEMPTS = 100;
+
+export type CaseSensitiveDirectoryCheck = (
+  dir: string,
+) => Promise<boolean>;
+
+/**
+ * Resolves sanitized local path segment names during a single AFC pull.
+ * Adds a UUID-based suffix only when the sanitized name is already taken in the
+ * destination directory (by an earlier entry in this pull or an existing local path).
+ */
+export class PullLocalNameAllocator {
+  private readonly usedByDir = new Map<string, Set<string>>();
+  private readonly caseSensitiveByDir = new Map<string, boolean>();
+
+  constructor(
+    private readonly pathExists: (localPath: string) => Promise<boolean>,
+    private readonly checkCaseSensitive: CaseSensitiveDirectoryCheck = isCaseSensitiveDirectory,
+  ) {}
+
+  async allocate(parentDir: string, remoteSegment: string): Promise<string> {
+    const sanitized = sanitizeLocalFilename(remoteSegment);
+
+    for (let attempt = 0; attempt < MAX_ALLOCATION_ATTEMPTS; attempt += 1) {
+      const candidate =
+        attempt === 0
+          ? sanitized
+          : appendUniqueSuffix(sanitized, randomSuffix());
+
+      if (!(await this.hasClash(parentDir, candidate))) {
+        this.register(parentDir, candidate);
+        return candidate;
+      }
+    }
+
+    throw new Error(
+      `Could not allocate a unique local name for remote segment '${remoteSegment}'`,
+    );
+  }
+
+  private async hasClash(parentDir: string, name: string): Promise<boolean> {
+    if (await this.isUsedInPull(parentDir, name)) {
+      return true;
+    }
+    return this.pathExists(path.join(parentDir, name));
+  }
+
+  private async isUsedInPull(
+    parentDir: string,
+    name: string,
+  ): Promise<boolean> {
+    const used = this.usedByDir.get(parentDir);
+    if (!used) {
+      return false;
+    }
+    for (const existing of used) {
+      if (await this.namesCollide(parentDir, existing, name)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private async namesCollide(
+    parentDir: string,
+    a: string,
+    b: string,
+  ): Promise<boolean> {
+    if (await this.isCaseSensitiveForDir(parentDir)) {
+      return a === b;
+    }
+    return a.toLowerCase() === b.toLowerCase();
+  }
+
+  private async isCaseSensitiveForDir(parentDir: string): Promise<boolean> {
+    let caseSensitive = this.caseSensitiveByDir.get(parentDir);
+    if (caseSensitive === undefined) {
+      caseSensitive = await this.checkCaseSensitive(parentDir);
+      this.caseSensitiveByDir.set(parentDir, caseSensitive);
+    }
+    return caseSensitive;
+  }
+
+  private register(parentDir: string, name: string): void {
+    let used = this.usedByDir.get(parentDir);
+    if (!used) {
+      used = new Set();
+      this.usedByDir.set(parentDir, used);
+    }
+    used.add(name);
+  }
+}
+
+function randomSuffix(): string {
+  return randomUUID().replace(/-/g, '').slice(0, 8);
+}

--- a/src/services/ios/afc/pull-local-name-allocator.ts
+++ b/src/services/ios/afc/pull-local-name-allocator.ts
@@ -13,8 +13,8 @@ export type CaseSensitiveDirectoryCheck = (dir: string) => Promise<boolean>;
 
 /**
  * Resolves sanitized local path segment names during a single AFC pull.
- * Adds a UUID-based suffix only when the sanitized name is already taken in the
- * destination directory (by an earlier entry in this pull or an existing local path).
+ * Adds a UUID-based suffix when the sanitized name is already taken in this pull, or
+ * when `overwrite` is false and a file already exists at that path on disk.
  */
 export class PullLocalNameAllocator {
   private readonly usedByDir = new Map<string, Set<string>>();
@@ -22,6 +22,7 @@ export class PullLocalNameAllocator {
 
   constructor(
     private readonly pathExists: (localPath: string) => Promise<boolean>,
+    private readonly overwrite: boolean,
     private readonly checkCaseSensitive: CaseSensitiveDirectoryCheck = isCaseSensitiveDirectory,
   ) {}
 
@@ -49,7 +50,10 @@ export class PullLocalNameAllocator {
     if (await this.isUsedInPull(parentDir, name)) {
       return true;
     }
-    return this.pathExists(path.join(parentDir, name));
+    if (!this.overwrite) {
+      return this.pathExists(path.join(parentDir, name));
+    }
+    return false;
   }
 
   private async isUsedInPull(

--- a/src/services/ios/afc/sanitize-local-filename.ts
+++ b/src/services/ios/afc/sanitize-local-filename.ts
@@ -1,0 +1,152 @@
+import os from 'node:os';
+
+/** Fallback when a remote name has no safe local characters after sanitization. */
+export const EMPTY_SANITIZED_FILENAME = '_';
+
+const MAX_FILENAME_BYTES = 255;
+
+/** C0 and C1 Unicode control characters. */
+// eslint-disable-next-line no-control-regex -- intentional filename sanitization
+const CONTROL_RE = /[\x00-\x1f\x80-\x9f]/g;
+
+/** Characters invalid on Windows filenames. */
+const WINDOWS_ILLEGAL_RE = /[/?<>\\:*|"]/g;
+
+/** Path separator on Unix-like systems (and macOS). */
+const POSIX_PATH_SEP_RE = /\//g;
+
+/** Colon is invalid in macOS / HFS+ / APFS file names. */
+const DARWIN_ILLEGAL_RE = /:/g;
+
+/** Unix reserved single-segment names (`.` and `..`). */
+const RESERVED_DOTS_RE = /^\.+$/;
+
+/** Windows reserved device names (case-insensitive, optional extension). */
+const WINDOWS_RESERVED_RE =
+  /^(con|prn|aux|nul|com[0-9]|lpt[0-9])(\..*)?$/i;
+
+/**
+ * Sanitize a single path segment from the device for use on the local filesystem.
+ *
+ * Rules are chosen from {@link os.platform} at pull time (the host writing files).
+ */
+export function sanitizeLocalFilename(name: string): string {
+  switch (os.platform()) {
+    case 'win32':
+      return sanitizeForWindows(name);
+    case 'darwin':
+      return sanitizeForDarwin(name);
+    default:
+      return sanitizeForPosix(name);
+  }
+}
+
+/**
+ * Insert a unique suffix before the file extension (or at the end when there is none).
+ */
+export function withUniqueSuffix(filename: string, suffix: string): string {
+  const dot = filename.lastIndexOf('.');
+  if (dot > 0) {
+    return `${filename.slice(0, dot)}_${suffix}${filename.slice(dot)}`;
+  }
+  return `${filename}_${suffix}`;
+}
+
+/** Sanitized name with a disambiguating suffix, still within host filename byte limits. */
+export function appendUniqueSuffix(sanitized: string, suffix: string): string {
+  const suffixed = withUniqueSuffix(sanitized, suffix);
+  return finalizeSegment(suffixed);
+}
+
+function isHighSurrogate(codePoint: number): boolean {
+  return codePoint >= 0xd800 && codePoint <= 0xdbff;
+}
+
+function isLowSurrogate(codePoint: number): boolean {
+  return codePoint >= 0xdc00 && codePoint <= 0xdfff;
+}
+
+/**
+ * Truncate a string to at most `byteLength` UTF-8 bytes without splitting code points.
+ * Ported from truncate-utf8-bytes (dependency of sanitize-filename).
+ */
+function truncateUtf8Bytes(input: string, byteLength: number): string {
+  let curByteLength = 0;
+
+  for (let i = 0; i < input.length; i += 1) {
+    const codePoint = input.charCodeAt(i);
+    let segment = input.charAt(i);
+
+    if (
+      isHighSurrogate(codePoint) &&
+      isLowSurrogate(input.charCodeAt(i + 1))
+    ) {
+      i += 1;
+      segment += input.charAt(i);
+    }
+
+    const segmentBytes = Buffer.byteLength(segment, 'utf8');
+    curByteLength += segmentBytes;
+
+    if (curByteLength === byteLength) {
+      return input.slice(0, i + 1);
+    }
+    if (curByteLength > byteLength) {
+      return input.slice(0, i - segment.length + 1);
+    }
+  }
+
+  return input;
+}
+
+/**
+ * Strip trailing spaces and dots (invalid on Windows). Avoids regex backtracking (CWE-1333).
+ * Ported from sanitize-filename.
+ */
+function replaceTrailingDotsAndSpaces(
+  input: string,
+  replacement: string,
+): string {
+  let end = input.length;
+  while (end > 0 && (input[end - 1] === '.' || input[end - 1] === ' ')) {
+    end -= 1;
+  }
+  return end < input.length ? input.slice(0, end) + replacement : input;
+}
+
+function stripWith(
+  input: string,
+  pattern: RegExp,
+  replacement = '',
+): string {
+  return input.replace(pattern, replacement);
+}
+
+function finalizeSegment(input: string): string {
+  const truncated = truncateUtf8Bytes(input, MAX_FILENAME_BYTES);
+  return truncated || EMPTY_SANITIZED_FILENAME;
+}
+
+function sanitizeForWindows(name: string): string {
+  let sanitized = stripWith(name, WINDOWS_ILLEGAL_RE);
+  sanitized = stripWith(sanitized, CONTROL_RE);
+  sanitized = stripWith(sanitized, RESERVED_DOTS_RE);
+  sanitized = stripWith(sanitized, WINDOWS_RESERVED_RE);
+  sanitized = replaceTrailingDotsAndSpaces(sanitized, '');
+  return finalizeSegment(sanitized);
+}
+
+function sanitizeForDarwin(name: string): string {
+  let sanitized = stripWith(name, POSIX_PATH_SEP_RE);
+  sanitized = stripWith(sanitized, DARWIN_ILLEGAL_RE);
+  sanitized = stripWith(sanitized, CONTROL_RE);
+  sanitized = stripWith(sanitized, RESERVED_DOTS_RE);
+  return finalizeSegment(sanitized);
+}
+
+function sanitizeForPosix(name: string): string {
+  let sanitized = stripWith(name, POSIX_PATH_SEP_RE);
+  sanitized = stripWith(sanitized, CONTROL_RE);
+  sanitized = stripWith(sanitized, RESERVED_DOTS_RE);
+  return finalizeSegment(sanitized);
+}

--- a/src/services/ios/afc/sanitize-local-filename.ts
+++ b/src/services/ios/afc/sanitize-local-filename.ts
@@ -22,8 +22,7 @@ const DARWIN_ILLEGAL_RE = /:/g;
 const RESERVED_DOTS_RE = /^\.+$/;
 
 /** Windows reserved device names (case-insensitive, optional extension). */
-const WINDOWS_RESERVED_RE =
-  /^(con|prn|aux|nul|com[0-9]|lpt[0-9])(\..*)?$/i;
+const WINDOWS_RESERVED_RE = /^(con|prn|aux|nul|com[0-9]|lpt[0-9])(\..*)?$/i;
 
 /**
  * Sanitize a single path segment from the device for use on the local filesystem.
@@ -77,10 +76,7 @@ function truncateUtf8Bytes(input: string, byteLength: number): string {
     const codePoint = input.charCodeAt(i);
     let segment = input.charAt(i);
 
-    if (
-      isHighSurrogate(codePoint) &&
-      isLowSurrogate(input.charCodeAt(i + 1))
-    ) {
+    if (isHighSurrogate(codePoint) && isLowSurrogate(input.charCodeAt(i + 1))) {
       i += 1;
       segment += input.charAt(i);
     }
@@ -114,11 +110,7 @@ function replaceTrailingDotsAndSpaces(
   return end < input.length ? input.slice(0, end) + replacement : input;
 }
 
-function stripWith(
-  input: string,
-  pattern: RegExp,
-  replacement = '',
-): string {
+function stripWith(input: string, pattern: RegExp, replacement = ''): string {
   return input.replace(pattern, replacement);
 }
 

--- a/src/services/ios/afc/sanitize-local-filename.ts
+++ b/src/services/ios/afc/sanitize-local-filename.ts
@@ -53,7 +53,26 @@ export function withUniqueSuffix(filename: string, suffix: string): string {
 
 /** Sanitized name with a disambiguating suffix, still within host filename byte limits. */
 export function appendUniqueSuffix(sanitized: string, suffix: string): string {
-  const suffixed = withUniqueSuffix(sanitized, suffix);
+  const dot = sanitized.lastIndexOf('.');
+  const hasExtension = dot > 0;
+  const base = hasExtension ? sanitized.slice(0, dot) : sanitized;
+  const extension = hasExtension ? sanitized.slice(dot) : '';
+  const suffixPart = `_${suffix}`;
+
+  const reservedBytes =
+    Buffer.byteLength(suffixPart, 'utf8') +
+    Buffer.byteLength(extension, 'utf8');
+  const maxBaseBytes = MAX_FILENAME_BYTES - reservedBytes;
+
+  const truncatedBase =
+    maxBaseBytes > 0
+      ? truncateUtf8Bytes(base, maxBaseBytes)
+      : EMPTY_SANITIZED_FILENAME;
+
+  const suffixed = hasExtension
+    ? `${truncatedBase || EMPTY_SANITIZED_FILENAME}${suffixPart}${extension}`
+    : `${truncatedBase || EMPTY_SANITIZED_FILENAME}${suffixPart}`;
+
   return finalizeSegment(suffixed);
 }
 

--- a/test/unit/afc/local-filesystem-case.spec.ts
+++ b/test/unit/afc/local-filesystem-case.spec.ts
@@ -1,0 +1,78 @@
+import { expect } from 'chai';
+import os from 'node:os';
+
+import {
+  clearCaseSensitivityCache,
+  isCaseSensitiveDirectory,
+  parseDiskutilInfoPlist,
+  type DiskutilInfoPlist,
+} from '../../../src/services/ios/afc/local-filesystem-case.js';
+
+describe('parseDiskutilInfoPlist', function () {
+  it('should detect case-insensitive APFS', function () {
+    const info: DiskutilInfoPlist = {
+      FilesystemName: 'APFS',
+      FilesystemUserVisibleName: 'APFS',
+      FilesystemType: 'apfs',
+    };
+    expect(parseDiskutilInfoPlist(info)).to.equal(false);
+  });
+
+  it('should detect case-sensitive APFS', function () {
+    const info: DiskutilInfoPlist = {
+      FilesystemName: 'Case-sensitive APFS',
+      FilesystemUserVisibleName: 'APFS (Case-sensitive)',
+      FilesystemType: 'apfs',
+    };
+    expect(parseDiskutilInfoPlist(info)).to.equal(true);
+  });
+
+  it('should detect case-sensitive HFS+', function () {
+    const info: DiskutilInfoPlist = {
+      FilesystemName: 'HFS+ (Case-sensitive)',
+      FilesystemUserVisibleName: 'Mac OS Extended (Case-sensitive, Journaled)',
+    };
+    expect(parseDiskutilInfoPlist(info)).to.equal(true);
+  });
+
+  it('should throw when diskutil plist omits case semantics', function () {
+    expect(() =>
+      parseDiskutilInfoPlist({ VolumeName: 'Mystery' }),
+    ).to.throw(
+      'diskutil info plist did not include recognizable case-sensitivity details',
+    );
+  });
+
+  it('should honor explicit case-sensitive plist fields when present', function () {
+    expect(
+      parseDiskutilInfoPlist({ 'Name (Case-Sensitive)': 'Yes' }),
+    ).to.equal(true);
+    expect(parseDiskutilInfoPlist({ 'Name (Case-Sensitive)': 'No' })).to.equal(
+      false,
+    );
+  });
+});
+
+describe('isCaseSensitiveDirectory', function () {
+  afterEach(function () {
+    clearCaseSensitivityCache();
+  });
+
+  (os.platform() === 'darwin' ? it : it.skip)(
+    'should match diskutil info -plist for the tmpdir volume on macOS',
+    async function () {
+      const detected = await isCaseSensitiveDirectory(os.tmpdir());
+      expect(detected).to.be.a('boolean');
+    },
+  );
+
+  (os.platform() === 'darwin' ? it : it.skip)(
+    'should return a stable cached result for the same directory',
+    async function () {
+      const dir = os.tmpdir();
+      const first = await isCaseSensitiveDirectory(dir);
+      const second = await isCaseSensitiveDirectory(dir);
+      expect(second).to.equal(first);
+    },
+  );
+});

--- a/test/unit/afc/local-filesystem-case.spec.ts
+++ b/test/unit/afc/local-filesystem-case.spec.ts
@@ -2,10 +2,10 @@ import { expect } from 'chai';
 import os from 'node:os';
 
 import {
+  type DiskutilInfoPlist,
   clearCaseSensitivityCache,
   isCaseSensitiveDirectory,
   parseDiskutilInfoPlist,
-  type DiskutilInfoPlist,
 } from '../../../src/services/ios/afc/local-filesystem-case.js';
 
 describe('parseDiskutilInfoPlist', function () {
@@ -36,17 +36,15 @@ describe('parseDiskutilInfoPlist', function () {
   });
 
   it('should throw when diskutil plist omits case semantics', function () {
-    expect(() =>
-      parseDiskutilInfoPlist({ VolumeName: 'Mystery' }),
-    ).to.throw(
+    expect(() => parseDiskutilInfoPlist({ VolumeName: 'Mystery' })).to.throw(
       'diskutil info plist did not include recognizable case-sensitivity details',
     );
   });
 
   it('should honor explicit case-sensitive plist fields when present', function () {
-    expect(
-      parseDiskutilInfoPlist({ 'Name (Case-Sensitive)': 'Yes' }),
-    ).to.equal(true);
+    expect(parseDiskutilInfoPlist({ 'Name (Case-Sensitive)': 'Yes' })).to.equal(
+      true,
+    );
     expect(parseDiskutilInfoPlist({ 'Name (Case-Sensitive)': 'No' })).to.equal(
       false,
     );

--- a/test/unit/afc/pull-local-name-allocator.spec.ts
+++ b/test/unit/afc/pull-local-name-allocator.spec.ts
@@ -1,0 +1,92 @@
+import { expect } from 'chai';
+import os from 'node:os';
+import path from 'node:path';
+import sinon from 'sinon';
+
+import { PullLocalNameAllocator } from '../../../src/services/ios/afc/pull-local-name-allocator.js';
+import { withUniqueSuffix } from '../../../src/services/ios/afc/sanitize-local-filename.js';
+
+describe('withUniqueSuffix', function () {
+  it('should insert the suffix before the extension', function () {
+    expect(withUniqueSuffix('reportfile.txt', 'a1b2c3d4')).to.equal(
+      'reportfile_a1b2c3d4.txt',
+    );
+  });
+
+  it('should append the suffix when there is no extension', function () {
+    expect(withUniqueSuffix('reportfile', 'a1b2c3d4')).to.equal(
+      'reportfile_a1b2c3d4',
+    );
+  });
+});
+
+describe('PullLocalNameAllocator', function () {
+  let platformStub: sinon.SinonStub<[], NodeJS.Platform>;
+  const parentDir = '/tmp/pull-test';
+
+  afterEach(function () {
+    platformStub?.restore();
+  });
+
+  function stubPlatform(platform: NodeJS.Platform): void {
+    platformStub = sinon.stub(os, 'platform').returns(platform);
+  }
+
+  it('should return the sanitized name when there is no clash', async function () {
+    stubPlatform('linux');
+    const exists = sinon.stub().resolves(false);
+    const allocator = new PullLocalNameAllocator(exists);
+
+    const name = await allocator.allocate(parentDir, 'keeps>chars');
+
+    expect(name).to.equal('keeps>chars');
+    expect(exists.calledOnce).to.equal(true);
+    expect(exists.firstCall.args[0]).to.equal(
+      path.join(parentDir, 'keeps>chars'),
+    );
+  });
+
+  it('should add a suffix when two remote names sanitize to the same local name', async function () {
+    stubPlatform('win32');
+    const exists = sinon.stub().resolves(false);
+    const allocator = new PullLocalNameAllocator(exists);
+
+    const first = await allocator.allocate(parentDir, 'file?');
+    const second = await allocator.allocate(parentDir, '*file*');
+
+    expect(first).to.equal('file');
+    expect(second).to.match(/^file_[0-9a-f]{8}$/);
+    expect(second).to.not.equal(first);
+  });
+
+  it('should add a suffix when the sanitized name already exists on disk', async function () {
+    stubPlatform('win32');
+    const exists = sinon.stub().callsFake(async (localPath: string) => path.basename(localPath) === 'reportfile.txt');
+    const allocator = new PullLocalNameAllocator(exists);
+
+    const name = await allocator.allocate(parentDir, 'report>file.txt');
+
+    expect(name).to.match(/^reportfile_[0-9a-f]{8}\.txt$/);
+  });
+
+  it('should treat names as case-insensitive when the volume is case-insensitive', async function () {
+    const exists = sinon.stub().resolves(false);
+    const allocator = new PullLocalNameAllocator(exists, async () => false);
+
+    await allocator.allocate(parentDir, 'File');
+    const second = await allocator.allocate(parentDir, 'file');
+
+    expect(second).to.match(/^file_[0-9a-f]{8}$/);
+  });
+
+  it('should allow differing case when the volume is case-sensitive', async function () {
+    const exists = sinon.stub().resolves(false);
+    const allocator = new PullLocalNameAllocator(exists, async () => true);
+
+    const first = await allocator.allocate(parentDir, 'File');
+    const second = await allocator.allocate(parentDir, 'file');
+
+    expect(first).to.equal('File');
+    expect(second).to.equal('file');
+  });
+});

--- a/test/unit/afc/pull-local-name-allocator.spec.ts
+++ b/test/unit/afc/pull-local-name-allocator.spec.ts
@@ -61,7 +61,12 @@ describe('PullLocalNameAllocator', function () {
 
   it('should add a suffix when the sanitized name already exists on disk', async function () {
     stubPlatform('win32');
-    const exists = sinon.stub().callsFake(async (localPath: string) => path.basename(localPath) === 'reportfile.txt');
+    const exists = sinon
+      .stub()
+      .callsFake(
+        async (localPath: string) =>
+          path.basename(localPath) === 'reportfile.txt',
+      );
     const allocator = new PullLocalNameAllocator(exists);
 
     const name = await allocator.allocate(parentDir, 'report>file.txt');

--- a/test/unit/afc/pull-local-name-allocator.spec.ts
+++ b/test/unit/afc/pull-local-name-allocator.spec.ts
@@ -35,7 +35,7 @@ describe('PullLocalNameAllocator', function () {
   it('should return the sanitized name when there is no clash', async function () {
     stubPlatform('linux');
     const exists = sinon.stub().resolves(false);
-    const allocator = new PullLocalNameAllocator(exists);
+    const allocator = new PullLocalNameAllocator(exists, false);
 
     const name = await allocator.allocate(parentDir, 'keeps>chars');
 
@@ -49,7 +49,7 @@ describe('PullLocalNameAllocator', function () {
   it('should add a suffix when two remote names sanitize to the same local name', async function () {
     stubPlatform('win32');
     const exists = sinon.stub().resolves(false);
-    const allocator = new PullLocalNameAllocator(exists);
+    const allocator = new PullLocalNameAllocator(exists, true);
 
     const first = await allocator.allocate(parentDir, 'file?');
     const second = await allocator.allocate(parentDir, '*file*');
@@ -59,7 +59,7 @@ describe('PullLocalNameAllocator', function () {
     expect(second).to.not.equal(first);
   });
 
-  it('should add a suffix when the sanitized name already exists on disk', async function () {
+  it('should add a suffix when the sanitized name already exists on disk and overwrite is false', async function () {
     stubPlatform('win32');
     const exists = sinon
       .stub()
@@ -67,16 +67,31 @@ describe('PullLocalNameAllocator', function () {
         async (localPath: string) =>
           path.basename(localPath) === 'reportfile.txt',
       );
-    const allocator = new PullLocalNameAllocator(exists);
+    const allocator = new PullLocalNameAllocator(exists, false);
 
     const name = await allocator.allocate(parentDir, 'report>file.txt');
 
     expect(name).to.match(/^reportfile_[0-9a-f]{8}\.txt$/);
   });
 
+  it('should reuse the sanitized name when overwrite is true and the path exists on disk', async function () {
+    stubPlatform('win32');
+    const exists = sinon.stub().resolves(true);
+    const allocator = new PullLocalNameAllocator(exists, true);
+
+    const name = await allocator.allocate(parentDir, 'report>file.txt');
+
+    expect(name).to.equal('reportfile.txt');
+    expect(exists.called).to.equal(false);
+  });
+
   it('should treat names as case-insensitive when the volume is case-insensitive', async function () {
     const exists = sinon.stub().resolves(false);
-    const allocator = new PullLocalNameAllocator(exists, async () => false);
+    const allocator = new PullLocalNameAllocator(
+      exists,
+      true,
+      async () => false,
+    );
 
     await allocator.allocate(parentDir, 'File');
     const second = await allocator.allocate(parentDir, 'file');
@@ -86,7 +101,11 @@ describe('PullLocalNameAllocator', function () {
 
   it('should allow differing case when the volume is case-sensitive', async function () {
     const exists = sinon.stub().resolves(false);
-    const allocator = new PullLocalNameAllocator(exists, async () => true);
+    const allocator = new PullLocalNameAllocator(
+      exists,
+      true,
+      async () => true,
+    );
 
     const first = await allocator.allocate(parentDir, 'File');
     const second = await allocator.allocate(parentDir, 'file');

--- a/test/unit/afc/sanitize-local-filename.spec.ts
+++ b/test/unit/afc/sanitize-local-filename.spec.ts
@@ -1,0 +1,84 @@
+import { expect } from 'chai';
+import os from 'node:os';
+import sinon from 'sinon';
+
+import {
+  EMPTY_SANITIZED_FILENAME,
+  sanitizeLocalFilename,
+} from '../../../src/services/ios/afc/sanitize-local-filename.js';
+
+describe('sanitizeLocalFilename', function () {
+  let platformStub: sinon.SinonStub<[], NodeJS.Platform>;
+
+  afterEach(function () {
+    platformStub?.restore();
+  });
+
+  function stubPlatform(platform: NodeJS.Platform): void {
+    platformStub = sinon.stub(os, 'platform').returns(platform);
+  }
+
+  describe('win32', function () {
+    beforeEach(function () {
+      stubPlatform('win32');
+    });
+
+    it('should remove Windows-illegal characters', function () {
+      expect(sanitizeLocalFilename('report>file.txt')).to.equal(
+        'reportfile.txt',
+      );
+      expect(sanitizeLocalFilename('a/b\\c:d*e?f"g|h')).to.equal('abcdefgh');
+    });
+
+    it('should reject reserved device names', function () {
+      expect(sanitizeLocalFilename('CON')).to.equal(EMPTY_SANITIZED_FILENAME);
+      expect(sanitizeLocalFilename('com1.log')).to.equal(
+        EMPTY_SANITIZED_FILENAME,
+      );
+    });
+
+    it('should strip trailing dots and spaces', function () {
+      expect(sanitizeLocalFilename('name. ')).to.equal('name');
+    });
+
+    it('should return a fallback for empty results', function () {
+      expect(sanitizeLocalFilename('..')).to.equal(EMPTY_SANITIZED_FILENAME);
+    });
+  });
+
+  describe('darwin', function () {
+    beforeEach(function () {
+      stubPlatform('darwin');
+    });
+
+    it('should remove path separators and colons', function () {
+      expect(sanitizeLocalFilename('folder:name')).to.equal('foldername');
+      expect(sanitizeLocalFilename('nested/name')).to.equal('nestedname');
+    });
+
+    it('should keep characters that are valid on macOS but not Windows', function () {
+      expect(sanitizeLocalFilename('bad>char')).to.equal('bad>char');
+      expect(sanitizeLocalFilename('keeps*star')).to.equal('keeps*star');
+    });
+
+    it('should return a fallback for reserved dot names', function () {
+      expect(sanitizeLocalFilename('..')).to.equal(EMPTY_SANITIZED_FILENAME);
+    });
+  });
+
+  describe('linux', function () {
+    beforeEach(function () {
+      stubPlatform('linux');
+    });
+
+    it('should only strip path separators and control chars', function () {
+      expect(sanitizeLocalFilename('keeps>chars')).to.equal('keeps>chars');
+      expect(sanitizeLocalFilename('nested/name')).to.equal('nestedname');
+      expect(sanitizeLocalFilename('also:colon')).to.equal('also:colon');
+    });
+
+    it('should return a fallback for reserved dot names', function () {
+      expect(sanitizeLocalFilename('..')).to.equal(EMPTY_SANITIZED_FILENAME);
+    });
+  });
+});

--- a/test/unit/afc/sanitize-local-filename.spec.ts
+++ b/test/unit/afc/sanitize-local-filename.spec.ts
@@ -4,8 +4,28 @@ import sinon from 'sinon';
 
 import {
   EMPTY_SANITIZED_FILENAME,
+  appendUniqueSuffix,
   sanitizeLocalFilename,
 } from '../../../src/services/ios/afc/sanitize-local-filename.js';
+
+describe('appendUniqueSuffix', function () {
+  it('should preserve the suffix on long names by truncating the base first', function () {
+    const longBase = 'a'.repeat(300);
+    const result = appendUniqueSuffix(`${longBase}.txt`, 'deadbeef');
+
+    expect(result.endsWith('_deadbeef.txt')).to.equal(true);
+    expect(Buffer.byteLength(result, 'utf8')).to.be.at.most(255);
+    expect(result).to.include('deadbeef');
+  });
+
+  it('should preserve the suffix when there is no extension', function () {
+    const longBase = 'b'.repeat(300);
+    const result = appendUniqueSuffix(longBase, 'cafebabe');
+
+    expect(result.endsWith('_cafebabe')).to.equal(true);
+    expect(Buffer.byteLength(result, 'utf8')).to.be.at.most(255);
+  });
+});
 
 describe('sanitizeLocalFilename', function () {
   let platformStub: sinon.SinonStub<[], NodeJS.Platform>;


### PR DESCRIPTION
## Summary

Fixes [#115](https://github.com/appium/appium-ios-remotexpc/issues/115) by sanitizing remote AFC path segments for the **host** filesystem during `pull`, and disambiguating names only when a real clash would occur in the destination directory.

- **`sanitize-local-filename.ts`** — Platform-specific sanitization (ported from `sanitize-filename` logic, no extra dependency):
  - **Windows**: illegal chars, control chars, reserved names (`CON`, …), trailing dots/spaces, 255-byte UTF-8 limit
  - **macOS**: `/`, `:`, control chars, `.` / `..`
  - **Linux**: `/`, control chars, `.` / `..` (keeps chars like `>` that are valid locally)
- **`pull-local-name-allocator.ts`** — Per-`pull()` allocator that:
  - Uses sanitized names by default
  - Adds `_<8-char-uuid>` **only on clash** (another file in the same pull, or an existing local path)
  - Respects volume case rules via `isCaseSensitiveDirectory`
- **`local-filesystem-case.ts`** — Case-sensitivity detection for clash comparison:
  - **macOS**: `df` → `diskutil info -plist` → `plist.parsePlist` (`FilesystemName`, `FilesystemUserVisibleName`, …)
  - Falls back to case-insensitive with a log message if detection fails
  - **Windows**: case-insensitive; **Linux**: case-sensitive
- **`AfcService.pull` / `_pullRecursiveInternal`** — Wire allocator for single-file and recursive pulls; remote paths and `match` globs still use original device names

Bumps `@appium/support` to `^7.2.2` for `plist.parsePlist`.

## Test plan

- [x] Unit: `sanitize-local-filename` (win32 / darwin / linux rules)
- [x] Unit: `pull-local-name-allocator` (no suffix without clash; suffix on sanitize collision and on-disk collision; case-sensitive vs case-insensitive volumes)
- [x] Unit: `local-filesystem-case` (plist parser fixtures; live `diskutil info -plist` on macOS)
- [ ] Integration (device): pull a file with host-invalid chars (e.g. `report>file.txt` on Windows) and confirm it lands locally
- [ ] Integration (device): pull two remote files that sanitize to the same name (e.g. `file?` and `*file*`) and confirm both are written with distinct local names
- [ ] Integration (optional): recursive directory pull with mixed safe/unsafe entry names