### PR TITLE
chore(tunnel): persist tunnel port to strongBox

### DIFF
--- a/src/lib/tunnel/tunnel-registry-server.ts
+++ b/src/lib/tunnel/tunnel-registry-server.ts
@@ -1,5 +1,7 @@
+import { BaseItem, strongbox } from '@appium/strongbox';
 import * as http from 'node:http';
 
+import { TUNNEL_CONTAINER_NAME } from '../../constants.js';
 import { getLogger } from '../logger.js';
 import type { TunnelRegistry, TunnelRegistryEntry } from '../types.js';
 import { TUNNEL_REGISTRY_API_BASE_PATH } from './constants.js';
@@ -391,6 +393,9 @@ export async function startTunnelRegistryServer(
 ): Promise<TunnelRegistryServer> {
   const server = new TunnelRegistryServer(tunnelInfos, port);
   await server.start();
+  const box = strongbox(TUNNEL_CONTAINER_NAME);
+  const item = new BaseItem('tunnelRegistryPort', box);
+  await item.write(String(port));
   return server;
 }
 

--- a/src/lib/tunnel/tunnel-registry-server.ts
+++ b/src/lib/tunnel/tunnel-registry-server.ts
@@ -393,9 +393,14 @@ export async function startTunnelRegistryServer(
 ): Promise<TunnelRegistryServer> {
   const server = new TunnelRegistryServer(tunnelInfos, port);
   await server.start();
-  const box = strongbox(TUNNEL_CONTAINER_NAME);
-  const item = new BaseItem('tunnelRegistryPort', box);
-  await item.write(String(port));
+  try {
+    const box = strongbox(TUNNEL_CONTAINER_NAME);
+    const item = new BaseItem('tunnelRegistryPort', box);
+    await item.write(String(port));
+  } catch (err) {
+    await server.stop();
+    throw err;
+  }
   return server;
 }
 


### PR DESCRIPTION
This PR fixes a bug where the tunnel was connected to registry because it was never stored persistently. It caused new Mac devices not be able to connect to the tunnel despite running the creation script.

The fix is to store the tunnel port in a strongbox and write to that.