### PR TITLE
feat: Fail fast if a tunnel registry is not running

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,8 +84,8 @@ export { NetworkMessageType } from './services/ios/dvt/instruments/network-monit
 export {
   TunnelAvailabilityError,
   getTunnelForDevice,
-  withRemoteXpcConnection,
-} from './services.js';
+} from './lib/tunnel/tunnel-availability.js';
+export { withRemoteXpcConnection } from './services.js';
 export type { TunnelEndpoint } from './lib/tunnel/tunnel-api-client.js';
 export { XCTestConfigurationEncoder } from './services/ios/testmanagerd/xctestconfiguration.js';
 export type { XCTestConfigurationParams } from './services/ios/testmanagerd/xctestconfiguration.js';

--- a/src/lib/tunnel/constants.ts
+++ b/src/lib/tunnel/constants.ts
@@ -1,0 +1,11 @@
+/** Host for the local tunnel registry HTTP API and TCP health probe. */
+export const TUNNEL_REGISTRY_HOST = '127.0.0.1';
+
+/** Base URL path for the tunnel registry HTTP API. */
+export const TUNNEL_REGISTRY_API_BASE_PATH = '/remotexpc/tunnels';
+
+/** Timeout for tunnel registry HTTP lookups (single GET per device). */
+export const TUNNEL_REGISTRY_HTTP_TIMEOUT_MS = 500;
+
+/** Timeout for TCP probe that the registry HTTP server is listening. */
+export const TUNNEL_REGISTRY_PORT_PROBE_TIMEOUT_MS = 300;

