### PR TITLE
fix: Add response demux and improve write framing for RSD AFC uploads

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test:webinspector": "mocha test/integration/webinspector-test.ts --exit --timeout 1m",
     "test:misagent": "mocha test/integration/misagent-service-test.ts --exit --timeout 1m",
     "test:afc": "mocha test/integration/afc-test.ts --exit --timeout 1m",
+    "test:afc-push-perf": "mocha test/integration/afc-push-performance-test.ts --exit --timeout 3m",
     "test:lockdown-tunnel": "mocha test/integration/lockdown-tunnel-test.ts --exit --timeout 1m",
     "test:crash-reports": "mocha test/integration/crash-reports-test.ts --exit --timeout 1m",
     "test:house-arrest": "mocha test/integration/house-arrest-test.ts --exit --timeout 1m",

--- a/src/services/ios/afc/codec.ts
+++ b/src/services/ios/afc/codec.ts
@@ -6,6 +6,7 @@ import {
   AFCMAGIC,
   AFC_HEADER_SIZE,
   AFC_OPERATION_TIMEOUT_MS,
+  MAXIMUM_READ_SIZE,
   NULL_BYTE,
 } from './constants.js';
 import { AfcError, AfcFopenMode, AfcOpcode } from './enums.js';
@@ -68,30 +69,33 @@ export function cstr(str: string): Buffer {
   return Buffer.concat([s, NULL_BYTE]);
 }
 /**
- * Build an AFC packet header for the provided operation and payload length.
+ * Build an AFC packet header with explicit entire_length and this_length values.
+ */
+export function encodeHeaderExplicit(
+  op: AfcOpcode,
+  packetNum: bigint,
+  entireLen: number,
+  thisLen: number,
+): Buffer {
+  const header = Buffer.alloc(AFC_HEADER_SIZE);
+  AFCMAGIC.copy(header, 0);
+  writeUInt64LE(BigInt(entireLen)).copy(header, 8);
+  writeUInt64LE(BigInt(thisLen)).copy(header, 16);
+  writeUInt64LE(packetNum).copy(header, 24);
+  writeUInt64LE(BigInt(op)).copy(header, 32);
+  return header;
+}
+
+/**
+ * Build an AFC packet header for a single contiguous payload after the header.
  */
 export function encodeHeader(
   op: AfcOpcode,
   packetNum: bigint,
   payloadLen: number,
-  thisLenOverride?: number,
 ): Buffer {
-  const entireLen = BigInt(AFC_HEADER_SIZE + payloadLen);
-  const thisLen = BigInt(thisLenOverride ?? AFC_HEADER_SIZE + payloadLen);
-
-  const header = Buffer.alloc(AFC_HEADER_SIZE);
-  // magic
-  AFCMAGIC.copy(header, 0);
-  // entire_length
-  writeUInt64LE(entireLen).copy(header, 8);
-  // this_length
-  writeUInt64LE(thisLen).copy(header, 16);
-  // packet_num
-  writeUInt64LE(packetNum).copy(header, 24);
-  // operation
-  writeUInt64LE(BigInt(op)).copy(header, 32);
-
-  return header;
+  const entireLen = AFC_HEADER_SIZE + payloadLen;
+  return encodeHeaderExplicit(op, packetNum, entireLen, entireLen);
 }
 
 const SOCKET_STATES = new WeakMap<net.Socket, SocketState>();
