### PR TITLE
feat: Only perform packet tap lazily

### DIFF
--- a/scripts/start-appletv-tunnel.mjs
+++ b/scripts/start-appletv-tunnel.mjs
@@ -186,17 +186,18 @@ async function establishOneTunnel(startResult, packetStreamBaseRef) {
   try {
     packetStreamPort = packetStreamBaseRef.value++;
     const pss = new PacketStreamServer(packetStreamPort);
+    if (tunnel.addPacketConsumer && tunnel.removePacketConsumer) {
+      pss.bindTunnel(tunnel);
+    } else {
+      log.warn(
+        `Tunnel for ${device.identifier} does not support packet consumers`,
+      );
+    }
     await pss.start();
 
-    const consumer = pss.getPacketConsumer();
-    if (consumer && tunnel.addPacketConsumer) {
-      tunnel.addPacketConsumer(consumer);
-      log.info(
-        `Packet stream server for ${device.identifier} on port ${packetStreamPort}`,
-      );
-    } else {
-      log.warn(`Failed to attach packet consumer for ${device.identifier}`);
-    }
+    log.info(
+      `Packet stream server for ${device.identifier} on port ${packetStreamPort}`,
+    );
     packetStreamServers.set(device.identifier, pss);
   } catch (err) {
     log.warn(`Failed to start packet stream server for ${device.identifier}: ${err}`);

--- a/scripts/tunnel-creation.mjs
+++ b/scripts/tunnel-creation.mjs
@@ -357,12 +357,8 @@ async function createTunnelForDevice(device, tlsOptions, packetStreamBaseRef) {
     try {
       packetStreamPort = packetStreamBaseRef.value++;
       const packetStreamServer = new PacketStreamServer(packetStreamPort);
+      packetStreamServer.bindTunnel(tunnel);
       await packetStreamServer.start();
-
-      const consumer = packetStreamServer.getPacketConsumer();
-      if (consumer) {
-        tunnel.addPacketConsumer(consumer);
-      }
 
       packetStreamServers.set(udid, packetStreamServer);
 

--- a/src/lib/tunnel/packet-stream-server.ts
+++ b/src/lib/tunnel/packet-stream-server.ts
@@ -3,8 +3,14 @@ import { EventEmitter } from 'node:events';
 import { type Server, type Socket, createServer } from 'node:net';
 
 import { getLogger } from '../logger.js';
+import type { PacketSource } from '../types.js';
 
 const log = getLogger('PacketStreamServer');
+
+type TunnelPacketBinding = Pick<
+  PacketSource,
+  'addPacketConsumer' | 'removePacketConsumer'
+>;
 
 /**
  * Server that exposes packet streaming from a tunnel over TCP
@@ -14,9 +20,21 @@ export class PacketStreamServer extends EventEmitter {
   private server: Server | null = null;
   private readonly clients: Set<Socket> = new Set();
   private packetConsumer: PacketConsumer | null = null;
+  private tunnel: TunnelPacketBinding | null = null;
+  private attachedToTunnel = false;
 
   constructor(private readonly port: number) {
     super();
+  }
+
+  /**
+   * Bind the tunnel whose packet consumer is attached only while TCP clients are connected.
+   */
+  bindTunnel(tunnel: TunnelPacketBinding): void {
+    this.tunnel = tunnel;
+    if (this.clients.size > 0) {
+      this.attachToTunnel();
+    }
   }
 
   /**
@@ -33,8 +51,6 @@ export class PacketStreamServer extends EventEmitter {
     });
     const server = this.server;
 
-    this.packetConsumer = this.createPacketConsumer();
-
     await new Promise<void>((resolve, reject) => {
       server.once('error', reject);
       server.listen(this.port, resolve);
@@ -43,6 +59,8 @@ export class PacketStreamServer extends EventEmitter {
   }
 
   async stop(): Promise<void> {
+    this.detachFromTunnel();
+
     for (const client of this.clients) {
       client.destroy();
     }
@@ -58,6 +76,10 @@ export class PacketStreamServer extends EventEmitter {
     }
   }
 
+  /**
+   * Returns the packet consumer used when attached to a tunnel.
+   * Prefer {@link bindTunnel} for lifecycle management.
+   */
   getPacketConsumer(): PacketConsumer | null {
     return this.packetConsumer;
   }
@@ -69,15 +91,50 @@ export class PacketStreamServer extends EventEmitter {
     log.info(`Client connected from ${client.remoteAddress}`);
     this.clients.add(client);
 
+    if (this.clients.size === 1) {
+      this.attachToTunnel();
+    }
+
+    const onClientGone = (): void => {
+      this.clients.delete(client);
+      if (this.clients.size === 0) {
+        this.detachFromTunnel();
+      }
+    };
+
     client.on('close', () => {
       log.info(`Client disconnected from ${client.remoteAddress}`);
-      this.clients.delete(client);
+      onClientGone();
     });
 
     client.on('error', (err) => {
       log.error(`Client error: ${err}`);
-      this.clients.delete(client);
+      onClientGone();
     });
+  }
+
+  private attachToTunnel(): void {
+    if (this.attachedToTunnel || !this.tunnel) {
+      return;
+    }
+
+    if (!this.packetConsumer) {
+      this.packetConsumer = this.createPacketConsumer();
+    }
+
+    this.tunnel.addPacketConsumer(this.packetConsumer);
+    this.attachedToTunnel = true;
+    log.debug('Attached packet consumer to tunnel');
+  }
+
+  private detachFromTunnel(): void {
+    if (!this.attachedToTunnel || !this.tunnel || !this.packetConsumer) {
+      return;
+    }
+
+    this.tunnel.removePacketConsumer(this.packetConsumer);
+    this.attachedToTunnel = false;
+    log.debug('Detached packet consumer from tunnel');
   }
 
   /**

--- a/test/unit/tunnel/packet-stream-server.spec.ts
+++ b/test/unit/tunnel/packet-stream-server.spec.ts
@@ -1,0 +1,171 @@
+import { expect } from 'chai';
+import { type AddressInfo, createConnection, createServer } from 'node:net';
+
+import { PacketStreamServer } from '../../../src/lib/tunnel/packet-stream-server.js';
+import type { PacketConsumer } from '../../../src/lib/types.js';
+
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once('error', reject);
+    server.listen(0, () => {
+      const address = server.address() as AddressInfo;
+      server.close((err) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve(address.port);
+      });
+    });
+  });
+}
+
+function createMockTunnel() {
+  const added: PacketConsumer[] = [];
+  const removed: PacketConsumer[] = [];
+
+  return {
+    tunnel: {
+      addPacketConsumer(consumer: PacketConsumer): void {
+        added.push(consumer);
+      },
+      removePacketConsumer(consumer: PacketConsumer): void {
+        removed.push(consumer);
+      },
+    },
+    added,
+    removed,
+  };
+}
+
+function connectClient(port: number): Promise<import('node:net').Socket> {
+  return new Promise((resolve, reject) => {
+    const client = createConnection({ host: '127.0.0.1', port }, () => {
+      resolve(client);
+    });
+    client.once('error', reject);
+  });
+}
+
+function closeClient(client: import('node:net').Socket): Promise<void> {
+  return new Promise((resolve) => {
+    client.once('close', () => resolve());
+    client.end();
+  });
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 1000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error('Timed out waiting for condition');
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+describe('PacketStreamServer', function () {
+  let port: number;
+  let server: PacketStreamServer;
+
+  beforeEach(async function () {
+    port = await getFreePort();
+    server = new PacketStreamServer(port);
+  });
+
+  afterEach(async function () {
+    await server.stop();
+  });
+
+  it('does not attach tunnel consumer when started with zero clients', async function () {
+    const { tunnel, added } = createMockTunnel();
+
+    server.bindTunnel(tunnel);
+    await server.start();
+
+    expect(added).to.have.lengthOf(0);
+    expect(server.getPacketConsumer()).to.be.null;
+  });
+
+  it('attaches tunnel consumer on first client and detaches on last disconnect', async function () {
+    const { tunnel, added, removed } = createMockTunnel();
+
+    server.bindTunnel(tunnel);
+    await server.start();
+
+    const client = await connectClient(port);
+    await waitFor(() => added.length === 1);
+
+    expect(added).to.have.lengthOf(1);
+    expect(server.getPacketConsumer()).to.equal(added[0]);
+    expect(removed).to.have.lengthOf(0);
+
+    await closeClient(client);
+    await waitFor(() => removed.length === 1);
+
+    expect(removed).to.have.lengthOf(1);
+    expect(removed[0]).to.equal(added[0]);
+  });
+
+  it('keeps tunnel consumer attached while any client remains connected', async function () {
+    const { tunnel, added, removed } = createMockTunnel();
+
+    server.bindTunnel(tunnel);
+    await server.start();
+
+    const client1 = await connectClient(port);
+    const client2 = await connectClient(port);
+
+    expect(added).to.have.lengthOf(1);
+
+    await closeClient(client1);
+    await waitFor(() => removed.length === 0);
+
+    expect(removed).to.have.lengthOf(0);
+
+    await closeClient(client2);
+    await waitFor(() => removed.length === 1);
+
+    expect(removed).to.have.lengthOf(1);
+  });
+
+  it('attaches when bindTunnel is called after clients are already connected', async function () {
+    const { tunnel, added } = createMockTunnel();
+
+    await server.start();
+
+    const client = await connectClient(port);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(added).to.have.lengthOf(0);
+
+    server.bindTunnel(tunnel);
+    await waitFor(() => added.length === 1);
+
+    expect(added).to.have.lengthOf(1);
+
+    await closeClient(client);
+  });
+
+  it('detaches from tunnel when stopped', async function () {
+    const { tunnel, added, removed } = createMockTunnel();
+
+    server.bindTunnel(tunnel);
+    await server.start();
+
+    const client = await connectClient(port);
+    await waitFor(() => added.length === 1);
+
+    expect(added).to.have.lengthOf(1);
+
+    await server.stop();
+
+    expect(removed).to.have.lengthOf(1);
+    expect(removed[0]).to.equal(added[0]);
+
+    client.destroy();
+  });
+});

--- a/test/unit/tunnel/packet-stream-server.spec.ts
+++ b/test/unit/tunnel/packet-stream-server.spec.ts
@@ -119,12 +119,11 @@ describe('PacketStreamServer', function () {
 
     const client1 = await connectClient(port);
     const client2 = await connectClient(port);
+    await waitFor(() => added.length === 1);
 
     expect(added).to.have.lengthOf(1);
 
     await closeClient(client1);
-    await waitFor(() => removed.length === 0);
-
     expect(removed).to.have.lengthOf(0);
 
     await closeClient(client2);


### PR DESCRIPTION
## Summary

When the tunnel packet stream server is enabled, L4 packet tap was registered on the tunnel at startup — even with zero TCP clients connected. That forces every device→TUN frame through `tapL4Packet()` and adds ~7–15% overhead on hot paths like zip_conduit IPA installs.

This PR makes packet tap **lazy**: the tunnel consumer is attached only while at least one `PacketStreamServer` client is connected, and detached when the last client leaves or the server stops.

| Scenario | L4 parse on install path |
|----------|----------------------------|
| Packet stream server running, no clients | Off |
| Client connects | On |
| All clients disconnect | Off again |

### Changes

- **`PacketStreamServer`**: new `bindTunnel()` API; `start()` only opens the TCP listener; attach on first client, detach on last disconnect / `stop()`
- **`scripts/tunnel-creation.mjs`** and **`scripts/start-appletv-tunnel.mjs`**: call `bindTunnel(tunnel)` instead of `tunnel.addPacketConsumer(...)` at tunnel creation
- **Unit tests**: `test/unit/tunnel/packet-stream-server.spec.ts` covers attach/detach lifecycle

### Motivation

Benchmarks on a ~200 MiB IPA install:

| Path | Install time |
|------|-------------|
| `appium-ios-device` (no tunnel) | ~14s |
| remotexpc zip_conduit, packet tap off | ~20–21s |
| remotexpc zip_conduit, packet tap on | ~22–25s |

With lazy attach, running tunnel-creation with packet stream enabled but no connected clients should match tap-off performance. Tap cost is only paid when something is actively capturing packets.
