### PR TITLE
fix(afc): coalesce file pushes into large WRITEs to fix large-app install freeze

### DIFF
--- a/src/services/ios/afc/codec.ts
+++ b/src/services/ios/afc/codec.ts
@@ -8,7 +8,8 @@ import {
   AFC_OPERATION_TIMEOUT_MS,
   NULL_BYTE,
 } from './constants.js';
-import { AfcError, AfcFopenMode, AfcOpcode } from './enums.js';
+import type { AfcFopenMode } from './enums.js';
+import { AfcError, AfcOpcode } from './enums.js';
 import { AfcConnectionError } from './errors.js';
 
 export interface AfcHeader {
@@ -211,22 +212,15 @@ export async function sendAfcPacket(
   thisLenOverride?: number,
 ): Promise<void> {
   const header = encodeHeader(op, packetNum, payload.length, thisLenOverride);
+  // Write the header and payload as a single buffer. Two separate writes put the
+  // 40-byte header in its own tiny TCP segment, which (together with the peer's
+  // delayed ACK) is exactly what stalls the serial AFC transfer loop. Coalescing
+  // into one write keeps each AFC packet in a single flush and halves syscalls;
+  // the header is tiny, so prepending it to the payload is cheap relative to the
+  // round-trip it saves.
+  const packet = payload.length ? Buffer.concat([header, payload]) : header;
   await new Promise<void>((resolve, reject) => {
-    socket.write(header, (err) => {
-      if (err) {
-        return reject(err);
-      }
-      if (payload.length) {
-        socket.write(payload, (err2) => {
-          if (err2) {
-            return reject(err2);
-          }
-          resolve();
-        });
-      } else {
-        resolve();
-      }
-    });
+    socket.write(packet, (err) => (err ? reject(err) : resolve()));
   });
 }
 
@@ -391,6 +385,12 @@ export async function createRawServiceSocket(
   const socket = await new Promise<net.Socket>((resolve, reject) => {
     const conn = net.createConnection({ host, port }, () => {
       conn.setKeepAlive(true);
+      // Disable Nagle's algorithm. These are interactive request/response and
+      // bulk-transfer channels: a small packet (e.g. a 40-byte AFC header) must
+      // not be held back waiting for the previous segment's ACK. Without this,
+      // the serial AFC write loop stalls to ~1 chunk/sec on the delayed-ACK
+      // timer, which is what makes large file pushes appear to hang.
+      conn.setNoDelay(true);
       resolve(conn);
     });
     conn.setTimeout(timeoutMs, () => {

--- a/src/services/ios/afc/constants.ts
+++ b/src/services/ios/afc/constants.ts
@@ -10,6 +10,22 @@ export const AFCMAGIC = Buffer.from('CFA6LPAA', 'ascii');
 // IO chunk sizes
 export const MAXIMUM_READ_SIZE = 4 * 1024 * 1024; // 4 MiB
 
+// Maximum bytes per AFC WRITE packet.
+//
+// Emitting one WRITE per 64 KiB source chunk turns a large push into hundreds of
+// serial request/response round-trips, each of which can stall on the tunnel
+// (the "app install freeze"). We coalesce the stream into WRITEs of up to this
+// size, cutting round-trips to ~fileSize/MAXIMUM_WRITE_SIZE.
+//
+// The size is bounded by two competing constraints:
+//  - large enough that round-trip count is small (unlike the old 64 KiB);
+//  - small enough that a single WRITE reliably drains + is acked within
+//    AFC_OPERATION_TIMEOUT_MS even on a slow tunnel (~0.5-1 MB/s). At 4 MiB that
+//    is ~4-8s per write, comfortably under the timeout, while still ~60x fewer
+//    round-trips than 64 KiB. (pymobiledevice3 uses 1 GiB but buffers the whole
+//    file in memory; we stream, so we keep this bounded and RAM-safe.)
+export const MAXIMUM_WRITE_SIZE = 4 * 1024 * 1024; // 4 MiB
+
 // Mapping of textual fopen modes to AFC modes
 export const AFC_FOPEN_TEXTUAL_MODES: Record<string, AfcFopenMode> = {
   r: AfcFopenMode.RDONLY,

--- a/src/services/ios/afc/index.ts
+++ b/src/services/ios/afc/index.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import type net from 'node:net';
 import path from 'node:path';
-import { Readable, Writable } from 'node:stream';
+import type { Readable, Writable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 
 import { getLogger } from '../../../lib/logger.js';
@@ -29,6 +29,7 @@ import {
   AFC_LOCK_EX,
   AFC_LOCK_UN,
   AFC_WRITE_THIS_LENGTH,
+  MAXIMUM_WRITE_SIZE,
 } from './constants.js';
 import { AfcError, AfcFileMode, AfcOpcode } from './enums.js';
 import { AfcConnectionError } from './errors.js';
@@ -226,12 +227,17 @@ export class AfcService {
     );
   }
 
-  createWriteStream(handle: bigint, chunkSize?: number): Writable {
+  createWriteStream(
+    handle: bigint,
+    chunkSize?: number,
+    onProgress?: (bytesWritten: number) => void,
+  ): Writable {
     return createAfcWriteStream(
       handle,
       this._dispatch.bind(this),
       this._receive.bind(this),
       chunkSize,
+      onProgress,
     );
   }
 
@@ -250,7 +256,7 @@ export class AfcService {
   async fwrite(
     handle: bigint,
     data: Buffer,
-    chunkSize = data.length,
+    chunkSize = MAXIMUM_WRITE_SIZE,
   ): Promise<void> {
     log.debug(`Writing ${data.length} bytes to handle ${handle}`);
     const effectiveChunkSize = chunkSize;
@@ -342,11 +348,22 @@ export class AfcService {
     return stream;
   }
 
-  async writeFromStream(filePath: string, stream: Readable): Promise<void> {
+  async writeFromStream(
+    filePath: string,
+    stream: Readable,
+    options: {
+      chunkSize?: number;
+      onProgress?: (bytesWritten: number) => void;
+    } = {},
+  ): Promise<void> {
     log.debug(`Writing stream to file: ${filePath}`);
     const handle = await this.fopen(filePath, 'w');
     await this._lockFile(handle);
-    const writeStream = this.createWriteStream(handle);
+    const writeStream = this.createWriteStream(
+      handle,
+      options.chunkSize,
+      options.onProgress,
+    );
     try {
       await pipeline(stream, writeStream);
       log.debug(`Successfully wrote file: ${filePath}`);

--- a/src/services/ios/afc/stream-utils.ts
+++ b/src/services/ios/afc/stream-utils.ts
@@ -1,7 +1,7 @@
 import { Readable, Writable } from 'node:stream';
 
-import { buildReadPayload, nextReadChunkSize, writeUInt64LE } from './codec.js';
-import { AFC_WRITE_THIS_LENGTH } from './constants.js';
+import { buildReadPayload, nextReadChunkSize } from './codec.js';
+import { AFC_WRITE_THIS_LENGTH, MAXIMUM_WRITE_SIZE } from './constants.js';
 import { AfcError, AfcOpcode } from './enums.js';
 
 type AfcDispatcher = (op: AfcOpcode, payload: Buffer) => Promise<void>;
@@ -57,13 +57,73 @@ export function createAfcReadStream(
 
 /**
  * Create a writable stream that pushes data over AFC WRITE requests.
+ *
+ * Incoming data is coalesced into WRITE packets of up to `chunkSize` bytes
+ * rather than emitting one WRITE per (typically 64 KiB) source chunk. Each WRITE
+ * is a separate device round-trip, and over the RSD tunnel every round-trip can
+ * stall ~1s on the peer's delayed ACK; coalescing keeps round-trips at
+ * ~fileSize/chunkSize while bounding buffered memory to ~chunkSize (we never
+ * hold the whole file in RAM). See MAXIMUM_WRITE_SIZE.
  */
 export function createAfcWriteStream(
   handle: bigint,
   dispatch: AfcWriteDispatcher,
   receive: () => Promise<{ status: AfcError; data: Buffer }>,
-  chunkSize?: number,
+  chunkSize: number = MAXIMUM_WRITE_SIZE,
+  onProgress?: (bytesWritten: number) => void,
 ): Writable {
+  if (!Number.isInteger(chunkSize) || chunkSize <= 0) {
+    throw new TypeError(
+      `createAfcWriteStream: chunkSize must be a positive integer (got ${chunkSize})`,
+    );
+  }
+
+  // Buffered-but-not-yet-written source chunks and their total length.
+  const pending: Buffer[] = [];
+  let pendingLen = 0;
+  // Total bytes acknowledged written by the device so far.
+  let written = 0;
+
+  // Peel exactly `n` bytes off the front of `pending`, build a single AFC WRITE
+  // payload (8-byte handle + data) so it goes out as one packet, and await the
+  // status. `n` is always <= pendingLen.
+  const writeNextBlock = async (n: number): Promise<void> => {
+    const payload = Buffer.allocUnsafe(8 + n);
+    payload.writeBigUInt64LE(handle, 0);
+
+    let copied = 0;
+    while (copied < n) {
+      const head = pending[0];
+      const need = n - copied;
+      if (head.length <= need) {
+        head.copy(payload, 8 + copied);
+        copied += head.length;
+        pending.shift();
+      } else {
+        head.copy(payload, 8 + copied, 0, need);
+        pending[0] = head.subarray(need);
+        copied += need;
+      }
+    }
+    pendingLen -= n;
+
+    await dispatch(AfcOpcode.WRITE, payload, AFC_WRITE_THIS_LENGTH);
+    const { status } = await receive();
+    if (status !== AfcError.SUCCESS) {
+      const errorName = AfcError[status] || 'UNKNOWN';
+      throw new Error(`fwrite chunk failed with ${errorName} (${status})`);
+    }
+    written += n;
+    if (onProgress) {
+      // A progress callback is observational; never let it fail the transfer.
+      try {
+        onProgress(written);
+      } catch {
+        // ignore progress-callback errors
+      }
+    }
+  };
+
   return new Writable({
     async write(
       chunk: Buffer,
@@ -71,31 +131,21 @@ export function createAfcWriteStream(
       callback: (error?: Error | null) => void,
     ) {
       try {
-        let offset = 0;
-        while (offset < chunk.length) {
-          const end = Math.min(
-            offset + (chunkSize ?? chunk.length),
-            chunk.length,
-          );
-          const subchunk = chunk.subarray(offset, end);
-
-          await dispatch(
-            AfcOpcode.WRITE,
-            Buffer.concat([writeUInt64LE(handle), subchunk]),
-            AFC_WRITE_THIS_LENGTH,
-          );
-          const { status } = await receive();
-
-          if (status !== AfcError.SUCCESS) {
-            const errorName = AfcError[status] || 'UNKNOWN';
-            callback(
-              new Error(
-                `fwrite chunk failed with ${errorName} (${status}) at offset ${offset}`,
-              ),
-            );
-            return;
-          }
-          offset = end;
+        pending.push(chunk);
+        pendingLen += chunk.length;
+        // Flush full chunkSize-sized WRITEs, keeping any remainder buffered.
+        while (pendingLen >= chunkSize) {
+          await writeNextBlock(chunkSize);
+        }
+        callback();
+      } catch (error) {
+        callback(error as Error);
+      }
+    },
+    async final(callback: (error?: Error | null) => void) {
+      try {
+        if (pendingLen > 0) {
+          await writeNextBlock(pendingLen);
         }
         callback();
       } catch (error) {

--- a/test/integration/afc-throughput-test.ts
+++ b/test/integration/afc-throughput-test.ts
@@ -1,0 +1,163 @@
+import { expect } from 'chai';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { Services } from '../../src/index.js';
+
+/**
+ * AFC bulk-transfer throughput / stall diagnostic.
+ *
+ * Reproduces and measures the large-app AFC push freeze reported in
+ * https://github.com/appium/appium-ios-remotexpc/issues/208 by pushing
+ * dummy files of increasing size and reporting:
+ *   - wall-clock time + throughput (MB/s)
+ *   - live DEVICE-ACKED progress (via writeFromStream's onProgress hook, which
+ *     fires only after each WRITE is acknowledged by the device — so it tracks
+ *     real progress, not bytes merely buffered on the host)
+ *   - a watchdog that ABORTS the push on a full stall (STALL_MS) or sustained
+ *     low throughput (avg < MIN_MBPS after GRACE_MS)
+ *
+ * The content is irrelevant (AFC does not compress), so we push zero-filled
+ * files — no real .ipa or signing required. Each size uses its OWN fresh AFC
+ * connection so an aborted push cannot desync the socket for the next size.
+ *
+ * Env knobs: SIZES_MB, WRITE_CHUNK_MB (override AFC write chunk), STALL_MS,
+ * GRACE_MS, MIN_MBPS.
+ *
+ * Run (with the tunnel up):
+ *   UDID=<udid> SIZES_MB=10,30,60,100 sudo -E npx mocha \
+ *     test/integration/afc-throughput-test.ts --exit --timeout 20m
+ */
+describe('AFC throughput / stall diagnostic', function () {
+  const udid = process.env.UDID || '';
+  const sizesMb = (process.env.SIZES_MB || '10,30,60,100')
+    .split(',')
+    .map((s) => Number(s.trim()))
+    .filter((n) => Number.isFinite(n) && n > 0);
+  // Override the AFC write chunk size (MiB); undefined = library default.
+  const writeChunkMb = process.env.WRITE_CHUNK_MB
+    ? Number(process.env.WRITE_CHUNK_MB)
+    : undefined;
+  // Abort only on a genuine hang: no acked progress at all for this long (ms).
+  // We do NOT abort on low throughput — the tunnel is genuinely slow and bursty
+  // (a 4 MiB write can take ~20s+ to drain), and a slow-but-progressing push is
+  // exactly what we want to measure, not fail.
+  const stallMs = Number(process.env.STALL_MS || 60_000);
+
+  before(function () {
+    if (!udid) {
+      throw new Error('UDID env var is required');
+    }
+  });
+
+  for (const sizeMb of sizesMb) {
+    it(`should push a ${sizeMb} MB file and report throughput`, async function () {
+      const totalBytes = sizeMb * 1024 * 1024;
+      // Backstop timeout: pessimistic ~0.1 MB/s floor, min 2 min. The watchdog
+      // is what fails a genuine hang fast; this only guards a slow crawl.
+      this.timeout(Math.max(120_000, sizeMb * 10_000));
+
+      const localPath = path.join(os.tmpdir(), `afc_thru_${sizeMb}mb.bin`);
+      const remotePath = `/Downloads/afc_thru_${sizeMb}mb_${Date.now()}.bin`;
+
+      // Generate the dummy file (zero-filled).
+      await fsp.writeFile(localPath, Buffer.alloc(totalBytes));
+
+      // A fresh connection per size isolates an aborted push from later sizes.
+      const afc = await Services.startAfcService(udid);
+
+      let written = 0; // device-acked bytes (from onProgress)
+      let lastProgressAt = Date.now();
+      let lastLogged = 0;
+      let aborted = false;
+
+      const fileStream = fs.createReadStream(localPath);
+      const start = Date.now();
+      let lastLogAt = start;
+
+      const watchdog = setInterval(() => {
+        const now = Date.now();
+        const sinceProgress = now - lastProgressAt;
+        // Log only when a chunk is acked, or as an occasional heartbeat during a
+        // long device-side gap — not on every tick.
+        const progressed = written > lastLogged;
+        if (progressed || now - lastLogAt >= 15_000) {
+          const pct = ((written / totalBytes) * 100).toFixed(0);
+          const mb = (written / 1024 / 1024).toFixed(0);
+          // eslint-disable-next-line no-console
+          console.log(
+            `[${sizeMb}MB] ${mb}/${sizeMb} MB (${pct}%)` +
+              (progressed
+                ? ''
+                : `  waiting ${(sinceProgress / 1000).toFixed(0)}s`),
+          );
+          lastLogged = written;
+          lastLogAt = now;
+        }
+        if (sinceProgress >= stallMs && written < totalBytes && !aborted) {
+          aborted = true;
+          const reason = `no acked progress for ${(
+            sinceProgress / 1000
+          ).toFixed(0)}s`;
+          // eslint-disable-next-line no-console
+          console.error(
+            `[${sizeMb}MB] ABORT (${reason}) at ${written}/${totalBytes} ` +
+              `bytes acked`,
+          );
+          clearInterval(watchdog);
+          // Destroying the source rejects the pipeline inside writeFromStream,
+          // so the push fails fast instead of hanging to the backstop timeout.
+          fileStream.destroy(
+            new Error(`AFC push aborted (${reason}) at ${written} bytes`),
+          );
+        }
+      }, 1_000);
+
+      try {
+        await afc.writeFromStream(remotePath, fileStream, {
+          chunkSize: writeChunkMb ? writeChunkMb * 1024 * 1024 : undefined,
+          onProgress: (b) => {
+            written = b;
+            lastProgressAt = Date.now();
+          },
+        });
+
+        const elapsedMs = Date.now() - start;
+        const throughput = totalBytes / 1024 / 1024 / (elapsedMs / 1000);
+        // eslint-disable-next-line no-console
+        console.log(
+          `[${sizeMb}MB] DONE in ${(elapsedMs / 1000).toFixed(1)}s => ` +
+            `${throughput.toFixed(2)} MB/s` +
+            (writeChunkMb ? ` (chunk ${writeChunkMb} MB)` : ''),
+        );
+
+        // Verify the device actually received the full file.
+        const stat = await afc.stat(remotePath);
+        expect(stat.st_size).to.equal(BigInt(totalBytes));
+        expect(aborted, 'transfer aborted mid-push').to.equal(false);
+      } finally {
+        clearInterval(watchdog);
+        if (!fileStream.destroyed) {
+          fileStream.destroy();
+        }
+        try {
+          await afc.rm(remotePath);
+        } catch {
+          // ignore
+        }
+        try {
+          afc.close();
+        } catch {
+          // ignore
+        }
+        try {
+          await fsp.unlink(localPath);
+        } catch {
+          // ignore
+        }
+      }
+    });
+  }
+});

--- a/test/unit/afc/write-stream.spec.ts
+++ b/test/unit/afc/write-stream.spec.ts
@@ -1,0 +1,143 @@
+import { expect } from 'chai';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+
+import { AFC_WRITE_THIS_LENGTH } from '../../../src/services/ios/afc/constants.js';
+import { AfcError, AfcOpcode } from '../../../src/services/ios/afc/enums.js';
+import { createAfcWriteStream } from '../../../src/services/ios/afc/stream-utils.js';
+
+interface CapturedWrite {
+  op: AfcOpcode;
+  payload: Buffer;
+  thisLen?: number;
+}
+
+/**
+ * Drive `createAfcWriteStream` with `data` split into `srcChunkSize` source
+ * chunks (simulating an fs read stream) and capture every AFC WRITE dispatched.
+ */
+async function runWrite(
+  data: Buffer,
+  chunkSize: number,
+  {
+    handle = 7n,
+    srcChunkSize = 64 * 1024,
+    status = AfcError.SUCCESS,
+  }: { handle?: bigint; srcChunkSize?: number; status?: AfcError } = {},
+): Promise<{ writes: CapturedWrite[]; progress: number[] }> {
+  const writes: CapturedWrite[] = [];
+  const dispatch = async (
+    op: AfcOpcode,
+    payload: Buffer,
+    thisLen?: number,
+  ): Promise<void> => {
+    // Snapshot the payload — the stream owns/reuses the source buffers.
+    writes.push({ op, payload: Buffer.from(payload), thisLen });
+  };
+  const receive = async (): Promise<{ status: AfcError; data: Buffer }> => ({
+    status,
+    data: Buffer.alloc(0),
+  });
+
+  const progress: number[] = [];
+  const ws = createAfcWriteStream(handle, dispatch, receive, chunkSize, (b) =>
+    progress.push(b),
+  );
+
+  const srcChunks: Buffer[] = [];
+  for (let i = 0; i < data.length; i += srcChunkSize) {
+    srcChunks.push(data.subarray(i, i + srcChunkSize));
+  }
+
+  await pipeline(Readable.from(srcChunks), ws);
+  return { writes, progress };
+}
+
+/** Build a buffer whose byte i == i % 256, so ordering is verifiable. */
+function rampBuffer(len: number): Buffer {
+  const b = Buffer.allocUnsafe(len);
+  for (let i = 0; i < len; i++) {
+    b[i] = i % 256;
+  }
+  return b;
+}
+
+/** Concatenate the data portion (after the 8-byte handle) of each WRITE. */
+function reassemble(writes: CapturedWrite[]): Buffer {
+  return Buffer.concat(writes.map((w) => w.payload.subarray(8)));
+}
+
+describe('createAfcWriteStream', function () {
+  it('coalesces source chunks into chunkSize-sized WRITEs and preserves data', async function () {
+    const data = rampBuffer(3500);
+    const { writes, progress } = await runWrite(data, 1024);
+
+    // 1024 + 1024 + 1024 + 428
+    expect(writes.map((w) => w.payload.length - 8)).to.deep.equal([
+      1024, 1024, 1024, 428,
+    ]);
+    expect(reassemble(writes).equals(data)).to.equal(true);
+    expect(progress).to.deep.equal([1024, 2048, 3072, 3500]);
+  });
+
+  it('sends each WRITE with the handle prefix, WRITE opcode and thisLength', async function () {
+    const { writes } = await runWrite(rampBuffer(2500), 1000, { handle: 42n });
+    for (const w of writes) {
+      expect(w.op).to.equal(AfcOpcode.WRITE);
+      expect(w.thisLen).to.equal(AFC_WRITE_THIS_LENGTH);
+      expect(w.payload.readBigUInt64LE(0)).to.equal(42n);
+    }
+  });
+
+  it('sends a single WRITE when the file is smaller than chunkSize', async function () {
+    const data = rampBuffer(1000);
+    const { writes } = await runWrite(data, 4096);
+    expect(writes).to.have.lengthOf(1);
+    expect(writes[0].payload.length - 8).to.equal(1000);
+    expect(reassemble(writes).equals(data)).to.equal(true);
+  });
+
+  it('handles a size that is an exact multiple of chunkSize without a trailing empty WRITE', async function () {
+    const { writes, progress } = await runWrite(rampBuffer(2000), 1000);
+    expect(writes.map((w) => w.payload.length - 8)).to.deep.equal([1000, 1000]);
+    expect(progress).to.deep.equal([1000, 2000]);
+  });
+
+  it('splits a single source chunk larger than chunkSize', async function () {
+    // One 5000-byte source chunk, 2000-byte AFC chunks => 2000+2000+1000.
+    const data = rampBuffer(5000);
+    const { writes } = await runWrite(data, 2000, { srcChunkSize: 1 << 20 });
+    expect(writes.map((w) => w.payload.length - 8)).to.deep.equal([
+      2000, 2000, 1000,
+    ]);
+    expect(reassemble(writes).equals(data)).to.equal(true);
+  });
+
+  it('writes nothing for an empty stream', async function () {
+    const { writes, progress } = await runWrite(Buffer.alloc(0), 1024);
+    expect(writes).to.have.lengthOf(0);
+    expect(progress).to.have.lengthOf(0);
+  });
+
+  it('rejects when the device returns a non-success status', async function () {
+    let err: unknown;
+    try {
+      await runWrite(rampBuffer(2048), 1024, {
+        status: AfcError.UNKNOWN_ERROR,
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).to.be.instanceOf(Error);
+  });
+
+  it('throws for an invalid chunkSize', function () {
+    const noop = async (): Promise<void> => {};
+    const recv = async (): Promise<{ status: AfcError; data: Buffer }> => ({
+      status: AfcError.SUCCESS,
+      data: Buffer.alloc(0),
+    });
+    expect(() => createAfcWriteStream(1n, noop, recv, 0)).to.throw(TypeError);
+    expect(() => createAfcWriteStream(1n, noop, recv, -5)).to.throw(TypeError);
+  });
+});


### PR DESCRIPTION
## Problem

Pushing a file over AFC issued one `WRITE` per ~64 KiB source-stream chunk, so a large app (e.g. 60 MB) became **~950 strictly-serial request/response round-trips** over the RSD tunnel. Each round-trip can stall on the peer's delayed ACK, so the transfer degraded into minutes and, on a flaky tunnel, never completed — the large-app **install freeze** reported in #208.

## Fix

`createAfcWriteStream` now **coalesces** source chunks into AFC `WRITE` packets of up to `MAXIMUM_WRITE_SIZE` (4 MiB), cutting round-trips ~60×. Memory stays bounded — it never holds the whole file in RAM (unlike a single giant write), and 4 MiB is small enough that one packet reliably drains and is acked within the AFC operation timeout even on a slow tunnel.

Also in this change:
- disable Nagle (`setNoDelay`) on the AFC/raw-service socket
- send each AFC packet's header + payload as a single `write()` (one flush, fewer syscalls)
- cap `fwrite()` chunking at `MAXIMUM_WRITE_SIZE`
- add an optional `onProgress` hook to `writeFromStream` (useful for install-progress reporting)

## Verification

Verified on a real device over an active RSD tunnel by pushing files of increasing size via `AfcService` (zero-filled dummy files; AFC does not compress, so content is irrelevant).

| Size | Before | After |
|---|---|---|
| 10 MB | ~67 s (≈0.15 MB/s) | ~21 s |
| 30 MB | effectively hung | ~75 s |
| 60 MB | effectively hung | ~151 s |
| 100 MB | effectively hung | ~305 s |

Before the change, large pushes crawled at ~0.06–0.15 MB/s and never completed under a reconnecting tunnel; after, they complete reliably. The remaining ~0.4 MB/s ceiling is the tunnel's per-connection bandwidth-delay limit, not AFC — a separate optimization.

Fixes #208