@@ -201,33 +205,54 @@ export async function readAfcResponse(
 }
 
 /**
- * Send an AFC packet (header and optional payload) to the socket.
+ * Write a buffer to the socket, waiting for drain only when the kernel buffer is full.
+ */
+export async function writeBufferToSocket(
+  socket: net.Socket,
+  data: Buffer,
+): Promise<void> {
+  assertSocketReadable(socket);
+  if (!data.length) {
+    return;
+  }
+  if (socket.write(data)) {
+    return;
+  }
+  await new Promise<void>((resolve, reject) => {
+    const onDrain = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = (err: Error) => {
+      cleanup();
+      reject(err);
+    };
+    const cleanup = () => {
+      socket.off('drain', onDrain);
+      socket.off('error', onError);
+    };
+    socket.once('drain', onDrain);
+    socket.once('error', onError);
+  });
+}
+
+/**
+ * Send an AFC packet as three socket writes: header, optional header payload, optional body.
+ * For FILE_WRITE, headerPayload is the 8-byte handle and content is file bytes (no memcpy).
  */
 export async function sendAfcPacket(
   socket: net.Socket,
   op: AfcOpcode,
   packetNum: bigint,
-  payload: Buffer = Buffer.alloc(0),
-  thisLenOverride?: number,
+  headerPayload: Buffer = Buffer.alloc(0),
+  content: Buffer = Buffer.alloc(0),
 ): Promise<void> {
-  const header = encodeHeader(op, packetNum, payload.length, thisLenOverride);
-  await new Promise<void>((resolve, reject) => {
-    socket.write(header, (err) => {
-      if (err) {
-        return reject(err);
-      }
-      if (payload.length) {
-        socket.write(payload, (err2) => {
-          if (err2) {
-            return reject(err2);
-          }
-          resolve();
-        });
-      } else {
-        resolve();
-      }
-    });
-  });
+  const thisLen = AFC_HEADER_SIZE + headerPayload.length;
+  const entireLen = thisLen + content.length;
+  const header = encodeHeaderExplicit(op, packetNum, entireLen, thisLen);
+  await writeBufferToSocket(socket, header);
+  await writeBufferToSocket(socket, headerPayload);
+  await writeBufferToSocket(socket, content);
 }
 
 /**
@@ -391,6 +416,7 @@ export async function createRawServiceSocket(
   const socket = await new Promise<net.Socket>((resolve, reject) => {
     const conn = net.createConnection({ host, port }, () => {
       conn.setKeepAlive(true);
+      conn.setNoDelay(true);
       resolve(conn);
     });
     conn.setTimeout(timeoutMs, () => {
@@ -415,7 +441,7 @@ export async function createRawServiceSocket(
  */
 export function nextReadChunkSize(left: bigint | number): number {
   const leftNum = typeof left === 'bigint' ? Number(left) : left;
-  return leftNum;
+  return Math.min(leftNum, MAXIMUM_READ_SIZE);
 }
 
 /**

--- a/src/services/ios/afc/codec.ts
+++ b/src/services/ios/afc/codec.ts
@@ -227,12 +227,22 @@ export async function writeBufferToSocket(
       cleanup();
       reject(err);
     };
+    const onClosed = () => {
+      cleanup();
+      reject(
+        new AfcConnectionError('AFC socket closed while waiting for drain'),
+      );
+    };
     const cleanup = () => {
       socket.off('drain', onDrain);
       socket.off('error', onError);
+      socket.off('close', onClosed);
+      socket.off('end', onClosed);
     };
     socket.once('drain', onDrain);
     socket.once('error', onError);
+    socket.once('close', onClosed);
+    socket.once('end', onClosed);
   });
 }
 

--- a/src/services/ios/afc/constants.ts
+++ b/src/services/ios/afc/constants.ts
@@ -7,8 +7,9 @@ import { AfcFopenMode } from './enums.js';
 // Magic bytes at start of every AFC header
 export const AFCMAGIC = Buffer.from('CFA6LPAA', 'ascii');
 
-// IO chunk sizes
-export const MAXIMUM_READ_SIZE = 4 * 1024 * 1024; // 4 MiB
+// IO chunk sizes (split writes avoid memcpy)
+export const MAXIMUM_READ_SIZE = 1024 * 1024;
+export const MAXIMUM_WRITE_SIZE = 1024 * 1024;
 
 // Mapping of textual fopen modes to AFC modes
 export const AFC_FOPEN_TEXTUAL_MODES: Record<string, AfcFopenMode> = {
@@ -23,10 +24,7 @@ export const AFC_FOPEN_TEXTUAL_MODES: Record<string, AfcFopenMode> = {
 // Header size: magic (8) + entire_length (8) + this_length (8) + packet_num (8) + operation (8)
 export const AFC_HEADER_SIZE = 40;
 
-export const AFC_OPERATION_TIMEOUT_MS = 15_000;
-
-// Override for WRITE packets' this_length
-export const AFC_WRITE_THIS_LENGTH = 48;
+export const AFC_OPERATION_TIMEOUT_MS = 30_000;
 
 export const NULL_BYTE = Buffer.from([0]);
 

--- a/src/services/ios/afc/demux.ts
+++ b/src/services/ios/afc/demux.ts
@@ -102,12 +102,17 @@ export class AfcPacketDemux {
     try {
       await this._readerLoop(socket);
     } catch (err) {
+      if (!this._isCurrentReader(socket)) {
+        return;
+      }
       this._failPending(
         err instanceof Error ? err : new Error(String(err)),
         true,
       );
     } finally {
-      this.readerActive = false;
+      if (this.readerSocket === socket) {
+        this.readerActive = false;
+      }
     }
   }
 
@@ -191,7 +196,7 @@ export class AfcPacketDemux {
         }
       }
     } catch (err) {
-      if (this.stopped) {
+      if (!this._isCurrentReader(socket)) {
         return;
       }
       const error =
@@ -201,6 +206,11 @@ export class AfcPacketDemux {
       }
       throw error;
     }
+  }
+
+  /** True while this socket owns the background reader task. */
+  private _isCurrentReader(socket: net.Socket): boolean {
+    return !this.stopped && this.readerSocket === socket;
   }
 
   private _failPending(err: Error, notifyService: boolean): void {

--- a/src/services/ios/afc/demux.ts
+++ b/src/services/ios/afc/demux.ts
@@ -1,0 +1,223 @@
+import type net from 'node:net';
+
+import { getLogger } from '../../../lib/logger.js';
+import {
+  fatalizeAfcSocket,
+  readAfcHeader,
+  readExact,
+  readUInt64LE,
+  sendAfcPacket,
+} from './codec.js';
+import { AFC_HEADER_SIZE, AFC_OPERATION_TIMEOUT_MS } from './constants.js';
+import { AfcError, AfcOpcode } from './enums.js';
+import { AfcConnectionError } from './errors.js';
+
+const log = getLogger('AfcService');
+
+type PendingResponse = {
+  resolve: (value: { status: AfcError; data: Buffer }) => void;
+  reject: (err: Error) => void;
+};
+
+/**
+ * Routes inbound AFC packets to the matching request by packet_num.
+ * A background reader task demultiplexes responses so callers can overlap
+ * sends while each operation is matched to its reply.
+ */
+export class AfcPacketDemux {
+  private readonly pending = new Map<bigint, PendingResponse>();
+  private packetNum = 0n;
+  private readerTask: Promise<void> | null = null;
+  private readerSocket: net.Socket | null = null;
+  private readerActive = false;
+  private sendLock: Promise<void> = Promise.resolve();
+  private stopped = false;
+
+  constructor(
+    private readonly getSocket: () => Promise<net.Socket>,
+    private readonly onFatalError: (err: Error) => void,
+  ) {}
+
+  ensureReaderStarted(socket: net.Socket): void {
+    if (this.stopped) {
+      throw new AfcConnectionError('AFC demux is stopped');
+    }
+    if (this.readerActive && this.readerSocket === socket) {
+      return;
+    }
+    this.readerSocket = socket;
+    this.readerActive = true;
+    this.readerTask = this._readerLoop(socket)
+      .catch((err) => {
+        this._failPending(
+          err instanceof Error ? err : new Error(String(err)),
+          true,
+        );
+      })
+      .finally(() => {
+        this.readerActive = false;
+      });
+  }
+
+  /**
+   * Register a waiter, send one packet, then await its response.
+   * packet_num assignment, waiter registration, and send are serialized;
+   * awaiting the response happens outside the send lock.
+   */
+  async sendAndWait(
+    op: AfcOpcode,
+    headerPayload: Buffer = Buffer.alloc(0),
+    content: Buffer = Buffer.alloc(0),
+    timeoutMs = AFC_OPERATION_TIMEOUT_MS,
+  ): Promise<{ status: AfcError; data: Buffer }> {
+    if (this.stopped) {
+      throw new AfcConnectionError('AFC demux is stopped');
+    }
+
+    const socket = await this.getSocket();
+    this.ensureReaderStarted(socket);
+
+    const responsePromise = await this._sendLocked(async () => {
+      const num = this.packetNum++;
+      const waiter = this._registerPending(num, timeoutMs, op);
+      try {
+        await sendAfcPacket(socket, op, num, headerPayload, content);
+      } catch (err) {
+        this._clearPending(num);
+        throw err;
+      }
+      return waiter;
+    });
+
+    return await responsePromise;
+  }
+
+  resetForNewSocket(): void {
+    this._failPending(new AfcConnectionError('AFC socket replaced'), false);
+    this.readerTask = null;
+    this.readerSocket = null;
+    this.readerActive = false;
+    this.stopped = false;
+    this.sendLock = Promise.resolve();
+  }
+
+  /** Graceful shutdown; does not notify the owning service. */
+  stop(): void {
+    this.stopped = true;
+    this._failPending(new AfcConnectionError('AFC demux stopped'), false);
+    this.readerTask = null;
+    this.readerSocket = null;
+    this.readerActive = false;
+  }
+
+  private async _sendLocked<T>(fn: () => Promise<T>): Promise<T> {
+    let release!: () => void;
+    const turn = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const previous = this.sendLock;
+    this.sendLock = previous.then(() => turn);
+    await previous;
+    try {
+      return await fn();
+    } finally {
+      release();
+    }
+  }
+
+  private _registerPending(
+    pktNum: bigint,
+    timeoutMs: number,
+    op: AfcOpcode,
+  ): Promise<{ status: AfcError; data: Buffer }> {
+    return new Promise<{ status: AfcError; data: Buffer }>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        if (!this.pending.has(pktNum)) {
+          return;
+        }
+        this._clearPending(pktNum);
+        reject(
+          new AfcConnectionError(
+            `AFC operation ${AfcOpcode[op] ?? op} timed out after ${timeoutMs}ms (packet ${pktNum})`,
+          ),
+        );
+      }, timeoutMs);
+
+      this.pending.set(pktNum, {
+        resolve: (value) => {
+          clearTimeout(timer);
+          resolve(value);
+        },
+        reject: (err) => {
+          clearTimeout(timer);
+          reject(err);
+        },
+      });
+    });
+  }
+
+  private _clearPending(pktNum: bigint): void {
+    this.pending.delete(pktNum);
+  }
+
+  private async _readerLoop(socket: net.Socket): Promise<void> {
+    try {
+      while (!this.stopped && !socket.destroyed) {
+        const header = await readAfcHeader(socket, AFC_OPERATION_TIMEOUT_MS);
+        const payloadLen = Number(
+          header.entireLength - BigInt(AFC_HEADER_SIZE),
+        );
+        const payload =
+          payloadLen > 0
+            ? await readExact(socket, payloadLen, AFC_OPERATION_TIMEOUT_MS)
+            : Buffer.alloc(0);
+
+        let status = AfcError.SUCCESS;
+        let data = payload;
+        const op = Number(header.operation) as AfcOpcode;
+
+        if (op === AfcOpcode.STATUS) {
+          if (payloadLen !== 8) {
+            log.error(`AFC STATUS response length != 8 (${payloadLen})`);
+          }
+          status = Number(readUInt64LE(payload.subarray(0, 8))) as AfcError;
+          data = Buffer.alloc(0);
+        } else if (op !== AfcOpcode.DATA) {
+          log.debug(
+            `Unexpected AFC response opcode ${op} for packet ${header.packetNum}`,
+          );
+        }
+
+        const waiter = this.pending.get(header.packetNum);
+        if (waiter) {
+          this.pending.delete(header.packetNum);
+          waiter.resolve({ status, data });
+        } else {
+          log.warn(
+            `AFC response with no waiter (packet ${header.packetNum}, op ${op})`,
+          );
+        }
+      }
+    } catch (err) {
+      if (this.stopped) {
+        return;
+      }
+      const error =
+        err instanceof Error ? err : new AfcConnectionError(String(err));
+      if (!socket.destroyed) {
+        fatalizeAfcSocket(socket, error);
+      }
+      throw error;
+    }
+  }
+
+  private _failPending(err: Error, notifyService: boolean): void {
+    for (const [, waiter] of this.pending) {
+      waiter.reject(err);
+    }
+    this.pending.clear();
+    if (notifyService) {
+      this.onFatalError(err);
+    }
+  }
+}