--- a/src/lib/tunnel/errors.ts
+++ b/src/lib/tunnel/errors.ts
@@ -1,0 +1,9 @@
+export class TunnelAvailabilityError extends Error {
+  readonly code = 'ERR_TUNNEL_AVAILABILITY';
+
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = new.target.name;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/src/lib/tunnel/tunnel-api-client.ts
+++ b/src/lib/tunnel/tunnel-api-client.ts
@@ -1,5 +1,6 @@
 import { getLogger } from '../logger.js';
 import type { TunnelRegistry, TunnelRegistryEntry } from '../types.js';
+import { TunnelAvailabilityError } from './errors.js';
 
 const log = getLogger('TunnelApiClient');
 
@@ -70,7 +71,9 @@ export class TunnelApiClient {
       const response = await this.fetchWithTimeout(this.apiBaseUrl);
 
       if (!response.ok) {
-        throw new Error(`API request failed with status: ${response.status}`);
+        throw new TunnelAvailabilityError(
+          `Failed to fetch tunnel registry from API: HTTP ${response.status}`,
+        );
       }
 
       return (await response.json()) as TunnelRegistry;
@@ -96,7 +99,9 @@ export class TunnelApiClient {
       }
 
       if (!response.ok) {
-        throw new Error(`API request failed with status: ${response.status}`);
+        throw new TunnelAvailabilityError(
+          `Failed to fetch tunnel for UDID ${udid}: HTTP ${response.status}`,
+        );
       }
 
       return (await response.json()) as TunnelRegistryEntry;
@@ -124,7 +129,9 @@ export class TunnelApiClient {
       }
 
       if (!response.ok) {
-        throw new Error(`API request failed with status: ${response.status}`);
+        throw new TunnelAvailabilityError(
+          `Failed to fetch tunnel for device ID ${deviceId}: HTTP ${response.status}`,
+        );
       }
 
       return (await response.json()) as TunnelRegistryEntry;
@@ -261,18 +268,30 @@ export class TunnelApiClient {
   }
 
   /**
-   * On strict: throws Error with message and cause. Otherwise logs and returns.
+   * On strict: throws {@link TunnelAvailabilityError} with message and cause.
+   * Otherwise logs and returns.
    */
   private handleFetchError(
     messagePrefix: string,
     error: unknown,
     logLevel: 'warn' | 'error' = 'warn',
   ): void {
+    if (error instanceof TunnelAvailabilityError) {
+      if (this.strict) {
+        throw error;
+      }
+      this.logFetchFailure(error.message, logLevel);
+      return;
+    }
     const detail = error instanceof Error ? error.message : String(error);
     const message = `${messagePrefix}: ${detail}`;
     if (this.strict) {
-      throw new Error(message, { cause: error });
+      throw new TunnelAvailabilityError(message, { cause: error });
     }
+    this.logFetchFailure(message, logLevel);
+  }
+
+  private logFetchFailure(message: string, logLevel: 'warn' | 'error'): void {
     if (logLevel === 'error') {
       log.error(message);
     } else {
@@ -293,12 +312,19 @@ export class TunnelApiClient {
       });
       return response;
     } catch (error) {
+      if (error instanceof TunnelAvailabilityError) {
+        throw error;
+      }
       if (error instanceof Error && error.name === 'AbortError') {
-        throw new Error(
+        throw new TunnelAvailabilityError(
           `Tunnel registry request timed out after ${this.timeoutMs}ms`,
+          { cause: error },
         );
       }
-      throw error;
+      throw new TunnelAvailabilityError(
+        `Tunnel registry request failed for ${url}`,
+        { cause: error },
+      );
     } finally {
       clearTimeout(timeoutId);
     }

--- a/src/lib/tunnel/tunnel-availability.ts
+++ b/src/lib/tunnel/tunnel-availability.ts
@@ -1,0 +1,177 @@
+import { BaseItem, strongbox } from '@appium/strongbox';
+import * as net from 'node:net';
+
+import { TUNNEL_CONTAINER_NAME } from '../../constants.js';
+import type { TunnelRegistryEntry } from '../types.js';
+import {
+  TUNNEL_REGISTRY_API_BASE_PATH,
+  TUNNEL_REGISTRY_HOST,
+  TUNNEL_REGISTRY_HTTP_TIMEOUT_MS,
+  TUNNEL_REGISTRY_PORT_PROBE_TIMEOUT_MS,
+} from './constants.js';
+import {
+  TunnelApiClient,
+  type TunnelApiClientOptions,
+  type TunnelEndpoint,
+} from './tunnel-api-client.js';
+
+const TUNNEL_REGISTRY_PORT = 'tunnelRegistryPort';
+
+export class TunnelAvailabilityError extends Error {
+  readonly code = 'ERR_TUNNEL_AVAILABILITY';
+
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = new.target.name;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/**
+ * Resolve tunnel registry metadata for a device (host, RSD port, packet stream).
+ * Strongbox port, TCP probe, then a single `GET /remotexpc/tunnels/{udid}`.
+ * @throws {TunnelAvailabilityError} When registry or tunnel for the UDID is unavailable.
+ */
+export async function getTunnelForDevice(
+  udid: string,
+): Promise<TunnelEndpoint> {
+  const client = await createValidatedStrictRegistryClient();
+
+  let entry: TunnelRegistryEntry | null;
+  try {
+    entry = await client.getTunnelByUdid(udid);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new TunnelAvailabilityError(
+      `Failed to reach tunnel registry: ${detail}`,
+      { cause: err },
+    );
+  }
+
+  if (!entry) {
+    throw new TunnelAvailabilityError(
+      `No tunnel found for device ${udid}. Please run the tunnel creation script first`,
+    );
+  }
+
+  return mapEntryToEndpoint(entry);
+}
+
+/**
+ * Returns the list of device UDIDs currently in the tunnel registry.
+ * Used to include tunnel-only devices (e.g. Apple TV over WiFi)
+ * in the "connected devices" list for session validation.
+ *
+ * @returns UDIDs when the registry is reachable (possibly empty).
+ * @throws {TunnelAvailabilityError} When the registry port is missing or unreachable.
+ */
+export async function getAvailableDevices(): Promise<string[]> {
+  const client = await createValidatedStrictRegistryClient();
+  try {
+    return await client.getAvailableDevices();
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new TunnelAvailabilityError(
+      `Failed to reach tunnel registry: ${detail}`,
+      { cause: err },
+    );
+  }
+}
+
+/**
+ * Read the tunnel registry HTTP port from strongbox.
+ * @throws {TunnelAvailabilityError} When the port was never stored (tunnel-creation not run).
+ */
+async function readTunnelRegistryPort(): Promise<number> {
+  const box = strongbox(TUNNEL_CONTAINER_NAME);
+  const item = new BaseItem(TUNNEL_REGISTRY_PORT, box);
+  const tunnelRegistryPort = await item.read();
+  if (
+    tunnelRegistryPort === undefined ||
+    String(tunnelRegistryPort).trim() === ''
+  ) {
+    throw new TunnelAvailabilityError(
+      'Tunnel registry port not found. Please run the tunnel creation script first',
+    );
+  }
+  return Number.parseInt(String(tunnelRegistryPort), 10);
+}
+
+/**
+ * Verify the registry HTTP server is accepting TCP connections on localhost.
+ * @throws {TunnelAvailabilityError} When the port is closed or the probe times out.
+ */
+async function assertRegistryPortAcceptingConnections(
+  port: number,
+): Promise<void> {
+  const registryAddress = `${TUNNEL_REGISTRY_HOST}:${port}`;
+  const unreachableMessage = `Tunnel registry at ${registryAddress} is not reachable. Please run the tunnel creation script first`;
+
+  await new Promise<void>((resolve, reject) => {
+    const socket = net.connect({ host: TUNNEL_REGISTRY_HOST, port });
+    const timer = setTimeout(() => {
+      socket.destroy();
+      reject(new TunnelAvailabilityError(unreachableMessage));
+    }, TUNNEL_REGISTRY_PORT_PROBE_TIMEOUT_MS);
+
+    const finish = (err?: Error) => {
+      clearTimeout(timer);
+      socket.removeAllListeners();
+      if (!socket.destroyed) {
+        socket.destroy();
+      }
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    };
+
+    socket.once('connect', () => finish());
+    socket.once('error', (err: NodeJS.ErrnoException) => {
+      if (err.code === 'ECONNREFUSED' || err.code === 'ENOTFOUND') {
+        finish(new TunnelAvailabilityError(unreachableMessage, { cause: err }));
+        return;
+      }
+      finish(
+        new TunnelAvailabilityError(
+          `Tunnel registry port probe failed for ${registryAddress}: ${err.message}`,
+          { cause: err },
+        ),
+      );
+    });
+  });
+}
+
+/** Map a registry entry to a flat tunnel endpoint for RSD connect. */
+function mapEntryToEndpoint(entry: TunnelRegistryEntry): TunnelEndpoint {
+  return {
+    host: entry.address,
+    port: entry.rsdPort,
+    udid: entry.udid,
+    packetStreamPort: entry.packetStreamPort,
+  };
+}
+
+/**
+ * Build a strict tunnel registry API client (caller supplies port via base URL).
+ */
+function createTunnelRegistryClient(
+  port: number,
+  options: TunnelApiClientOptions = {},
+): TunnelApiClient {
+  return new TunnelApiClient(
+    `http://${TUNNEL_REGISTRY_HOST}:${port}${TUNNEL_REGISTRY_API_BASE_PATH}`,
+    options,
+  );
+}
+
+/** Strongbox port, TCP probe, then a strict registry client with the lookup timeout. */
+async function createValidatedStrictRegistryClient(): Promise<TunnelApiClient> {
+  const port = await readTunnelRegistryPort();
+  await assertRegistryPortAcceptingConnections(port);
+  return createTunnelRegistryClient(port, {
+    strict: true,
+    timeoutMs: TUNNEL_REGISTRY_HTTP_TIMEOUT_MS,
+  });
+}

--- a/src/lib/tunnel/tunnel-availability.ts
+++ b/src/lib/tunnel/tunnel-availability.ts
@@ -9,23 +9,16 @@ import {
   TUNNEL_REGISTRY_HTTP_TIMEOUT_MS,
   TUNNEL_REGISTRY_PORT_PROBE_TIMEOUT_MS,
 } from './constants.js';
+import { TunnelAvailabilityError } from './errors.js';
 import {
   TunnelApiClient,
   type TunnelApiClientOptions,
   type TunnelEndpoint,
 } from './tunnel-api-client.js';
 
+export { TunnelAvailabilityError };
+
 const TUNNEL_REGISTRY_PORT = 'tunnelRegistryPort';
-
-export class TunnelAvailabilityError extends Error {
-  readonly code = 'ERR_TUNNEL_AVAILABILITY';
-
-  constructor(message: string, options?: { cause?: unknown }) {
-    super(message, options);
-    this.name = new.target.name;
-    Object.setPrototypeOf(this, new.target.prototype);
-  }
-}
 
 /**
  * Resolve tunnel registry metadata for a device (host, RSD port, packet stream).
@@ -36,17 +29,7 @@ export async function getTunnelForDevice(
   udid: string,
 ): Promise<TunnelEndpoint> {
   const client = await createValidatedStrictRegistryClient();
-
-  let entry: TunnelRegistryEntry | null;
-  try {
-    entry = await client.getTunnelByUdid(udid);
-  } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
-    throw new TunnelAvailabilityError(
-      `Failed to reach tunnel registry: ${detail}`,
-      { cause: err },
-    );
-  }
+  const entry = await client.getTunnelByUdid(udid);
 
   if (!entry) {
     throw new TunnelAvailabilityError(
@@ -67,20 +50,12 @@ export async function getTunnelForDevice(
  */
 export async function getAvailableDevices(): Promise<string[]> {
   const client = await createValidatedStrictRegistryClient();
-  try {
-    return await client.getAvailableDevices();
-  } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
-    throw new TunnelAvailabilityError(
-      `Failed to reach tunnel registry: ${detail}`,
-      { cause: err },
-    );
-  }
+  return await client.getAvailableDevices();
 }
 
 /**
  * Read the tunnel registry HTTP port from strongbox.
- * @throws {TunnelAvailabilityError} When the port was never stored (tunnel-creation not run).
+ * @throws {TunnelAvailabilityError} When the port was never stored or is not a valid TCP port.
  */
 async function readTunnelRegistryPort(): Promise<number> {
   const box = strongbox(TUNNEL_CONTAINER_NAME);
@@ -94,7 +69,14 @@ async function readTunnelRegistryPort(): Promise<number> {
       'Tunnel registry port not found. Please run the tunnel creation script first',
     );
   }
-  return Number.parseInt(String(tunnelRegistryPort), 10);
+  const stored = String(tunnelRegistryPort).trim();
+  const port = Number.parseInt(stored, 10);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new TunnelAvailabilityError(
+      `Tunnel registry port "${stored}" is invalid; expected an integer between 1 and 65535`,
+    );
+  }
+  return port;
 }
 
 /**

--- a/src/lib/tunnel/tunnel-registry-routes.ts
+++ b/src/lib/tunnel/tunnel-registry-routes.ts
@@ -1,11 +1,6 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { match } from 'path-to-regexp';
 
-/**
- * Base URL path for the tunnel registry HTTP API.
- */
-export const TUNNEL_REGISTRY_API_BASE_PATH = '/remotexpc/tunnels';
-
 export type RouteHandler = (
   req: IncomingMessage,
   res: ServerResponse,

--- a/src/lib/tunnel/tunnel-registry-server.ts
+++ b/src/lib/tunnel/tunnel-registry-server.ts
@@ -2,9 +2,9 @@ import * as http from 'node:http';
 
 import { getLogger } from '../logger.js';
 import type { TunnelRegistry, TunnelRegistryEntry } from '../types.js';
+import { TUNNEL_REGISTRY_API_BASE_PATH } from './constants.js';
 import {
   type RouteRecord,
-  TUNNEL_REGISTRY_API_BASE_PATH,
   createRouteDispatcher,
   getRequestPathname,
 } from './tunnel-registry-routes.js';

--- a/src/services.ts
+++ b/src/services.ts
@@ -1,14 +1,8 @@
-import { BaseItem, strongbox } from '@appium/strongbox';
-
-import { TUNNEL_CONTAINER_NAME } from './constants.js';
 import { getLogger } from './lib/logger.js';
 import type { RemoteXpcConnection } from './lib/remote-xpc/remote-xpc-connection.js';
 import { TunnelManager, rsdSessionLockKey } from './lib/tunnel/index.js';
-import {
-  TunnelApiClient,
-  type TunnelApiClientOptions,
-  type TunnelEndpoint,
-} from './lib/tunnel/tunnel-api-client.js';
+import type { TunnelEndpoint } from './lib/tunnel/tunnel-api-client.js';
+import { getTunnelForDevice } from './lib/tunnel/tunnel-availability.js';
 import type {
   DVTInstruments,
   SyslogService as SyslogServiceType,
@@ -40,21 +34,15 @@ import SyslogService from './services/ios/syslog-service/index.js';
 import { DvtTestmanagedProxyService } from './services/ios/testmanagerd/index.js';
 import { WebInspectorService } from './services/ios/webinspector/index.js';
 
-const TUNNEL_REGISTRY_PORT = 'tunnelRegistryPort';
 const log = getLogger('Services');
 
 /** Pause after closing discovery RSD so device `remoted` can accept the next session. */
 const RSD_RELEASE_DELAY_MS = 300;
 
-export class TunnelAvailabilityError extends Error {
-  readonly code = 'ERR_TUNNEL_AVAILABILITY';
-
-  constructor(message: string) {
-    super(message);
-    this.name = new.target.name;
-    Object.setPrototypeOf(this, new.target.prototype);
-  }
-}
+export {
+  getAvailableDevices,
+  getTunnelForDevice,
+} from './lib/tunnel/tunnel-availability.js';
 
 /**
  * Start the diagnostics service for the given device UDID.
@@ -444,45 +432,6 @@ export async function startXCTestServices(
 }
 
 /**
- * Returns the list of device UDIDs currently in the tunnel registry.
- * Used to include tunnel-only devices (e.g. Apple TV over WiFi)
- * in the "connected devices" list for session validation.
- *
- * @returns Promise resolving to an array of UDIDs. Returns [] only when the
- * registry is reachable and reports no tunnels.
- * @throws When tunnel registry port is missing or empty in strongbox.
- * @throws When registry is unreachable or response is invalid.
- */
-export async function getAvailableDevices(): Promise<string[]> {
-  const client = await getTunnelRegistryClient({ strict: true });
-  return await client.getAvailableDevices();
-}
-
-/**
- * Resolve tunnel registry metadata for a device (host, RSD port, packet stream).
- * Does not open a discovery `RemoteXpcConnection`; use {@link withRemoteXpcConnection}
- * when service ports must be looked up via RSD.
- */
-export async function getTunnelForDevice(
-  udid: string,
-): Promise<TunnelEndpoint> {
-  const tunnelApiClient = await getTunnelRegistryClient();
-  const tunnelExists = await tunnelApiClient.hasTunnel(udid);
-  if (!tunnelExists) {
-    throw new TunnelAvailabilityError(
-      `No tunnel found for device ${udid}. Please run the tunnel creation script first`,
-    );
-  }
-  const tunnelConnection = await tunnelApiClient.getTunnelConnection(udid);
-  if (!tunnelConnection) {
-    throw new TunnelAvailabilityError(
-      `Failed to get tunnel connection details for device ${udid}`,
-    );
-  }
-  return tunnelConnection;
-}
-
-/**
  * Run `fn` with a freshly opened discovery `RemoteXpcConnection` and close
  * that connection unconditionally when `fn` settles. Use this whenever a
  * `start*Service` helper only needs the RSD to discover a service port:
@@ -548,30 +497,3 @@ async function startSyslogWithServiceName(
     serviceDescriptor: remoteXPC.findService(serviceName),
   }));
 }
-
-// #region Private Functions
-
-/**
- * Build a tunnel registry API client from the stored registry port.
- */
-async function getTunnelRegistryClient(
-  options: TunnelApiClientOptions = {},
-): Promise<TunnelApiClient> {
-  const box = strongbox(TUNNEL_CONTAINER_NAME);
-  const item = new BaseItem(TUNNEL_REGISTRY_PORT, box);
-  const tunnelRegistryPort = await item.read();
-  if (
-    tunnelRegistryPort === undefined ||
-    String(tunnelRegistryPort).trim() === ''
-  ) {
-    throw new TunnelAvailabilityError(
-      'Tunnel registry port not found. Please run the tunnel creation script first',
-    );
-  }
-  return new TunnelApiClient(
-    `http://127.0.0.1:${tunnelRegistryPort}/remotexpc/tunnels`,
-    options,
-  );
-}
-
-// #endregion

--- a/test/integration/tunnel-test.ts
+++ b/test/integration/tunnel-test.ts
@@ -5,9 +5,9 @@ import {
   PacketStreamClient,
   TunnelManager,
 } from '../../src/lib/tunnel/index.js';
+import { getTunnelForDevice } from '../../src/lib/tunnel/tunnel-availability.js';
 import type { SyslogService as ISyslogService } from '../../src/lib/types.js';
 import {
-  getTunnelForDevice,
   startSyslogBinaryService,
   startSyslogTextService,
 } from '../../src/services.js';

--- a/test/unit/services/start-services-cleanup.spec.ts
+++ b/test/unit/services/start-services-cleanup.spec.ts
@@ -51,14 +51,15 @@ async function loadServicesWithStubs(
         }
       },
     },
-    '../../../src/lib/tunnel/tunnel-api-client.js': {
-      TunnelApiClient: class {
-        async hasTunnel() {
-          return true;
-        }
-        async getTunnelConnection() {
-          return { host: '127.0.0.1', port: 1234 };
-        }
+    '../../../src/lib/tunnel/tunnel-availability.js': {
+      getTunnelForDevice: async () => ({
+        host: '127.0.0.1',
+        port: 1234,
+        udid: 'test-udid',
+        packetStreamPort: undefined as number | undefined,
+      }),
+      TunnelAvailabilityError: class extends Error {
+        readonly code = 'ERR_TUNNEL_AVAILABILITY';
       },
     },
     '../../../src/lib/tunnel/index.js': {
@@ -166,6 +167,71 @@ describe('start*Service — discovery RemoteXpcConnection lifecycle', function (
         findServiceStub.calledOnceWith('com.apple.os_trace_relay.shim.remote'),
         'expected findService("com.apple.os_trace_relay.shim.remote")',
       ).to.equal(true);
+    });
+  });
+
+  describe('tunnel lookup failure', function () {
+    it('does not open RSD when tunnel resolution fails', async function () {
+      const connectSpy = sinon.spy();
+      const remoteXPCStub: RemoteXpcStub = {
+        findService: sinon.stub(),
+        close: sinon.spy(),
+      };
+
+      const services = await esmock('../../../src/services.js', {
+        '@appium/strongbox': {
+          strongbox: () => ({}),
+          BaseItem: class {
+            async read() {
+              return '12345';
+            }
+          },
+        },
+        '../../../src/lib/tunnel/tunnel-availability.js': {
+          TunnelAvailabilityError: class extends Error {
+            readonly code = 'ERR_TUNNEL_AVAILABILITY';
+            constructor(message: string) {
+              super(message);
+              this.name = 'TunnelAvailabilityError';
+            }
+          },
+          getTunnelForDevice: async () => {
+            throw new (class extends Error {
+              readonly code = 'ERR_TUNNEL_AVAILABILITY';
+              constructor() {
+                super(
+                  'No tunnel found for device test-udid. Please run the tunnel creation script first',
+                );
+              }
+            })();
+          },
+        },
+        '../../../src/lib/tunnel/index.js': {
+          TunnelManager: {
+            rsdSessionLockKey: (host: string, port: number) =>
+              `${host}:${port}`,
+            runSerializedRsdSession: async (
+              _lockKey: string,
+              fn: () => Promise<unknown>,
+            ) => fn(),
+            connectRemoteXPCUnlocked: connectSpy,
+          },
+        },
+      });
+
+      let caught: Error | undefined;
+      try {
+        await services.startAfcService('test-udid');
+      } catch (err) {
+        caught = err as Error;
+      }
+
+      expect(caught, 'expected tunnel lookup to fail').to.exist;
+      expect(
+        connectSpy.called,
+        'connectRemoteXPCUnlocked must not run when tunnel lookup fails',
+      ).to.equal(false);
+      expect(remoteXPCStub.close.called).to.equal(false);
     });
   });
 

--- a/test/unit/services/tunnel-availability-error.spec.ts
+++ b/test/unit/services/tunnel-availability-error.spec.ts
@@ -1,38 +1,35 @@
 import { expect } from 'chai';
 import esmock from 'esmock';
 
-type TunnelApiClientMock = {
-  hasTunnel?: () => Promise<boolean>;
-  getTunnelConnection?: () => Promise<unknown>;
-};
+class MockTunnelAvailabilityError extends Error {
+  readonly code = 'ERR_TUNNEL_AVAILABILITY';
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'TunnelAvailabilityError';
+  }
+}
 
 async function loadServices(
-  tunnelRegistryPort: string | undefined,
-  tunnelApiClientMock?: TunnelApiClientMock,
+  tunnelAvailabilityOverrides: Record<string, unknown> = {},
 ) {
-  const dependencyMocks: Record<string, unknown> = {
-    '@appium/strongbox': {
-      strongbox: () => ({}),
-      BaseItem: class {
-        async read() {
-          return tunnelRegistryPort;
-        }
+  return await esmock('../../../src/services.js', {
+    '../../../src/lib/tunnel/tunnel-availability.js': {
+      TunnelAvailabilityError: MockTunnelAvailabilityError,
+      getAvailableDevices: async () => {
+        throw new MockTunnelAvailabilityError(
+          'Tunnel registry port not found. Please run the tunnel creation script first',
+        );
       },
+      getTunnelForDevice: async () => ({
+        host: '127.0.0.1',
+        port: 1234,
+        udid: 'test-udid',
+        packetStreamPort: undefined as number | undefined,
+      }),
+      ...tunnelAvailabilityOverrides,
     },
-  };
-
-  if (tunnelApiClientMock) {
-    dependencyMocks['../../../src/lib/tunnel/tunnel-api-client.js'] = {
-      TunnelApiClient: class {
-        hasTunnel = tunnelApiClientMock.hasTunnel ?? (async () => true);
-        getTunnelConnection =
-          tunnelApiClientMock.getTunnelConnection ??
-          (async () => ({ host: '127.0.0.1', port: 1234 }));
-      },
-    };
-  }
-
-  return await esmock('../../../src/services.js', dependencyMocks);
+  });
 }
 
 async function expectTunnelAvailabilityError(
@@ -52,7 +49,7 @@ async function expectTunnelAvailabilityError(
 
 describe('TunnelAvailabilityError', function () {
   it('throws a dedicated error when tunnel registry port is missing', async function () {
-    const services = await loadServices(undefined);
+    const services = await loadServices();
     await expectTunnelAvailabilityError(
       async () => await services.getAvailableDevices(),
       'Tunnel registry port not found. Please run the tunnel creation script first',
@@ -61,24 +58,16 @@ describe('TunnelAvailabilityError', function () {
   });
 
   it('throws a dedicated error when no tunnel exists for a device', async function () {
-    const services = await loadServices('12345', {
-      hasTunnel: async () => false,
+    const services = await loadServices({
+      getTunnelForDevice: async () => {
+        throw new MockTunnelAvailabilityError(
+          'No tunnel found for device test-udid. Please run the tunnel creation script first',
+        );
+      },
     });
     await expectTunnelAvailabilityError(
       async () => await services.getTunnelForDevice('test-udid'),
       'No tunnel found for device test-udid. Please run the tunnel creation script first',
-      services,
-    );
-  });
-
-  it('throws a dedicated error when tunnel details cannot be resolved', async function () {
-    const services = await loadServices('12345', {
-      hasTunnel: async () => true,
-      getTunnelConnection: async () => undefined,
-    });
-    await expectTunnelAvailabilityError(
-      async () => await services.getTunnelForDevice('test-udid'),
-      'Failed to get tunnel connection details for device test-udid',
       services,
     );
   });

--- a/test/unit/services/tunnel-availability-error.spec.ts
+++ b/test/unit/services/tunnel-availability-error.spec.ts
@@ -35,13 +35,12 @@ async function loadServices(
 async function expectTunnelAvailabilityError(
   action: () => Promise<unknown>,
   expectedMessage: string,
-  services: { TunnelAvailabilityError: new (...args: any[]) => Error },
 ) {
   try {
     await action();
     expect.fail('Expected action to throw');
   } catch (err) {
-    expect(err).to.be.instanceOf(services.TunnelAvailabilityError);
+    expect(err).to.be.instanceOf(MockTunnelAvailabilityError);
     expect((err as Error).message).to.equal(expectedMessage);
     expect((err as { code?: string }).code).to.equal('ERR_TUNNEL_AVAILABILITY');
   }
@@ -53,7 +52,6 @@ describe('TunnelAvailabilityError', function () {
     await expectTunnelAvailabilityError(
       async () => await services.getAvailableDevices(),
       'Tunnel registry port not found. Please run the tunnel creation script first',
-      services,
     );
   });
 
@@ -68,7 +66,6 @@ describe('TunnelAvailabilityError', function () {
     await expectTunnelAvailabilityError(
       async () => await services.getTunnelForDevice('test-udid'),
       'No tunnel found for device test-udid. Please run the tunnel creation script first',
-      services,
     );
   });
 });

--- a/test/unit/tunnel/tunnel-availability.spec.ts
+++ b/test/unit/tunnel/tunnel-availability.spec.ts
@@ -1,0 +1,148 @@
+import { expect } from 'chai';
+import esmock from 'esmock';
+
+const TEST_UDID = 'test-udid';
+const REGISTRY_PORT = 12_345;
+
+type TunnelApiClientMock = {
+  getTunnelByUdid?: (udid: string) => Promise<unknown>;
+};
+
+function createNetSocketMock(mode: 'connect' | 'refuse') {
+  const handlers: Record<string, Array<(arg?: unknown) => void>> = {};
+  const socket = {
+    once(event: string, handler: (arg?: unknown) => void) {
+      handlers[event] ??= [];
+      handlers[event].push(handler);
+    },
+    destroy() {},
+    removeAllListeners() {},
+  };
+
+  process.nextTick(() => {
+    if (mode === 'connect') {
+      for (const handler of handlers.connect ?? []) {
+        handler();
+      }
+      return;
+    }
+    const err = Object.assign(new Error('connect ECONNREFUSED'), {
+      code: 'ECONNREFUSED',
+    });
+    for (const handler of handlers.error ?? []) {
+      handler(err);
+    }
+  });
+
+  return socket;
+}
+
+async function loadTunnelAvailability(
+  options: {
+    tunnelRegistryPort?: string | undefined;
+    netMode?: 'connect' | 'refuse';
+    tunnelApiClientMock?: TunnelApiClientMock;
+  } = {},
+) {
+  const dependencyMocks: Record<string, unknown> = {
+    '@appium/strongbox': {
+      strongbox: () => ({}),
+      BaseItem: class {
+        async read() {
+          return options.tunnelRegistryPort;
+        }
+      },
+    },
+    'node:net': {
+      connect: () => createNetSocketMock(options.netMode ?? 'connect'),
+    },
+  };
+
+  if (options.tunnelApiClientMock) {
+    dependencyMocks['../../../src/lib/tunnel/tunnel-api-client.js'] = {
+      TunnelApiClient: class {
+        getTunnelByUdid =
+          options.tunnelApiClientMock?.getTunnelByUdid ?? (async () => null);
+      },
+    };
+  }
+
+  return await esmock(
+    '../../../src/lib/tunnel/tunnel-availability.js',
+    dependencyMocks,
+  );
+}
+
+async function expectTunnelAvailabilityError(
+  action: () => Promise<unknown>,
+  expectedMessage: string,
+  TunnelAvailabilityError: new (message: string) => Error,
+) {
+  try {
+    await action();
+    expect.fail('Expected action to throw');
+  } catch (err) {
+    expect(err).to.be.instanceOf(TunnelAvailabilityError);
+    expect((err as Error).message).to.equal(expectedMessage);
+    expect((err as { code?: string }).code).to.equal('ERR_TUNNEL_AVAILABILITY');
+  }
+}
+
+describe('tunnel-availability', function () {
+  it('throws when tunnel registry port is missing in strongbox', async function () {
+    const mod = await loadTunnelAvailability({ tunnelRegistryPort: undefined });
+    await expectTunnelAvailabilityError(
+      async () => await mod.getTunnelForDevice(TEST_UDID),
+      'Tunnel registry port not found. Please run the tunnel creation script first',
+      mod.TunnelAvailabilityError,
+    );
+  });
+
+  it('throws quickly when registry TCP port refuses connections', async function () {
+    const mod = await loadTunnelAvailability({
+      tunnelRegistryPort: String(REGISTRY_PORT),
+      netMode: 'refuse',
+    });
+    await expectTunnelAvailabilityError(
+      async () => await mod.getTunnelForDevice(TEST_UDID),
+      `Tunnel registry at 127.0.0.1:${REGISTRY_PORT} is not reachable. Please run the tunnel creation script first`,
+      mod.TunnelAvailabilityError,
+    );
+  });
+
+  it('throws when GET by UDID returns no entry', async function () {
+    const mod = await loadTunnelAvailability({
+      tunnelRegistryPort: String(REGISTRY_PORT),
+      tunnelApiClientMock: {
+        getTunnelByUdid: async () => null,
+      },
+    });
+    await expectTunnelAvailabilityError(
+      async () => await mod.getTunnelForDevice(TEST_UDID),
+      `No tunnel found for device ${TEST_UDID}. Please run the tunnel creation script first`,
+      mod.TunnelAvailabilityError,
+    );
+  });
+
+  it('returns endpoint when GET by UDID returns an entry', async function () {
+    const mod = await loadTunnelAvailability({
+      tunnelRegistryPort: String(REGISTRY_PORT),
+      tunnelApiClientMock: {
+        getTunnelByUdid: async () => ({
+          udid: TEST_UDID,
+          address: 'fe80::1',
+          rsdPort: 62078,
+          packetStreamPort: 9100,
+        }),
+      },
+    });
+
+    const endpoint = await mod.getTunnelForDevice(TEST_UDID);
+    expect(endpoint).to.deep.equal({
+      host: 'fe80::1',
+      port: 62078,
+      udid: TEST_UDID,
+      packetStreamPort: 9100,
+    });
+  });
+});

--- a/test/unit/tunnel/tunnel-availability.spec.ts
+++ b/test/unit/tunnel/tunnel-availability.spec.ts
@@ -98,6 +98,15 @@ describe('tunnel-availability', function () {
     );
   });
 
+  it('throws when tunnel registry port is not a valid TCP port', async function () {
+    const mod = await loadTunnelAvailability({ tunnelRegistryPort: '70000' });
+    await expectTunnelAvailabilityError(
+      async () => await mod.getTunnelForDevice(TEST_UDID),
+      'Tunnel registry port "70000" is invalid; expected an integer between 1 and 65535',
+      mod.TunnelAvailabilityError,
+    );
+  });
+
   it('throws quickly when registry TCP port refuses connections', async function () {
     const mod = await loadTunnelAvailability({
       tunnelRegistryPort: String(REGISTRY_PORT),


### PR DESCRIPTION
## Summary

When the tunnel registry was down or a UDID had no tunnel entry, `getTunnelForDevice` could still reach `connectRemoteXPCUnlocked` and wait ~13s on RSD. Lookup used a non-strict registry client (10s timeout) plus duplicate HTTP (`hasTunnel` then `getTunnelConnection`).

This PR adds a dedicated tunnel availability path that fails in under ~500ms and never opens RSD when the registry or tunnel entry is missing.

## What changed

- New `src/lib/tunnel/tunnel-availability.ts` centralizes registry checks:
  - Read registry port from strongbox
  - TCP probe `127.0.0.1:{port}` (300ms) before HTTP
  - Single strict `GET /remotexpc/tunnels/{udid}` (500ms) per device lookup
  - Same validated client path for `getAvailableDevices` (list registry)
- `TunnelAvailabilityError` (`ERR_TUNNEL_AVAILABILITY`) with optional `cause` for wrapped fetch/socket errors; probe messages include `host:port` (e.g. `Tunnel registry at 127.0.0.1:42314 is not reachable…`)
- Tunnel-specific constants moved to `src/lib/tunnel/constants.ts` (`TUNNEL_REGISTRY_HOST`, `TUNNEL_REGISTRY_API_BASE_PATH`, timeouts)
- `services.ts` simplified: `withRemoteXpcConnection` still calls `getTunnelForDevice`; `Services` re-exports `getTunnelForDevice` and `getAvailableDevices` for **appium-xcuitest-driver** (`remotexpc.Services.getTunnelForDevice`)
- Package root exports `TunnelAvailabilityError`, `getTunnelForDevice`, `getAvailableDevices` from the tunnel module

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| No strongbox port / registry not listening / UDID not in registry | Slow or ambiguous failure; could attempt RSD | `TunnelAvailabilityError` in ~300–500ms; **no** `connectRemoteXPCUnlocked` |
| Registry up, tunnel listed | Works | Unchanged |
| Stale registry entry, dead tunnel process | ~13s RSD timeout | Still possible on RSD (out of scope) |

## Tests

- `test/unit/tunnel/tunnel-availability.spec.ts` — missing port, TCP refuse, GET 404, GET 200
- Updated `tunnel-availability-error.spec.ts` and `start-services-cleanup.spec.ts` (lookup failure must not call `connectRemoteXPCUnlocked`)

## Follow-up

- **appium-xcuitest-driver**: treat `TunnelAvailabilityError` in syslog / optional paths (e.g. `ios-device-log.ts`) so RemoteXPC is skipped immediately when the registry is down