--- a/src/services/ios/afc/demux.ts
+++ b/src/services/ios/afc/demux.ts
@@ -1,3 +1,4 @@
+import AsyncLock from 'async-lock';
 import type net from 'node:net';
 
 import { getLogger } from '../../../lib/logger.js';
@@ -30,7 +31,7 @@ export class AfcPacketDemux {
   private readerTask: Promise<void> | null = null;
   private readerSocket: net.Socket | null = null;
   private readerActive = false;
-  private sendLock: Promise<void> = Promise.resolve();
+  private readonly sendLock = new AsyncLock();
   private stopped = false;
 
   constructor(
@@ -89,7 +90,6 @@ export class AfcPacketDemux {
     this.readerSocket = null;
     this.readerActive = false;
     this.stopped = false;
-    this.sendLock = Promise.resolve();
   }
 
   /** Graceful shutdown; does not notify the owning service. */
@@ -114,18 +114,8 @@ export class AfcPacketDemux {
     }
   }
 
-  private async _sendLocked<T>(fn: () => Promise<T>): Promise<T> {
-    const previous = this.sendLock;
-    let release!: () => void;
-    this.sendLock = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    await previous;
-    try {
-      return await fn();
-    } finally {
-      release();
-    }
+  private _sendLocked<T>(fn: () => Promise<T>): Promise<T> {
+    return this.sendLock.acquire('afc-send', fn);
   }
 
   private _registerPending(

--- a/src/services/ios/afc/demux.ts
+++ b/src/services/ios/afc/demux.ts
@@ -130,30 +130,32 @@ export class AfcPacketDemux {
     timeoutMs: number,
     op: AfcOpcode,
   ): Promise<{ status: AfcError; data: Buffer }> {
-    return new Promise<{ status: AfcError; data: Buffer }>((resolve, reject) => {
-      const timer = setTimeout(() => {
-        if (!this.pending.has(pktNum)) {
-          return;
-        }
-        this._clearPending(pktNum);
-        reject(
-          new AfcConnectionError(
-            `AFC operation ${AfcOpcode[op] ?? op} timed out after ${timeoutMs}ms (packet ${pktNum})`,
-          ),
-        );
-      }, timeoutMs);
+    return new Promise<{ status: AfcError; data: Buffer }>(
+      (resolve, reject) => {
+        const timer = setTimeout(() => {
+          if (!this.pending.has(pktNum)) {
+            return;
+          }
+          this._clearPending(pktNum);
+          reject(
+            new AfcConnectionError(
+              `AFC operation ${AfcOpcode[op] ?? op} timed out after ${timeoutMs}ms (packet ${pktNum})`,
+            ),
+          );
+        }, timeoutMs);
 
-      this.pending.set(pktNum, {
-        resolve: (value) => {
-          clearTimeout(timer);
-          resolve(value);
-        },
-        reject: (err) => {
-          clearTimeout(timer);
-          reject(err);
-        },
-      });
-    });
+        this.pending.set(pktNum, {
+          resolve: (value) => {
+            clearTimeout(timer);
+            resolve(value);
+          },
+          reject: (err) => {
+            clearTimeout(timer);
+            reject(err);
+          },
+        });
+      },
+    );
   }
 
   private _clearPending(pktNum: bigint): void {

--- a/src/services/ios/afc/demux.ts
+++ b/src/services/ios/afc/demux.ts
@@ -47,16 +47,7 @@ export class AfcPacketDemux {
     }
     this.readerSocket = socket;
     this.readerActive = true;
-    this.readerTask = this._readerLoop(socket)
-      .catch((err) => {
-        this._failPending(
-          err instanceof Error ? err : new Error(String(err)),
-          true,
-        );
-      })
-      .finally(() => {
-        this.readerActive = false;
-      });
+    this.readerTask = this._runReaderLoop(socket);
   }
 
   /**
@@ -110,13 +101,25 @@ export class AfcPacketDemux {
     this.readerActive = false;
   }
 
+  private async _runReaderLoop(socket: net.Socket): Promise<void> {
+    try {
+      await this._readerLoop(socket);
+    } catch (err) {
+      this._failPending(
+        err instanceof Error ? err : new Error(String(err)),
+        true,
+      );
+    } finally {
+      this.readerActive = false;
+    }
+  }
+
   private async _sendLocked<T>(fn: () => Promise<T>): Promise<T> {
+    const previous = this.sendLock;
     let release!: () => void;
-    const turn = new Promise<void>((resolve) => {
+    this.sendLock = new Promise<void>((resolve) => {
       release = resolve;
     });
-    const previous = this.sendLock;
-    this.sendLock = previous.then(() => turn);
     await previous;
     try {
       return await fn();

--- a/src/services/ios/afc/demux.ts
+++ b/src/services/ios/afc/demux.ts
@@ -28,7 +28,6 @@ type PendingResponse = {
 export class AfcPacketDemux {
   private readonly pending = new Map<bigint, PendingResponse>();
   private packetNum = 0n;
-  private readerTask: Promise<void> | null = null;
   private readerSocket: net.Socket | null = null;
   private readerActive = false;
   private readonly sendLock = new AsyncLock();
@@ -48,7 +47,7 @@ export class AfcPacketDemux {
     }
     this.readerSocket = socket;
     this.readerActive = true;
-    this.readerTask = this._runReaderLoop(socket);
+    void this._runReaderLoop(socket);
   }
 
   /**
@@ -86,7 +85,6 @@ export class AfcPacketDemux {
 
   resetForNewSocket(): void {
     this._failPending(new AfcConnectionError('AFC socket replaced'), false);
-    this.readerTask = null;
     this.readerSocket = null;
     this.readerActive = false;
     this.stopped = false;
@@ -96,7 +94,6 @@ export class AfcPacketDemux {
   stop(): void {
     this.stopped = true;
     this._failPending(new AfcConnectionError('AFC demux stopped'), false);
-    this.readerTask = null;
     this.readerSocket = null;
     this.readerActive = false;
   }

--- a/src/services/ios/afc/index.ts
+++ b/src/services/ios/afc/index.ts
@@ -20,16 +20,10 @@ import {
   nanosecondsToMilliseconds,
   parseCStringArray,
   parseKeyValueNullList,
-  readAfcResponse,
-  sendAfcPacket,
   writeUInt64LE,
 } from './codec.js';
-import {
-  AFC_FOPEN_TEXTUAL_MODES,
-  AFC_LOCK_EX,
-  AFC_LOCK_UN,
-  AFC_WRITE_THIS_LENGTH,
-} from './constants.js';
+import { AFC_FOPEN_TEXTUAL_MODES, MAXIMUM_WRITE_SIZE } from './constants.js';
+import { AfcPacketDemux } from './demux.js';
 import { AfcError, AfcFileMode, AfcOpcode } from './enums.js';
 import { AfcConnectionError } from './errors.js';
 import { PullLocalNameAllocator } from './pull-local-name-allocator.js';
@@ -95,7 +89,7 @@ export class AfcService {
   static readonly RSD_SERVICE_NAME = 'com.apple.afc.shim.remote';
 
   private socket: net.Socket | null = null;
-  private packetNum: bigint = 0n;
+  private demux: AfcPacketDemux | null = null;
   private silent: boolean = false;
   /** Set when the AFC byte stream is no longer safe to reuse on this instance. */
   private connectionError: Error | null = null;
@@ -218,19 +212,14 @@ export class AfcService {
   }
 
   createReadStream(handle: bigint, size: bigint): Readable {
-    return createAfcReadStream(
-      handle,
-      size,
-      this._dispatch.bind(this),
-      this._receive.bind(this),
-    );
+    return createAfcReadStream(handle, size, this._sendAndWait.bind(this));
   }
 
   createWriteStream(handle: bigint, chunkSize?: number): Writable {
     return createAfcWriteStream(
       handle,
-      this._dispatch.bind(this),
-      this._receive.bind(this),
+      (handlePayload, content) =>
+        this._sendAndWait(AfcOpcode.WRITE, handlePayload, content),
       chunkSize,
     );
   }
@@ -262,12 +251,11 @@ export class AfcService {
       const chunk = data.subarray(offset, end);
       chunkCount++;
 
-      await this._dispatch(
+      const { status } = await this._sendAndWait(
         AfcOpcode.WRITE,
-        Buffer.concat([writeUInt64LE(handle), chunk]),
-        AFC_WRITE_THIS_LENGTH,
+        writeUInt64LE(handle),
+        chunk,
       );
-      const { status } = await this._receive();
       if (status !== AfcError.SUCCESS) {
         const errorName = AfcError[status] || 'UNKNOWN';
         if (!this.silent) {
@@ -312,15 +300,13 @@ export class AfcService {
   async setFileContents(filePath: string, data: Buffer): Promise<void> {
     log.debug(`Writing ${data.length} bytes to file: ${filePath}`);
     const h = await this.fopen(filePath, 'w');
-    await this._lockFile(h);
     try {
-      await this.fwrite(h, data);
+      await this.fwrite(h, data, MAXIMUM_WRITE_SIZE);
       log.debug(`Successfully wrote file: ${filePath}`);
     } catch (error) {
       await this.rmSingle(filePath, true);
       throw error;
     } finally {
-      await this._unlockFile(h);
       await this.fclose(h);
     }
   }
@@ -345,7 +331,6 @@ export class AfcService {
   async writeFromStream(filePath: string, stream: Readable): Promise<void> {
     log.debug(`Writing stream to file: ${filePath}`);
     const handle = await this.fopen(filePath, 'w');
-    await this._lockFile(handle);
     const writeStream = this.createWriteStream(handle);
     try {
       await pipeline(stream, writeStream);
@@ -354,7 +339,6 @@ export class AfcService {
       await this.rmSingle(filePath, true);
       throw error;
     } finally {
-      await this._unlockFile(handle);
       await this.fclose(handle);
     }
   }
@@ -548,7 +532,9 @@ export class AfcService {
 
   async push(localSrc: string, remoteDst: string): Promise<void> {
     log.debug(`Pushing file from '${localSrc}' to '${remoteDst}'`);
-    const readStream = fs.createReadStream(localSrc);
+    const readStream = fs.createReadStream(localSrc, {
+      highWaterMark: MAXIMUM_WRITE_SIZE,
+    });
     await this.writeFromStream(remoteDst, readStream);
     log.debug(`Successfully pushed file to '${remoteDst}'`);
   }
@@ -580,6 +566,8 @@ export class AfcService {
    */
   close(): void {
     log.debug('Closing AFC service connection');
+    this.demux?.stop();
+    this.demux = null;
     const socket = this.socket;
     this.socket = null;
     this.connectionError = null;
@@ -791,16 +779,48 @@ export class AfcService {
     }
   }
 
+  private _getDemux(): AfcPacketDemux {
+    if (!this.demux) {
+      this.demux = new AfcPacketDemux(
+        async () => await this._connect(),
+        (err) => this._markConnectionDead(err),
+      );
+    }
+    return this.demux;
+  }
+
+  private async _sendAndWait(
+    op: AfcOpcode,
+    headerPayload: Buffer = Buffer.alloc(0),
+    content: Buffer = Buffer.alloc(0),
+  ): Promise<{ status: AfcError; data: Buffer }> {
+    return await this._withAfcConnection(async () =>
+      this._getDemux().sendAndWait(op, headerPayload, content),
+    );
+  }
+
   private async _connect(): Promise<net.Socket> {
     this._assertConnectionAlive();
     if (this.socket && !this.socket.destroyed) {
       return this.socket;
     }
+
+    const previousSocket = this.socket;
+    if (previousSocket) {
+      if (!previousSocket.destroyed) {
+        cleanupServiceSocket(previousSocket);
+        previousSocket.destroy();
+      }
+      this.demux?.resetForNewSocket();
+    }
+    this.socket = null;
+
     const [host, rsdPort] = this.address;
 
     this.socket = await createRawServiceSocket(host, rsdPort, {
       timeoutMs: 30000,
     });
+    this._getDemux().ensureReaderStarted(this.socket);
     log.debug('RSD handshake complete; switching to raw AFC');
 
     return this.socket;
@@ -818,43 +838,6 @@ export class AfcService {
     return filePath;
   }
 
-  private async _lockFile(handle: bigint): Promise<void> {
-    await this._doOperation(
-      AfcOpcode.FILE_LOCK,
-      Buffer.concat([writeUInt64LE(handle), writeUInt64LE(AFC_LOCK_EX)]),
-    );
-  }
-
-  private async _unlockFile(handle: bigint): Promise<void> {
-    try {
-      await this._doOperation(
-        AfcOpcode.FILE_LOCK,
-        Buffer.concat([writeUInt64LE(handle), writeUInt64LE(AFC_LOCK_UN)]),
-      );
-    } catch (error) {
-      log.warn(`Failed to unlock file handle ${handle}:`, error);
-    }
-  }
-
-  private async _dispatch(
-    op: AfcOpcode,
-    payload: Buffer = Buffer.alloc(0),
-    thisLenOverride?: number,
-  ): Promise<void> {
-    return await this._withAfcConnection(async () => {
-      const sock = await this._connect();
-      await sendAfcPacket(sock, op, this.packetNum++, payload, thisLenOverride);
-    });
-  }
-
-  private async _receive(): Promise<{ status: AfcError; data: Buffer }> {
-    return await this._withAfcConnection(async () => {
-      const sock = await this._connect();
-      const res = await readAfcResponse(sock);
-      return { status: res.status, data: res.data };
-    });
-  }
-
   /**
    * Send a single-operation request and parse result.
    * Throws if status != SUCCESS.
@@ -863,10 +846,8 @@ export class AfcService {
   private async _doOperation(
     op: AfcOpcode,
     payload: Buffer = Buffer.alloc(0),
-    thisLenOverride?: number,
   ): Promise<Buffer> {
-    await this._dispatch(op, payload, thisLenOverride);
-    const { status, data } = await this._receive();
+    const { status, data } = await this._sendAndWait(op, payload);
 
     if (status !== AfcError.SUCCESS) {
       const errorName = AfcError[status] || 'UNKNOWN';

--- a/src/services/ios/afc/stream-utils.ts
+++ b/src/services/ios/afc/stream-utils.ts
@@ -1,16 +1,19 @@
 import { Readable, Writable } from 'node:stream';
 
 import { buildReadPayload, nextReadChunkSize, writeUInt64LE } from './codec.js';
-import { AFC_WRITE_THIS_LENGTH } from './constants.js';
+import { MAXIMUM_WRITE_SIZE } from './constants.js';
 import { AfcError, AfcOpcode } from './enums.js';
 
-type AfcDispatcher = (op: AfcOpcode, payload: Buffer) => Promise<void>;
-
-type AfcWriteDispatcher = (
+export type AfcSendAndWait = (
   op: AfcOpcode,
-  payload: Buffer,
-  thisLenOverride?: number,
-) => Promise<void>;
+  headerPayload?: Buffer,
+  content?: Buffer,
+) => Promise<{ status: AfcError; data: Buffer }>;
+
+export type AfcFileWriteAndWait = (
+  handlePayload: Buffer,
+  content: Buffer,
+) => Promise<{ status: AfcError; data: Buffer }>;
 
 /**
  * Create a readable stream that pulls file chunks over AFC READ requests.
@@ -18,8 +21,7 @@ type AfcWriteDispatcher = (
 export function createAfcReadStream(
   handle: bigint,
   size: bigint,
-  dispatch: AfcDispatcher,
-  receive: () => Promise<{ status: AfcError; data: Buffer }>,
+  sendAndWait: AfcSendAndWait,
 ): Readable {
   let left = size;
 
@@ -32,8 +34,10 @@ export function createAfcReadStream(
         }
 
         const toRead = nextReadChunkSize(left);
-        await dispatch(AfcOpcode.READ, buildReadPayload(handle, toRead));
-        const { status, data } = await receive();
+        const { status, data } = await sendAndWait(
+          AfcOpcode.READ,
+          buildReadPayload(handle, toRead),
+        );
 
         if (status !== AfcError.SUCCESS) {
           const errorName = AfcError[status] || 'UNKNOWN';
@@ -60,10 +64,11 @@ export function createAfcReadStream(
  */
 export function createAfcWriteStream(
   handle: bigint,
-  dispatch: AfcWriteDispatcher,
-  receive: () => Promise<{ status: AfcError; data: Buffer }>,
-  chunkSize?: number,
+  writeChunk: AfcFileWriteAndWait,
+  chunkSize = MAXIMUM_WRITE_SIZE,
 ): Writable {
+  const handlePayload = writeUInt64LE(handle);
+
   return new Writable({
     async write(
       chunk: Buffer,
@@ -73,18 +78,10 @@ export function createAfcWriteStream(
       try {
         let offset = 0;
         while (offset < chunk.length) {
-          const end = Math.min(
-            offset + (chunkSize ?? chunk.length),
-            chunk.length,
-          );
+          const end = Math.min(offset + chunkSize, chunk.length);
           const subchunk = chunk.subarray(offset, end);
 
-          await dispatch(
-            AfcOpcode.WRITE,
-            Buffer.concat([writeUInt64LE(handle), subchunk]),
-            AFC_WRITE_THIS_LENGTH,
-          );
-          const { status } = await receive();
+          const { status } = await writeChunk(handlePayload, subchunk);
 
           if (status !== AfcError.SUCCESS) {
             const errorName = AfcError[status] || 'UNKNOWN';

--- a/src/services/ios/testmanagerd/index.ts
+++ b/src/services/ios/testmanagerd/index.ts
@@ -785,10 +785,10 @@ export class DvtTestmanagedProxyService extends BaseService {
       return this.parseAuxiliaryStandard(buffer);
     }
 
-    // Alternate format used by go-ios / iOS 17+ testmanagerd callbacks:
+    // Alternate format used by iOS 17+ testmanagerd callbacks:
     // The first 16 bytes are an AuxiliaryHeader (magic + length) that does
     // not match the standard MESSAGE_AUX_MAGIC. The remaining bytes are
-    // DTX PrimitiveDictionary key-value pairs (see go-ios dtx.go).
+    // DTX PrimitiveDictionary key-value pairs.
     const result = this.parseAuxiliaryPrimitiveDictionary(buffer.subarray(16));
     if (result.length === 0) {
       log.debug(

--- a/test/integration/afc-push-performance-test.ts
+++ b/test/integration/afc-push-performance-test.ts
@@ -1,0 +1,145 @@
+import { expect } from 'chai';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { getLogger } from '../../src/lib/logger.js';
+import * as Services from '../../src/services.js';
+import { AfcFileMode } from '../../src/services/ios/afc/enums.js';
+import type AfcService from '../../src/services/ios/afc/index.js';
+
+const log = getLogger('AFC.PushPerformance.test');
+
+const MIB = 1024 * 1024;
+const DEFAULT_PUSH_SIZE_BYTES = 10 * MIB;
+const DEFAULT_MAX_DURATION_MS = 120_000;
+
+/**
+ * Integration test for large AFC uploads over an active RemoteXPC tunnel.
+ *
+ * Required:
+ * - UDID: target device UDID
+ * - Tunnel registry running (e.g. `sudo npm run test:tunnel-creation`)
+ *
+ * Optional:
+ * - AFC_PUSH_SIZE_BYTES: upload size in bytes (default: 10 MiB)
+ * - AFC_PUSH_MAX_MS: max allowed upload duration in ms (default: 120000)
+ *
+ * Example:
+ *   UDID=... AFC_PUSH_MAX_MS=60000 npm run test:afc-push-perf
+ */
+describe('AFC push performance', function () {
+  const udid = process.env.UDID || '';
+  const pushSizeBytes = parsePositiveInt(
+    process.env.AFC_PUSH_SIZE_BYTES,
+    DEFAULT_PUSH_SIZE_BYTES,
+  );
+  const maxDurationMs = parsePositiveInt(
+    process.env.AFC_PUSH_MAX_MS,
+    DEFAULT_MAX_DURATION_MS,
+  );
+
+  // Mocha hook timeout must exceed the perf ceiling plus setup/teardown.
+  this.timeout(maxDurationMs + 30_000);
+
+  let afc: AfcService;
+  let localPath = '';
+  let remotePath = '';
+
+  before(async function () {
+    if (!udid) {
+      log.warn('Skipping AFC push performance test: UDID is not set');
+      this.skip();
+      return;
+    }
+
+    localPath = path.join(
+      os.tmpdir(),
+      `afc_push_perf_${Date.now()}_${pushSizeBytes}.bin`,
+    );
+    remotePath = `/Downloads/afc_push_perf_${Date.now()}.bin`;
+
+    log.info(
+      `Preparing ${formatMiB(pushSizeBytes)} local file at ${localPath}`,
+    );
+    await writeFixedSizeFile(localPath, pushSizeBytes);
+
+    afc = await Services.startAfcService(udid);
+  });
+
+  after(async function () {
+    try {
+      if (afc && remotePath) {
+        await afc.rm(remotePath, true);
+      }
+    } catch {
+      // ignore cleanup errors
+    }
+    try {
+      afc?.close();
+    } catch {
+      // ignore
+    }
+    if (localPath) {
+      try {
+        await fs.unlink(localPath);
+      } catch {
+        // ignore
+      }
+    }
+  });
+
+  it('should push a large file within the configured duration budget', async function () {
+    log.info(
+      `Uploading ${formatMiB(pushSizeBytes)} to ${remotePath} (max ${maxDurationMs}ms)`,
+    );
+
+    const startedAt = performance.now();
+    await afc.push(localPath, remotePath);
+    const elapsedMs = performance.now() - startedAt;
+
+    const stat = await afc.stat(remotePath);
+    expect(stat.st_ifmt).to.equal(AfcFileMode.S_IFREG);
+    expect(stat.st_size).to.equal(BigInt(pushSizeBytes));
+
+    const mibPerSecond = pushSizeBytes / MIB / (elapsedMs / 1000);
+    log.info(
+      `AFC push completed in ${elapsedMs.toFixed(0)}ms (${mibPerSecond.toFixed(2)} MiB/s)`,
+    );
+
+    expect(elapsedMs).to.be.lessThan(
+      maxDurationMs,
+      `expected push to finish within ${maxDurationMs}ms but took ${elapsedMs.toFixed(0)}ms (${mibPerSecond.toFixed(2)} MiB/s)`,
+    );
+  });
+});
+
+function parsePositiveInt(raw: string | undefined, fallback: number): number {
+  if (!raw) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`Expected a positive integer, got "${raw}"`);
+  }
+  return parsed;
+}
+
+function formatMiB(bytes: number): string {
+  return `${(bytes / MIB).toFixed(1)} MiB`;
+}
+
+async function writeFixedSizeFile(filePath: string, sizeBytes: number): Promise<void> {
+  const chunk = Buffer.alloc(MIB, 0x42);
+  const handle = await fs.open(filePath, 'w');
+  try {
+    let written = 0;
+    while (written < sizeBytes) {
+      const toWrite = Math.min(chunk.length, sizeBytes - written);
+      await handle.write(chunk.subarray(0, toWrite));
+      written += toWrite;
+    }
+  } finally {
+    await handle.close();
+  }
+}

--- a/test/integration/afc-push-performance-test.ts
+++ b/test/integration/afc-push-performance-test.ts
@@ -129,7 +129,10 @@ function formatMiB(bytes: number): string {
   return `${(bytes / MIB).toFixed(1)} MiB`;
 }
 
-async function writeFixedSizeFile(filePath: string, sizeBytes: number): Promise<void> {
+async function writeFixedSizeFile(
+  filePath: string,
+  sizeBytes: number,
+): Promise<void> {
   const chunk = Buffer.alloc(MIB, 0x42);
   const handle = await fs.open(filePath, 'w');
   try {

--- a/test/unit/afc/codec.spec.ts
+++ b/test/unit/afc/codec.spec.ts
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import {
   cstr,
   encodeHeader,
+  encodeHeaderExplicit,
   nanosecondsToMilliseconds,
   parseCStringArray,
   parseKeyValueNullList,
@@ -13,7 +14,6 @@ import {
   AFCMAGIC,
   AFC_FOPEN_TEXTUAL_MODES,
   AFC_HEADER_SIZE,
-  AFC_WRITE_THIS_LENGTH,
 } from '../../../src/services/ios/afc/constants.js';
 import { AfcFopenMode } from '../../../src/services/ios/afc/enums.js';
 
@@ -59,10 +59,14 @@ describe('AFC Codec Utilities', function () {
     expect(Number(opcode)).to.equal(Number(op));
   });
 
-  it('should support WRITE-specific this_length override', function () {
-    const hdr = encodeHeader(0x10 /* WRITE */, 0n, 64, AFC_WRITE_THIS_LENGTH);
-    const thisLen = readUInt64LE(hdr, 16);
-    expect(Number(thisLen)).to.equal(AFC_WRITE_THIS_LENGTH);
+  it('should support WRITE-specific this_length for split payloads', function () {
+    const handleLen = 8;
+    const contentLen = 64;
+    const thisLen = AFC_HEADER_SIZE + handleLen;
+    const entireLen = thisLen + contentLen;
+    const hdr = encodeHeaderExplicit(0x10 /* WRITE */, 0n, entireLen, thisLen);
+    expect(Number(readUInt64LE(hdr, 8))).to.equal(entireLen);
+    expect(Number(readUInt64LE(hdr, 16))).to.equal(thisLen);
   });
 
   it('should encode C-string with trailing null', function () {

--- a/test/unit/afc/codec.spec.ts
+++ b/test/unit/afc/codec.spec.ts
@@ -100,11 +100,11 @@ describe('AFC Codec Utilities', function () {
   });
 
   it('should map textual fopen modes correctly', function () {
-    expect(AFC_FOPEN_TEXTUAL_MODES['r']).to.equal(AfcFopenMode.RDONLY);
+    expect(AFC_FOPEN_TEXTUAL_MODES.r).to.equal(AfcFopenMode.RDONLY);
     expect(AFC_FOPEN_TEXTUAL_MODES['r+']).to.equal(AfcFopenMode.RW);
-    expect(AFC_FOPEN_TEXTUAL_MODES['w']).to.equal(AfcFopenMode.WRONLY);
+    expect(AFC_FOPEN_TEXTUAL_MODES.w).to.equal(AfcFopenMode.WRONLY);
     expect(AFC_FOPEN_TEXTUAL_MODES['w+']).to.equal(AfcFopenMode.WR);
-    expect(AFC_FOPEN_TEXTUAL_MODES['a']).to.equal(AfcFopenMode.APPEND);
+    expect(AFC_FOPEN_TEXTUAL_MODES.a).to.equal(AfcFopenMode.APPEND);
     expect(AFC_FOPEN_TEXTUAL_MODES['a+']).to.equal(AfcFopenMode.RDAPPEND);
   });
 

--- a/test/unit/afc/demux.spec.ts
+++ b/test/unit/afc/demux.spec.ts
@@ -32,14 +32,13 @@ describe('AfcPacketDemux', function () {
       Buffer.from('/Downloads\0'),
     );
 
-    const requestHeader = await readExactFromSocket(deviceSide, AFC_HEADER_SIZE);
+    const requestHeader = await readExactFromSocket(
+      deviceSide,
+      AFC_HEADER_SIZE,
+    );
     const packetNum = readUInt64LE(requestHeader, 24);
     deviceSide.write(
-      encodeResponse(
-        AfcOpcode.DATA,
-        packetNum,
-        Buffer.from('file.txt\0\0'),
-      ),
+      encodeResponse(AfcOpcode.DATA, packetNum, Buffer.from('file.txt\0\0')),
     );
 
     const { status, data } = await responseTask;
@@ -62,11 +61,16 @@ describe('AfcPacketDemux', function () {
       Buffer.from('/missing\0'),
     );
 
-    const requestHeader = await readExactFromSocket(deviceSide, AFC_HEADER_SIZE);
+    const requestHeader = await readExactFromSocket(
+      deviceSide,
+      AFC_HEADER_SIZE,
+    );
     const packetNum = readUInt64LE(requestHeader, 24);
     const statusPayload = Buffer.alloc(8);
     statusPayload.writeBigUInt64LE(BigInt(AfcError.OBJECT_NOT_FOUND), 0);
-    deviceSide.write(encodeResponse(AfcOpcode.STATUS, packetNum, statusPayload));
+    deviceSide.write(
+      encodeResponse(AfcOpcode.STATUS, packetNum, statusPayload),
+    );
 
     const { status, data } = await responseTask;
     expect(status).to.equal(AfcError.OBJECT_NOT_FOUND);
@@ -127,10 +131,7 @@ async function createPairedSockets(): Promise<{
   };
 }
 
-function readExactFromSocket(
-  socket: net.Socket,
-  n: number,
-): Promise<Buffer> {
+function readExactFromSocket(socket: net.Socket, n: number): Promise<Buffer> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
     let total = 0;

--- a/test/unit/afc/demux.spec.ts
+++ b/test/unit/afc/demux.spec.ts
@@ -1,0 +1,158 @@
+import { expect } from 'chai';
+import net from 'node:net';
+
+import { readUInt64LE } from '../../../src/services/ios/afc/codec.js';
+import { AFC_HEADER_SIZE } from '../../../src/services/ios/afc/constants.js';
+import { AfcPacketDemux } from '../../../src/services/ios/afc/demux.js';
+import { AfcError, AfcOpcode } from '../../../src/services/ios/afc/enums.js';
+
+function encodeResponse(
+  op: AfcOpcode,
+  packetNum: bigint,
+  payload: Buffer = Buffer.alloc(0),
+): Buffer {
+  const entireLen = AFC_HEADER_SIZE + payload.length;
+  const header = Buffer.alloc(AFC_HEADER_SIZE);
+  Buffer.from('CFA6LPAA', 'ascii').copy(header, 0);
+  header.writeBigUInt64LE(BigInt(entireLen), 8);
+  header.writeBigUInt64LE(BigInt(entireLen), 16);
+  header.writeBigUInt64LE(packetNum, 24);
+  header.writeBigUInt64LE(BigInt(op), 32);
+  return Buffer.concat([header, payload]);
+}
+
+describe('AfcPacketDemux', function () {
+  it('routes responses to the matching packet_num', async function () {
+    const { server, client, deviceSide, getSocket } =
+      await createPairedSockets();
+    const demux = new AfcPacketDemux(getSocket, () => {});
+
+    const responseTask = demux.sendAndWait(
+      AfcOpcode.READ_DIR,
+      Buffer.from('/Downloads\0'),
+    );
+
+    const requestHeader = await readExactFromSocket(deviceSide, AFC_HEADER_SIZE);
+    const packetNum = readUInt64LE(requestHeader, 24);
+    deviceSide.write(
+      encodeResponse(
+        AfcOpcode.DATA,
+        packetNum,
+        Buffer.from('file.txt\0\0'),
+      ),
+    );
+
+    const { status, data } = await responseTask;
+    expect(status).to.equal(AfcError.SUCCESS);
+    expect(data.toString('utf8')).to.include('file.txt');
+
+    demux.stop();
+    server.close();
+    client.destroy();
+    deviceSide.destroy();
+  });
+
+  it('parses STATUS responses', async function () {
+    const { server, client, deviceSide, getSocket } =
+      await createPairedSockets();
+    const demux = new AfcPacketDemux(getSocket, () => {});
+
+    const responseTask = demux.sendAndWait(
+      AfcOpcode.GET_FILE_INFO,
+      Buffer.from('/missing\0'),
+    );
+
+    const requestHeader = await readExactFromSocket(deviceSide, AFC_HEADER_SIZE);
+    const packetNum = readUInt64LE(requestHeader, 24);
+    const statusPayload = Buffer.alloc(8);
+    statusPayload.writeBigUInt64LE(BigInt(AfcError.OBJECT_NOT_FOUND), 0);
+    deviceSide.write(encodeResponse(AfcOpcode.STATUS, packetNum, statusPayload));
+
+    const { status, data } = await responseTask;
+    expect(status).to.equal(AfcError.OBJECT_NOT_FOUND);
+    expect(data.length).to.equal(0);
+
+    demux.stop();
+    server.close();
+    client.destroy();
+    deviceSide.destroy();
+  });
+});
+
+async function createPairedSockets(): Promise<{
+  server: net.Server;
+  client: net.Socket;
+  deviceSide: net.Socket;
+  getSocket: () => Promise<net.Socket>;
+}> {
+  let deviceSide: net.Socket | null = null;
+  const server = net.createServer((socket) => {
+    deviceSide = socket;
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('expected TCP server address');
+  }
+
+  const client = await new Promise<net.Socket>((resolve, reject) => {
+    const conn = net.createConnection(address.port, address.address, () =>
+      resolve(conn),
+    );
+    conn.once('error', reject);
+  });
+
+  await new Promise<void>((resolve) => {
+    const check = () => {
+      if (deviceSide) {
+        resolve();
+        return;
+      }
+      setImmediate(check);
+    };
+    check();
+  });
+
+  const getSocket = async () => client;
+
+  return {
+    server,
+    client,
+    deviceSide: deviceSide as net.Socket,
+    getSocket,
+  };
+}
+
+function readExactFromSocket(
+  socket: net.Socket,
+  n: number,
+): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+
+    const onData = (chunk: Buffer) => {
+      chunks.push(chunk);
+      total += chunk.length;
+      if (total >= n) {
+        cleanup();
+        resolve(Buffer.concat(chunks).subarray(0, n));
+      }
+    };
+    const onError = (err: Error) => {
+      cleanup();
+      reject(err);
+    };
+    const cleanup = () => {
+      socket.off('data', onData);
+      socket.off('error', onError);
+    };
+
+    socket.on('data', onData);
+    socket.once('error', onError);
+  });
+}


### PR DESCRIPTION
## Summary

Fixes AFC install/upload hangs and timeouts when using RemoteXPC tunnels ([#208](https://github.com/appium/appium-ios-remotexpc/issues/208)).

The previous AFC client used a sequential send-then-receive model on a shared socket without routing responses by `packet_num`. That could desync under load (especially large IPA uploads with many 1 MiB WRITE chunks), leading to 15s operation timeouts and apparent driver hangs during `fullReset` app install.

This PR:

- Adds **`AfcPacketDemux`** — a background reader that routes inbound AFC packets to the matching request by `packet_num`, with serialized sends and per-operation timeouts.
- Fixes **`_connect()`** so the demux reader starts on connect and is reset only when the socket is replaced.
- Improves **WRITE packet framing** — three socket writes (header / handle / data) with correct `this_length` vs `entire_length`, avoiding per-chunk `Buffer.concat`.
- Enables **`TCP_NODELAY`** on AFC service sockets and uses **1 MiB** read/write chunks with a **30s** operation timeout.
- Removes **advisory FILE_LOCK** around uploads (not used on the reference install path; saves two round-trips per file).
- Adds a dedicated **AFC push performance integration test** for regression tracking on real devices/tunnels.
- Adds unit tests for demux routing and updated codec header tests.

**Note:** Benchmarking showed tunnel throughput also varies widely by stack (~58s vs ~8s vs ~1s for 10 MiB AFC over Appium tuntap / lockdown tunnel / go-ios tunnel). This PR fixes AFC protocol correctness and write efficiency; further install speed gains depend on **`appium-ios-tuntap`** (tracked separately).

## Changes

| Area | Files |
|---|---|
| Response demux | `src/services/ios/afc/demux.ts` (new) |
| AFC service | `src/services/ios/afc/index.ts` |
| Codec / writes | `src/services/ios/afc/codec.ts` |
| Constants | `src/services/ios/afc/constants.ts` |
| Streams | `src/services/ios/afc/stream-utils.ts` |
| Perf integration test | `test/integration/afc-push-performance-test.ts` (new) |
| Unit tests | `test/unit/afc/demux.spec.ts` (new), `test/unit/afc/codec.spec.ts` |
| npm script | `test:afc-push-perf` in `package.json` |
| Comment cleanup | `src/services/ios/testmanagerd/index.ts` |

## Integration test: AFC push performance

New test: `npm run test:afc-push-perf`

- Requires `UDID` and an active tunnel (`npm run test:tunnel-creation`)
- Uploads **10 MiB** (configurable via `AFC_PUSH_SIZE_BYTES`) to `/Downloads/…`
- Verifies remote file size via `stat`
- Asserts upload completes within **`AFC_PUSH_MAX_MS`** (default **120s**)
- Logs duration and **MiB/s** for manual/regression comparison

```bash
UDID=<udid> npm run test:afc-push-perf
UDID=<udid> AFC_PUSH_MAX_MS=60000 npm run test:afc-push-perf   # stricter budget after tuntap fix
```

## Test plan

- [ ] `npm run build`
- [ ] `npm run test:unit -- --grep 'AfcPacketDemux|AFC Codec'`
- [ ] `npm run test:unit` (full unit suite)
- [ ] With Appium tunnel running:
  ```bash
  UDID=<udid> npm run test:afc-push-perf
  ```
- [ ] `UDID=<udid> npm run test:afc` (existing AFC integration suite)
- [ ] Verify `listdir` / `stat` / `push` / `pull` over RSD AFC
- [ ] (Optional) Full 200 MiB IPA push via xcuitest-driver `fullReset` install with tunnel active — confirm no hang vs issue #208
