### PR TITLE
feat: Bump appium-ios-tuntap to ^1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,23 +106,22 @@ The `appium-ios-tuntap (previously tuntap-bridge)` module plays a crucial role i
 import {
   createLockdownServiceByUDID,
   rsdSessionLockKey,
-  startCoreDeviceProxy,
+  startCoreDeviceProxyTcp,
   TunnelManager,
 } from 'appium-ios-remotexpc';
 
 // Create lockdown service
 const { lockdownService, device } = await createLockdownServiceByUDID(udid);
 
-// Start CoreDeviceProxy
-const { socket } = await startCoreDeviceProxy(
+// Start CoreDeviceProxy (raw TCP; TLS handled in native forwarder)
+const { socket, cert, key } = await startCoreDeviceProxyTcp(
   lockdownService,
   device.DeviceID,
   device.Properties.SerialNumber,
-  { rejectUnauthorized: false }
 );
 
 // Create tunnel using tuntap
-const tunnel = await TunnelManager.getTunnel(socket);
+const tunnel = await TunnelManager.getTunnel(socket, { cert, key });
 console.log(`Tunnel created at ${tunnel.Address} with RSD port ${tunnel.RsdPort}`);
 
 // Discover RSD services (serialized per tunnel; closed before return)

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@appium/strongbox": "^1.0.0-rc.1",
     "@appium/support": "^7.2.2",
     "@xmldom/xmldom": "^0.x",
-    "appium-ios-tuntap": "^0.x",
+    "appium-ios-tuntap": "^1.0.0",
     "async-lock": "^1.4.1",
     "axios": "^1.15.1",
     "commander": "^14.0.1",

--- a/scripts/start-appletv-tunnel.mjs
+++ b/scripts/start-appletv-tunnel.mjs
@@ -26,8 +26,26 @@ let registryServer = null;
 const registryWatcherStops = [];
 /** @type {Map<string, Promise<void>>} */
 const reconnectingByUdid = new Map();
-/** @type {AppleTvEstablishedTunnel[]} */
-const establishedTunnels = [];
+/** @type {Map<string, AppleTvEstablishedTunnel>} */
+const establishedTunnelsByUdid = new Map();
+
+function registerEstablishedTunnel(result) {
+  const udid = result.device.identifier;
+  const previous = establishedTunnelsByUdid.get(udid);
+  if (
+    previous?.tunnelConnection &&
+    previous.tunnelConnection !== result.tunnelConnection
+  ) {
+    void (async () => {
+      try {
+        await previous.tunnelConnection.closer();
+      } catch {
+        // superseded tunnel may already be stopped
+      }
+    })();
+  }
+  establishedTunnelsByUdid.set(udid, result);
+}
 let tunnelService = null;
 
 function parsePort(value) {
@@ -91,7 +109,7 @@ function setupCleanupHandlers() {
         } catch {}
       }
 
-      for (const { tunnelConnection } of establishedTunnels) {
+      for (const { tunnelConnection } of establishedTunnelsByUdid.values()) {
         try {
           if (tunnelConnection && typeof tunnelConnection.closer === 'function') {
             log.info('Closing tunnel...');
@@ -101,7 +119,7 @@ function setupCleanupHandlers() {
           log.warn(`Error closing tunnel: ${err}`);
         }
       }
-      establishedTunnels.length = 0;
+      establishedTunnelsByUdid.clear();
 
       if (tunnelService) {
         tunnelService.disconnect();
@@ -165,7 +183,7 @@ async function establishOneTunnel(startResult) {
     },
   };
 
-  establishedTunnels.push(result);
+  registerEstablishedTunnel(result);
   return result;
 }
 

--- a/scripts/start-appletv-tunnel.mjs
+++ b/scripts/start-appletv-tunnel.mjs
@@ -14,7 +14,7 @@ import {
   discoverServices,
   servicesToCatalog,
   startTunnelRegistryServer,
-  watchTunnelRegistrySockets,
+  watchTunnelRegistryOnDead,
 } from 'appium-ios-remotexpc';
 import { DEFAULT_TUNNEL_REGISTRY_PORT } from '../build/src/lib/tunnel/tunnel-registry-server.js';
 
@@ -55,21 +55,12 @@ function parseNonNegativeInteger(value) {
  * @param {AppleTvEstablishedTunnel[]} successfulResults
  */
 function attachAppleTvTunnelRegistryLifecycleWatch(registry, successfulResults, callbacks = {}) {
-  const watches = successfulResults
-    .filter((r) => r.tlsSocket)
-    .map((r) => {
-      const watch = {
-        udid: r.device.identifier,
-        socket: r.tlsSocket,
-      };
-      return watch;
-    });
+  const watches = successfulResults.map((r) => ({
+    udid: r.device.identifier,
+    registerOnDead: r.registerOnDead,
+  }));
 
-  if (watches.length === 0) {
-    return;
-  }
-
-  const { stop } = watchTunnelRegistrySockets({
+  const { stop } = watchTunnelRegistryOnDead({
     registry,
     watches,
     onRemove: async (udid) => {
@@ -84,7 +75,7 @@ function attachAppleTvTunnelRegistryLifecycleWatch(registry, successfulResults, 
   });
   registryWatcherStops.push(stop);
   log.info(
-    'Tunnel registry will update automatically if a tunnel upstream socket goes away.',
+    'Tunnel registry will update automatically if a native forwarder exits unexpectedly.',
   );
 }
 
@@ -100,18 +91,14 @@ function setupCleanupHandlers() {
         } catch {}
       }
 
-      for (const { tunnel, tlsSocket } of establishedTunnels) {
+      for (const { tunnelConnection } of establishedTunnels) {
         try {
-          if (tunnel && typeof tunnel.closer === 'function') {
+          if (tunnelConnection && typeof tunnelConnection.closer === 'function') {
             log.info('Closing tunnel...');
-            await tunnel.closer();
+            await tunnelConnection.closer();
           }
         } catch (err) {
           log.warn(`Error closing tunnel: ${err}`);
-        }
-        if (tlsSocket && !tlsSocket.destroyed) {
-          log.info('Closing TLS-PSK connection...');
-          tlsSocket.destroy();
         }
       }
       establishedTunnels.length = 0;
@@ -151,25 +138,36 @@ function setupCleanupHandlers() {
 }
 
 /**
- * @param {{ socket: import('tls').TLSSocket; device: { identifier: string; name?: string } }} startResult
+ * @param {{ tcpSocket: import('net').Socket; psk: Buffer; device: { identifier: string; name?: string } }} startResult
  * @returns {Promise<AppleTvEstablishedTunnel>}
  */
 async function establishOneTunnel(startResult) {
-  const tlsSocket = startResult.socket;
-  const device = startResult.device;
+  const { tcpSocket, psk, device } = startResult;
+  const lifecycle = { notify: null };
 
-  log.info('Creating tunnel with TunnelManager...');
-  const tunnel = await TunnelManager.getTunnel(tlsSocket);
+  const tunnelConnection = await TunnelManager.getTunnelPsk(
+    tcpSocket,
+    { psk },
+    {
+      onDead: (reason) => lifecycle.notify?.(reason),
+    },
+  );
 
-  establishedTunnels.push({ tunnel, tlsSocket, device });
-
-  return {
+  const result = {
     device,
-    tunnel,
-    tlsSocket,
+    tunnel: {
+      Address: tunnelConnection.Address,
+      RsdPort: tunnelConnection.RsdPort,
+    },
+    tunnelConnection,
+    registerOnDead: (handler) => {
+      lifecycle.notify = handler;
+    },
   };
-}
 
+  establishedTunnels.push(result);
+  return result;
+}
 
 async function refreshServiceCatalog(udid, entry) {
   log.info(`Refreshing RSD service catalog for ${udid}...`);
@@ -257,8 +255,8 @@ async function runAppleTvReconnectAttempts({
 
     try {
       const result = await tunnelService.startTunnel(undefined, udid);
-      if (!result.socket) {
-        throw new Error('TLS-PSK socket not established');
+      if (!result.tcpSocket) {
+        throw new Error('TCP socket to listener port not established');
       }
       const reconnected = await establishOneTunnel(result);
       const ok = await publishDiscoveredTunnelEntry(reconnected);
@@ -353,47 +351,6 @@ async function main() {
   tunnelService = new AppleTVTunnelService();
 
   try {
-    /** @type {AppleTvEstablishedTunnel[]} */
-    const successfulResults = [];
-
-    if (deviceIdentifier) {
-      log.info('Starting Apple TV tunnel...');
-      const result = await tunnelService.startTunnel(undefined, deviceIdentifier);
-      if (!result.socket) {
-        throw new Error('TLS-PSK socket not established');
-      }
-      successfulResults.push(await establishOneTunnel(result));
-    } else {
-      const devices = await tunnelService.discoverDevices();
-      log.info(
-        `Discovered ${devices.length} Apple TV device(s); establishing tunnels...`,
-      );
-
-      for (let i = 0; i < devices.length; i++) {
-        const d = devices[i];
-        try {
-          log.info(`\n--- ${d.identifier} (${d.name ?? 'Apple TV'}) ---`);
-          const result = await tunnelService.startTunnel(undefined, d.identifier);
-          if (!result.socket) {
-            throw new Error('TLS-PSK socket not established');
-          }
-          successfulResults.push(
-            await establishOneTunnel(result),
-          );
-          log.info(`Tunnel established for ${d.identifier}`);
-        } catch (err) {
-          log.warn(`Skipping ${d.identifier}: ${err}`);
-        }
-        if (i < devices.length - 1) {
-          await sleep(1000);
-        }
-      }
-    }
-
-    if (successfulResults.length === 0) {
-      throw new Error('No tunnel could be established');
-    }
-
     const readiness = new TunnelReadinessCoordinator();
     const registry = {
       tunnels: {},
@@ -409,29 +366,76 @@ async function main() {
       refreshServices: refreshServiceCatalog,
     });
 
-    const registryPublished = [];
-    for (const r of successfulResults) {
-      const ok = await publishDiscoveredTunnelEntry(r);
-      if (ok) {
-        registryPublished.push(r);
-      }
-    }
-
     const reconnectTunnelByUdid = createAppleTvReconnectTunnelByUdid({
       reconnectRetries: options.reconnectRetries,
       tunnelService,
     });
 
-    for (const r of registryPublished) {
+    /** @type {AppleTvEstablishedTunnel[]} */
+    const successfulResults = [];
+
+    if (deviceIdentifier) {
+      log.info('Starting Apple TV tunnel...');
+      const result = await tunnelService.startTunnel(undefined, deviceIdentifier);
+      if (!result.tcpSocket) {
+        throw new Error('TCP socket to listener port not established');
+      }
+      const established = await establishOneTunnel(result);
+      successfulResults.push(established);
       attachAppleTvTunnelRegistryLifecycleWatch(
         registryServer.getRegistry(),
-        [r],
+        [established],
         {
           onTunnelDead: async ({ udid }) => {
             await reconnectTunnelByUdid(udid);
           },
         },
       );
+    } else {
+      const devices = await tunnelService.discoverDevices();
+      log.info(
+        `Discovered ${devices.length} Apple TV device(s); establishing tunnels...`,
+      );
+
+      for (let i = 0; i < devices.length; i++) {
+        const d = devices[i];
+        try {
+          log.info(`\n--- ${d.identifier} (${d.name ?? 'Apple TV'}) ---`);
+          const result = await tunnelService.startTunnel(undefined, d.identifier);
+          if (!result.tcpSocket) {
+            throw new Error('TCP socket to listener port not established');
+          }
+          const established = await establishOneTunnel(result);
+          successfulResults.push(established);
+          attachAppleTvTunnelRegistryLifecycleWatch(
+            registryServer.getRegistry(),
+            [established],
+            {
+              onTunnelDead: async ({ udid }) => {
+                await reconnectTunnelByUdid(udid);
+              },
+            },
+          );
+          log.info(`Tunnel established for ${d.identifier}`);
+        } catch (err) {
+          log.warn(`Skipping ${d.identifier}: ${err}`);
+        }
+        if (i < devices.length - 1) {
+          await sleep(1000);
+        }
+      }
+    }
+
+    if (successfulResults.length === 0) {
+      throw new Error('No tunnel could be established');
+    }
+
+    const registryPublished = [];
+    for (const r of successfulResults) {
+      const ok = await publishDiscoveredTunnelEntry(r);
+      if (ok) {
+        registryPublished.push(r);
+      }
     }
 
     log.info(
@@ -473,5 +477,6 @@ await main();
  * @typedef {object} AppleTvEstablishedTunnel
  * @property {{ identifier: string, name?: string }} device
  * @property {{ Address: string, RsdPort?: number }} tunnel
- * @property {import('tls').TLSSocket} tlsSocket
+ * @property {import('appium-ios-tuntap').TunnelConnection} tunnelConnection
+ * @property {(handler: (reason: string) => void) => void} registerOnDead
  */

--- a/scripts/start-appletv-tunnel.mjs
+++ b/scripts/start-appletv-tunnel.mjs
@@ -29,20 +29,35 @@ const reconnectingByUdid = new Map();
 /** @type {Map<string, AppleTvEstablishedTunnel>} */
 const establishedTunnelsByUdid = new Map();
 
+/** @type {Map<string, () => void>} */
+const lifecycleWatchStopByUdid = new Map();
+
+async function closeTunnelQuietly(tunnelConnection) {
+  try {
+    await tunnelConnection.closer();
+  } catch {
+    // superseded tunnel may already be stopped
+  }
+}
+
+function stopLifecycleWatch(udid) {
+  const stop = lifecycleWatchStopByUdid.get(udid);
+  if (stop) {
+    stop();
+    lifecycleWatchStopByUdid.delete(udid);
+  }
+}
+
 function registerEstablishedTunnel(result) {
   const udid = result.device.identifier;
+  stopLifecycleWatch(udid);
+
   const previous = establishedTunnelsByUdid.get(udid);
   if (
     previous?.tunnelConnection &&
     previous.tunnelConnection !== result.tunnelConnection
   ) {
-    void (async () => {
-      try {
-        await previous.tunnelConnection.closer();
-      } catch {
-        // superseded tunnel may already be stopped
-      }
-    })();
+    void closeTunnelQuietly(previous.tunnelConnection);
   }
   establishedTunnelsByUdid.set(udid, result);
 }
@@ -73,25 +88,32 @@ function parseNonNegativeInteger(value) {
  * @param {AppleTvEstablishedTunnel[]} successfulResults
  */
 function attachAppleTvTunnelRegistryLifecycleWatch(registry, successfulResults, callbacks = {}) {
-  const watches = successfulResults.map((r) => ({
-    udid: r.device.identifier,
-    registerOnDead: r.registerOnDead,
-  }));
+  for (const result of successfulResults) {
+    const udid = result.device.identifier;
+    stopLifecycleWatch(udid);
 
-  const { stop } = watchTunnelRegistryOnDead({
-    registry,
-    watches,
-    onRemove: async (udid) => {
-      registryServer?.removeTunnelEntry(udid);
-    },
-    onTunnelDead: async ({ udid, address }) => {
-      await TunnelManager.closeTunnelByAddress(address).catch(() => {});
-      if (callbacks.onTunnelDead) {
-        await callbacks.onTunnelDead({ udid, address });
-      }
-    },
-  });
-  registryWatcherStops.push(stop);
+    const { stop } = watchTunnelRegistryOnDead({
+      registry,
+      watches: [
+        {
+          udid,
+          registerOnDead: result.registerOnDead,
+        },
+      ],
+      onRemove: async (removedUdid) => {
+        registryServer?.removeTunnelEntry(removedUdid);
+      },
+      onTunnelDead: async ({ udid: droppedUdid, address }) => {
+        await TunnelManager.closeTunnelByAddress(address).catch(() => {});
+        if (callbacks.onTunnelDead) {
+          await callbacks.onTunnelDead({ udid: droppedUdid, address });
+        }
+      },
+    });
+    registryWatcherStops.push(stop);
+    lifecycleWatchStopByUdid.set(udid, stop);
+  }
+
   log.info(
     'Tunnel registry will update automatically if a native forwarder exits unexpectedly.',
   );
@@ -108,6 +130,7 @@ function setupCleanupHandlers() {
           stop?.();
         } catch {}
       }
+      lifecycleWatchStopByUdid.clear();
 
       for (const { tunnelConnection } of establishedTunnelsByUdid.values()) {
         try {

--- a/scripts/tunnel-creation.mjs
+++ b/scripts/tunnel-creation.mjs
@@ -27,22 +27,71 @@ let registryServer = null;
 /** @type {Map<string, TunnelCreationSuccessResult>} */
 const establishedTunnelsByUdid = new Map();
 
+/** @type {Map<string, () => void>} */
+const lifecycleWatchStopByUdid = new Map();
+
+async function closeTunnelQuietly(tunnelConnection) {
+  try {
+    await tunnelConnection.closer();
+  } catch {
+    // superseded tunnel may already be stopped
+  }
+}
+
+function stopLifecycleWatch(udid) {
+  const stop = lifecycleWatchStopByUdid.get(udid);
+  if (stop) {
+    stop();
+    lifecycleWatchStopByUdid.delete(udid);
+  }
+}
+
 function registerEstablishedTunnel(result) {
   const udid = result.device.Properties.SerialNumber;
+  stopLifecycleWatch(udid);
+
   const previous = establishedTunnelsByUdid.get(udid);
   if (
     previous?.tunnelConnection &&
     previous.tunnelConnection !== result.tunnelConnection
   ) {
-    void (async () => {
-      try {
-        await previous.tunnelConnection.closer();
-      } catch {
-        // superseded tunnel may already be stopped
-      }
-    })();
+    void closeTunnelQuietly(previous.tunnelConnection);
   }
   establishedTunnelsByUdid.set(udid, result);
+}
+
+function connectionTypeRank(connectionType) {
+  if (connectionType === 'USB') {
+    return 0;
+  }
+  if (connectionType === 'Network') {
+    return 1;
+  }
+  return 2;
+}
+
+/**
+ * usbmux may list the same UDID twice (USB + Network). Prefer USB for tunneling.
+ *
+ * @param {import('appium-ios-remotexpc').UsbmuxDevice[]} devices
+ */
+function dedupeDevicesByUdid(devices) {
+  const byUdid = new Map();
+  for (const device of devices) {
+    const udid = device.Properties.SerialNumber;
+    const existing = byUdid.get(udid);
+    if (!existing) {
+      byUdid.set(udid, device);
+      continue;
+    }
+    if (
+      connectionTypeRank(device.Properties.ConnectionType) <
+      connectionTypeRank(existing.Properties.ConnectionType)
+    ) {
+      byUdid.set(udid, device);
+    }
+  }
+  return [...byUdid.values()];
 }
 
 function parsePort(value) {
@@ -142,25 +191,32 @@ const reconnectingByUdid = new Map();
  * @param {TunnelCreationSuccessResult[]} successful
  */
 function attachTunnelRegistryLifecycleWatch(registry, successful, callbacks = {}) {
-  const watches = successful.map((r) => ({
-    udid: r.device.Properties.SerialNumber,
-    registerOnDead: r.registerOnDead,
-  }));
+  for (const result of successful) {
+    const udid = result.device.Properties.SerialNumber;
+    stopLifecycleWatch(udid);
 
-  const { stop } = watchTunnelRegistryOnDead({
-    registry,
-    watches,
-    onRemove: async (udid) => {
-      registryServer?.removeTunnelEntry(udid);
-    },
-    onTunnelDead: async ({ udid, address }) => {
-      await TunnelManager.closeTunnelByAddress(address).catch(() => {});
-      if (callbacks.onTunnelDead) {
-        await callbacks.onTunnelDead({ udid, address });
-      }
-    },
-  });
-  registryWatcherStops.push(stop);
+    const { stop } = watchTunnelRegistryOnDead({
+      registry,
+      watches: [
+        {
+          udid,
+          registerOnDead: result.registerOnDead,
+        },
+      ],
+      onRemove: async (removedUdid) => {
+        registryServer?.removeTunnelEntry(removedUdid);
+      },
+      onTunnelDead: async ({ udid: droppedUdid, address }) => {
+        await TunnelManager.closeTunnelByAddress(address).catch(() => {});
+        if (callbacks.onTunnelDead) {
+          await callbacks.onTunnelDead({ udid: droppedUdid, address });
+        }
+      },
+    });
+    registryWatcherStops.push(stop);
+    lifecycleWatchStopByUdid.set(udid, stop);
+  }
+
   log.info(
     'Tunnel registry will update automatically if a native forwarder exits unexpectedly.',
   );
@@ -253,6 +309,7 @@ function setupCleanupHandlers() {
         stop?.();
       } catch {}
     }
+    lifecycleWatchStopByUdid.clear();
 
     for (const { tunnelConnection } of establishedTunnelsByUdid.values()) {
       try {
@@ -443,6 +500,14 @@ async function main() {
         });
         process.exit(1);
       }
+    }
+
+    const beforeDedupe = devicesToProcess.length;
+    devicesToProcess = dedupeDevicesByUdid(devicesToProcess);
+    if (devicesToProcess.length < beforeDedupe) {
+      log.info(
+        `Deduped ${beforeDedupe} usbmux entries to ${devicesToProcess.length} device(s) (USB preferred over Network)`,
+      );
     }
 
     log.info(`\nProcessing ${devicesToProcess.length} device(s)...`);

--- a/scripts/tunnel-creation.mjs
+++ b/scripts/tunnel-creation.mjs
@@ -15,7 +15,7 @@ import {
   servicesToCatalog,
   startCoreDeviceProxyTcp,
   startTunnelRegistryServer,
-  watchTunnelRegistrySockets,
+  watchTunnelRegistryOnDead,
 } from 'appium-ios-remotexpc';
 import { DEFAULT_TUNNEL_REGISTRY_PORT } from '../build/src/lib/tunnel/tunnel-registry-server.js';
 
@@ -23,6 +23,27 @@ const log = logger.getLogger('TunnelCreation');
 
 /** @type {import('appium-ios-remotexpc').TunnelRegistryServer | null} */
 let registryServer = null;
+
+/** @type {Map<string, TunnelCreationSuccessResult>} */
+const establishedTunnelsByUdid = new Map();
+
+function registerEstablishedTunnel(result) {
+  const udid = result.device.Properties.SerialNumber;
+  const previous = establishedTunnelsByUdid.get(udid);
+  if (
+    previous?.tunnelConnection &&
+    previous.tunnelConnection !== result.tunnelConnection
+  ) {
+    void (async () => {
+      try {
+        await previous.tunnelConnection.closer();
+      } catch {
+        // superseded tunnel may already be stopped
+      }
+    })();
+  }
+  establishedTunnelsByUdid.set(udid, result);
+}
 
 function parsePort(value) {
   const port = Number.parseInt(value, 10);
@@ -115,28 +136,18 @@ const registryWatcherStops = [];
 const reconnectingByUdid = new Map();
 
 /**
- * When CoreDeviceProxy upstream sockets go away, drop the UDID from the HTTP registry
- * and tear down TunnelManager state.
+ * When the native forwarder exits, drop the UDID from the HTTP registry and tear down state.
  *
  * @param {object} registry
  * @param {TunnelCreationSuccessResult[]} successful
  */
 function attachTunnelRegistryLifecycleWatch(registry, successful, callbacks = {}) {
-  const watches = successful
-    .filter((r) => r.socket)
-    .map((r) => {
-      const watch = {
-        udid: r.device.Properties.SerialNumber,
-        socket: r.socket,
-      };
-      return watch;
-    });
+  const watches = successful.map((r) => ({
+    udid: r.device.Properties.SerialNumber,
+    registerOnDead: r.registerOnDead,
+  }));
 
-  if (watches.length === 0) {
-    return;
-  }
-
-  const { stop } = watchTunnelRegistrySockets({
+  const { stop } = watchTunnelRegistryOnDead({
     registry,
     watches,
     onRemove: async (udid) => {
@@ -151,7 +162,7 @@ function attachTunnelRegistryLifecycleWatch(registry, successful, callbacks = {}
   });
   registryWatcherStops.push(stop);
   log.info(
-    'Tunnel registry will update automatically if a tunnel upstream socket goes away.',
+    'Tunnel registry will update automatically if a native forwarder exits unexpectedly.',
   );
 }
 
@@ -163,7 +174,6 @@ async function runReconnectAttempts({
   udid,
   maxRetries,
   device,
-  tlsOptions,
   reconnectTunnelByUdid,
 }) {
   let attempt = 0;
@@ -175,19 +185,19 @@ async function runReconnectAttempts({
 
     registryServer?.markTunnelPending(udid);
 
-    const result = await createTunnelForDevice(device, tlsOptions);
+    const result = await createTunnelForDevice(device);
     if (result.success) {
-      const ok = await publishDiscoveredTunnelEntry(result);
-      if (ok && registryServer) {
-        attachTunnelRegistryLifecycleWatch(
-          registryServer.getRegistry(),
-          [result],
-          {
-            onTunnelDead: async ({ udid: droppedUdid }) => {
-              await reconnectTunnelByUdid(droppedUdid);
-            },
+      attachTunnelRegistryLifecycleWatch(
+        registryServer.getRegistry(),
+        [result],
+        {
+          onTunnelDead: async ({ udid: droppedUdid }) => {
+            await reconnectTunnelByUdid(droppedUdid);
           },
-        );
+        },
+      );
+      const ok = await publishDiscoveredTunnelEntry(result);
+      if (ok) {
         log.info(`Reconnected tunnel for ${udid}`);
       }
       return;
@@ -202,7 +212,6 @@ async function runReconnectAttempts({
 function createReconnectTunnelByUdid({
   reconnectRetries,
   devicesByUdid,
-  tlsOptions,
 }) {
   return async function reconnectTunnelByUdid(udid) {
     if (typeof reconnectRetries !== 'number') {
@@ -222,7 +231,6 @@ function createReconnectTunnelByUdid({
       udid,
       maxRetries: reconnectRetries,
       device,
-      tlsOptions,
       reconnectTunnelByUdid,
     });
 
@@ -245,6 +253,18 @@ function setupCleanupHandlers() {
         stop?.();
       } catch {}
     }
+
+    for (const { tunnelConnection } of establishedTunnelsByUdid.values()) {
+      try {
+        if (tunnelConnection && typeof tunnelConnection.closer === 'function') {
+          log.info('Closing tunnel...');
+          await tunnelConnection.closer();
+        }
+      } catch (err) {
+        log.warn(`Error closing tunnel: ${err}`);
+      }
+    }
+    establishedTunnelsByUdid.clear();
 
     log.info('Cleanup completed.');
   };
@@ -273,7 +293,7 @@ function setupCleanupHandlers() {
   });
 }
 
-async function createTunnelForDevice(device, tlsOptions) {
+async function createTunnelForDevice(device) {
   const udid = device.Properties.SerialNumber;
 
   try {
@@ -298,42 +318,37 @@ async function createTunnelForDevice(device, tlsOptions) {
     log.info('CoreDeviceProxy started successfully');
 
     log.info(`Creating tunnel...`);
-    const tunnel = await TunnelManager.getTunnel(socket, { cert, key });
+    const lifecycle = { notify: null };
+    const tunnelConnection = await TunnelManager.getTunnel(
+      socket,
+      { cert, key },
+      {
+        onDead: (reason) => lifecycle.notify?.(reason),
+      },
+    );
     log.info(
-      `Tunnel created for address: ${tunnel.Address} with RsdPort: ${tunnel.RsdPort}`,
+      `Tunnel created for address: ${tunnelConnection.Address} with RsdPort: ${tunnelConnection.RsdPort}`,
     );
 
     log.info(`✅ Tunnel creation completed successfully for device: ${udid}`);
-    log.info(`   Tunnel Address: ${tunnel.Address}`);
-    log.info(`   Tunnel RsdPort: ${tunnel.RsdPort}`);
+    log.info(`   Tunnel Address: ${tunnelConnection.Address}`);
+    log.info(`   Tunnel RsdPort: ${tunnelConnection.RsdPort}`);
 
-    try {
-      if (socket && typeof socket === 'object' && socket.setNoDelay) {
-        socket.setNoDelay(true);
-      }
+    const result = {
+      device,
+      tunnel: {
+        Address: tunnelConnection.Address,
+        RsdPort: tunnelConnection.RsdPort,
+      },
+      success: true,
+      tunnelConnection,
+      registerOnDead: (handler) => {
+        lifecycle.notify = handler;
+      },
+    };
 
-      return {
-        device,
-        tunnel: {
-          Address: tunnel.Address,
-          RsdPort: tunnel.RsdPort,
-        },
-        success: true,
-        socket,
-      };
-    } catch (err) {
-      log.warn(`Could not add device to info server: ${err}`);
-
-      return {
-        device,
-        tunnel: {
-          Address: tunnel.Address,
-          RsdPort: tunnel.RsdPort,
-        },
-        success: true,
-        socket,
-      };
-    }
+    registerEstablishedTunnel(result);
+    return result;
   } catch (error) {
     const errorMessage = `Failed to create tunnel for device ${udid}: ${error}`;
     log.error(`❌ ${errorMessage}`);
@@ -384,11 +399,6 @@ async function main() {
   if (options.keepOpen) {
     log.info('Running in "keep connections open" mode for lsof inspection');
   }
-
-  const tlsOptions = {
-    rejectUnauthorized: false,
-    minVersion: 'TLSv1.2',
-  };
 
   const registryPort =
     options.tunnelRegistryPort ?? DEFAULT_TUNNEL_REGISTRY_PORT;
@@ -459,29 +469,28 @@ async function main() {
     const reconnectTunnelByUdid = createReconnectTunnelByUdid({
       reconnectRetries,
       devicesByUdid,
-      tlsOptions,
     });
 
     const results = [];
     const successful = [];
 
     for (const device of devicesToProcess) {
-      const result = await createTunnelForDevice(device, tlsOptions);
+      const result = await createTunnelForDevice(device);
       results.push(result);
 
       if (result.success) {
+        attachTunnelRegistryLifecycleWatch(
+          registryServer.getRegistry(),
+          [result],
+          {
+            onTunnelDead: async ({ udid }) => {
+              await reconnectTunnelByUdid(udid);
+            },
+          },
+        );
         const published = await publishDiscoveredTunnelEntry(result);
         if (published) {
           successful.push(result);
-          attachTunnelRegistryLifecycleWatch(
-            registryServer.getRegistry(),
-            [result],
-            {
-              onTunnelDead: async ({ udid }) => {
-                await reconnectTunnelByUdid(udid);
-              },
-            },
-          );
         }
       }
 
@@ -538,5 +547,6 @@ await main();
  * @typedef {object} TunnelCreationSuccessResult
  * @property {{ Properties: { SerialNumber: string }, DeviceID: number }} device
  * @property {{ Address: string, RsdPort?: number }} tunnel
- * @property {import('tls').TLSSocket} [socket]
+ * @property {import('appium-ios-tuntap').TunnelConnection} tunnelConnection
+ * @property {(handler: (reason: string) => void) => void} registerOnDead
  */

--- a/scripts/tunnel-creation.mjs
+++ b/scripts/tunnel-creation.mjs
@@ -13,7 +13,7 @@ import {
   createUsbmux,
   discoverServices,
   servicesToCatalog,
-  startCoreDeviceProxy,
+  startCoreDeviceProxyTcp,
   startTunnelRegistryServer,
   watchTunnelRegistrySockets,
 } from 'appium-ios-remotexpc';
@@ -289,17 +289,16 @@ async function createTunnelForDevice(device, tlsOptions) {
       `Lockdown service created for device: ${lockdownDevice.Properties.SerialNumber}`,
     );
 
-    log.info('Starting CoreDeviceProxy...');
-    const { socket } = await startCoreDeviceProxy(
+    log.info('Starting CoreDeviceProxy (raw TCP, native OpenSSL forwarder)...');
+    const { socket, cert, key } = await startCoreDeviceProxyTcp(
       lockdownService,
       lockdownDevice.DeviceID,
       lockdownDevice.Properties.SerialNumber,
-      tlsOptions,
     );
     log.info('CoreDeviceProxy started successfully');
 
     log.info(`Creating tunnel...`);
-    const tunnel = await TunnelManager.getTunnel(socket);
+    const tunnel = await TunnelManager.getTunnel(socket, { cert, key });
     log.info(
       `Tunnel created for address: ${tunnel.Address} with RsdPort: ${tunnel.RsdPort}`,
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
   TunnelReadinessCoordinator,
   discoverServices,
   servicesToCatalog,
+  watchTunnelRegistryOnDead,
   watchTunnelRegistrySockets,
 } from './lib/tunnel/index.js';
 import {
@@ -20,7 +21,10 @@ import {
 } from './lib/tunnel/tunnel-registry-server.js';
 import { Usbmux, createUsbmux } from './lib/usbmux/index.js';
 import * as Services from './services.js';
-import { startCoreDeviceProxy } from './services/ios/tunnel-service/index.js';
+import {
+  startCoreDeviceProxy,
+  startCoreDeviceProxyTcp,
+} from './services/ios/tunnel-service/index.js';
 
 export type { Device as UsbmuxDevice } from './lib/usbmux/index.js';
 export type {
@@ -152,7 +156,9 @@ export {
   createLockdownServiceForTunnel,
   createLockdownServiceByUDID,
   startCoreDeviceProxy,
+  startCoreDeviceProxyTcp,
   TunnelRegistryServer,
   startTunnelRegistryServer,
   watchTunnelRegistrySockets,
+  watchTunnelRegistryOnDead,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,10 +21,7 @@ import {
 } from './lib/tunnel/tunnel-registry-server.js';
 import { Usbmux, createUsbmux } from './lib/usbmux/index.js';
 import * as Services from './services.js';
-import {
-  startCoreDeviceProxy,
-  startCoreDeviceProxyTcp,
-} from './services/ios/tunnel-service/index.js';
+import { startCoreDeviceProxyTcp } from './services/ios/tunnel-service/index.js';
 
 export type { Device as UsbmuxDevice } from './lib/usbmux/index.js';
 export type {
@@ -155,7 +152,6 @@ export {
   TunnelReadinessCoordinator,
   createLockdownServiceForTunnel,
   createLockdownServiceByUDID,
-  startCoreDeviceProxy,
   startCoreDeviceProxyTcp,
   TunnelRegistryServer,
   startTunnelRegistryServer,

--- a/src/lib/apple-tv/tunnel/tunnel-service.ts
+++ b/src/lib/apple-tv/tunnel/tunnel-service.ts
@@ -1,5 +1,5 @@
 import { util } from '@appium/support';
-import * as tls from 'node:tls';
+import * as net from 'node:net';
 
 import { createDiscoveryBackend } from '../../discovery/discovery-backend-factory.js';
 import { getLogger } from '../../logger.js';
@@ -23,7 +23,7 @@ import { PairingStorage } from '../storage/pairing-storage.js';
 import type { PairRecord } from '../storage/types.js';
 import type { AppleTVDevice } from '../types.js';
 import { RemotedController } from './remoted-controller.js';
-import type { TcpListenerInfo, TlsPskConnectionOptions } from './types.js';
+import type { TcpListenerInfo } from './types.js';
 
 const log = getLogger('TunnelService');
 const appleTVLog = getLogger('AppleTVTunnelService');
@@ -121,69 +121,6 @@ export class TunnelService {
     return createListenerResponse;
   }
 
-  async createTlsPskConnection(
-    hostname: string,
-    port: number,
-  ): Promise<tls.TLSSocket> {
-    log.debug(`Creating TLS-PSK connection to ${hostname}:${port}`);
-
-    return new Promise((resolve, reject) => {
-      const options: TlsPskConnectionOptions = {
-        host: hostname,
-        port,
-        pskCallback: (hint: string | null) => {
-          log.debug(`PSK callback invoked with hint: ${hint}`);
-          return {
-            psk: this.keys.encryptionKey,
-            identity: '',
-          };
-        },
-        ciphers:
-          'PSK-AES256-CBC-SHA:PSK-AES128-CBC-SHA:PSK-3DES-EDE-CBC-SHA:PSK-RC4-SHA:PSK',
-        secureProtocol: 'TLSv1_2_method',
-        // SECURITY NOTE: Disabling certificate validation is intentional and safe in this context.
-        // This connection uses TLS-PSK (Pre-Shared Key) authentication, where the pre-shared key
-        // itself provides mutual authentication between client and server. Traditional X.509
-        // certificate validation is not used in PSK-based TLS connections. The encryption key
-        // was securely established during the pairing process (which involves PIN verification),
-        // and this key authenticates both parties. This is the standard approach for Apple TV's
-        // RemoteXPC protocol and should NOT be changed to use certificate validation.
-        rejectUnauthorized: false,
-        checkServerIdentity: () => undefined,
-      };
-
-      const socket = tls.connect(options, () => {
-        log.debug('TLS-PSK connection established');
-        resolve(socket);
-      });
-
-      socket.on('error', (error: Error & { code?: string }) => {
-        log.error('TLS-PSK connection error:', error);
-
-        if (
-          error.message?.includes('no shared cipher') ||
-          error.code === 'ECONNRESET'
-        ) {
-          log.error('PSK ciphers may not be available in your Node.js build');
-          log.error('You may need to:');
-          log.error('1. Use Node.js compiled with PSK-enabled OpenSSL');
-          log.error('2. Use a Python subprocess for the TLS-PSK connection');
-          log.error('3. Use a native module like node-openssl');
-        }
-
-        reject(error);
-      });
-
-      socket.on('secureConnect', () => {
-        log.debug('Secure connection event fired');
-      });
-
-      socket.on('tlsClientError', (error) => {
-        log.error('TLS client error:', error);
-      });
-    });
-  }
-
   getSequenceNumber(): number {
     return this.sequenceNumber;
   }
@@ -242,7 +179,11 @@ export class AppleTVTunnelService {
   async startTunnel(
     deviceId?: string,
     specificDeviceIdentifier?: string,
-  ): Promise<{ socket: tls.TLSSocket; device: AppleTVDevice }> {
+  ): Promise<{
+    tcpSocket: net.Socket;
+    psk: Buffer;
+    device: AppleTVDevice;
+  }> {
     const devices = await this.discoverDevices();
     this.logDiscoveredDevices(devices);
 
@@ -383,7 +324,11 @@ export class AppleTVTunnelService {
     identifier: string,
     pairRecord: PairRecord,
     failedAttempts: { identifier: string; error: string }[],
-  ): Promise<{ socket: tls.TLSSocket; device: AppleTVDevice } | null> {
+  ): Promise<{
+    tcpSocket: net.Socket;
+    psk: Buffer;
+    device: AppleTVDevice;
+  } | null> {
     const connectionTarget = device.ip ?? device.hostname;
     if (!connectionTarget) {
       failedAttempts.push({
@@ -408,10 +353,9 @@ export class AppleTVTunnelService {
         const listenerInfo = await this.createTcpListener(keys);
         this.networkClient.disconnect();
 
-        const tlsSocket = await this.createTlsPskConnection(
+        const tcpSocket = await connectToListenerPort(
           connectionTarget,
           listenerInfo.port,
-          keys,
         );
 
         appleTVLog.debug('Step 6: Tunnel Establishment success');
@@ -421,7 +365,7 @@ export class AppleTVTunnelService {
         );
         appleTVLog.info(`   Target: ${connectionTarget}:${device.port}`);
 
-        return { socket: tlsSocket, device };
+        return { tcpSocket, psk: keys.encryptionKey, device };
       } catch (error: any) {
         const errorMessage = error.message || String(error);
         appleTVLog.debug(
@@ -523,17 +467,16 @@ export class AppleTVTunnelService {
 
     return listenerInfo;
   }
+}
 
-  private async createTlsPskConnection(
-    hostname: string,
-    port: number,
-    keys: VerificationKeys,
-  ): Promise<tls.TLSSocket> {
-    const tunnelService = new TunnelService(
-      this.networkClient,
-      keys,
-      this.sequenceNumber,
-    );
-    return tunnelService.createTlsPskConnection(hostname, port);
-  }
+function connectToListenerPort(
+  hostname: string,
+  port: number,
+): Promise<net.Socket> {
+  return new Promise((resolve, reject) => {
+    const socket = net.connect({ host: hostname, port }, () => {
+      resolve(socket);
+    });
+    socket.once('error', reject);
+  });
 }

--- a/src/lib/apple-tv/tunnel/types.ts
+++ b/src/lib/apple-tv/tunnel/types.ts
@@ -1,23 +1,5 @@
-import type * as tls from 'node:tls';
-
 export interface TcpListenerInfo {
   port: number;
   serviceName: string;
   devicePublicKey: string;
-}
-
-/**
- * Extended TLS connection options that include PSK (Pre-Shared Key) callback support.
- * This interface extends the standard Node.js TLS ConnectionOptions to add PSK authentication.
- */
-export interface TlsPskConnectionOptions extends tls.ConnectionOptions {
-  /**
-   * Callback function invoked during TLS handshake to provide PSK credentials.
-   * @param hint - Optional hint from the server about which PSK identity to use
-   * @returns Object containing the pre-shared key and identity string
-   */
-  pskCallback?: (hint: string | null) => {
-    psk: Buffer;
-    identity: string;
-  };
 }

--- a/src/lib/tunnel/index.ts
+++ b/src/lib/tunnel/index.ts
@@ -62,36 +62,7 @@ class TunnelManagerService {
       credentials,
       options,
     );
-
-    const existingTunnel = this.tunnelRegistry.get(tunnel.Address);
-    if (existingTunnel?.isActive) {
-      log.info(`Reusing existing tunnel for address: ${tunnel.Address}`);
-      try {
-        if (tunnel.tunnelManager) {
-          try {
-            await tunnel.closer();
-          } catch (error) {
-            log.warn(`Error closing redundant tunnel: ${error}`);
-          }
-          existingTunnel.lastUsed = Date.now();
-          return existingTunnel.tunnel;
-        }
-      } catch (error) {
-        log.warn(
-          `Error checking tunnel functionality: ${error}, creating a new one`,
-        );
-        existingTunnel.isActive = false;
-      }
-    }
-
-    log.info(`Creating new tunnel for address: ${tunnel.Address}`);
-    this.tunnelRegistry.set(tunnel.Address, {
-      tunnel,
-      lastUsed: Date.now(),
-      isActive: true,
-    });
-
-    return tunnel;
+    return this.registerTunnel(tunnel, 'tunnel');
   }
 
   /**
@@ -103,36 +74,7 @@ class TunnelManagerService {
     options?: { onDead?: (reason: string) => void },
   ): Promise<TunnelConnection> {
     const tunnel = await connectToTunnelPsk(tcpSocket, credentials, options);
-
-    const existingTunnel = this.tunnelRegistry.get(tunnel.Address);
-    if (existingTunnel?.isActive) {
-      log.info(`Reusing existing tunnel for address: ${tunnel.Address}`);
-      try {
-        if (tunnel.tunnelManager) {
-          try {
-            await tunnel.closer();
-          } catch (error) {
-            log.warn(`Error closing redundant tunnel: ${error}`);
-          }
-          existingTunnel.lastUsed = Date.now();
-          return existingTunnel.tunnel;
-        }
-      } catch (error) {
-        log.warn(
-          `Error checking tunnel functionality: ${error}, creating a new one`,
-        );
-        existingTunnel.isActive = false;
-      }
-    }
-
-    log.info(`Creating new Apple TV tunnel for address: ${tunnel.Address}`);
-    this.tunnelRegistry.set(tunnel.Address, {
-      tunnel,
-      lastUsed: Date.now(),
-      isActive: true,
-    });
-
-    return tunnel;
+    return this.registerTunnel(tunnel, 'Apple TV tunnel');
   }
 
   /**
@@ -203,6 +145,41 @@ class TunnelManagerService {
    */
   async closeTunnel(): Promise<void> {
     return this.closeAllTunnels();
+  }
+
+  private async registerTunnel(
+    tunnel: TunnelConnection,
+    kindLabel: string,
+  ): Promise<TunnelConnection> {
+    const existingTunnel = this.tunnelRegistry.get(tunnel.Address);
+    if (existingTunnel?.isActive) {
+      log.info(`Reusing existing tunnel for address: ${tunnel.Address}`);
+      try {
+        if (tunnel.tunnelManager) {
+          try {
+            await tunnel.closer();
+          } catch (error) {
+            log.warn(`Error closing redundant tunnel: ${error}`);
+          }
+          existingTunnel.lastUsed = Date.now();
+          return existingTunnel.tunnel;
+        }
+      } catch (error) {
+        log.warn(
+          `Error checking tunnel functionality: ${error}, creating a new one`,
+        );
+        existingTunnel.isActive = false;
+      }
+    }
+
+    log.info(`Creating new ${kindLabel} for address: ${tunnel.Address}`);
+    this.tunnelRegistry.set(tunnel.Address, {
+      tunnel,
+      lastUsed: Date.now(),
+      isActive: true,
+    });
+
+    return tunnel;
   }
 }
 

--- a/src/lib/tunnel/index.ts
+++ b/src/lib/tunnel/index.ts
@@ -1,8 +1,11 @@
 import {
   type TunnelConnection,
+  type TunnelLockdownTlsCredentials,
+  type TunnelPskTlsCredentials,
   connectToTunnelLockdown,
+  connectToTunnelPsk,
 } from 'appium-ios-tuntap';
-import type { TLSSocket } from 'node:tls';
+import type { Socket } from 'node:net';
 
 import { getLogger } from '../logger.js';
 
@@ -47,54 +50,77 @@ class TunnelManagerService {
   }
 
   /**
-   * Establishes a tunnel connection if not already connected.
-   * If a tunnel is already open for the same address, it will be reused.
-   *
-   * @param secureServiceSocket - The secure service socket used to create the tunnel.
-   * @returns A promise that resolves to the tunnel connection instance.
+   * Establishes a tunnel via native OpenSSL forwarding (raw TCP + pair-record PEM).
    */
-  async getTunnel(secureServiceSocket: TLSSocket): Promise<TunnelConnection> {
-    // Create a new tunnel
-    const tunnel = await connectToTunnelLockdown(secureServiceSocket);
+  async getTunnel(
+    tcpSocket: Socket,
+    credentials: TunnelLockdownTlsCredentials,
+  ): Promise<TunnelConnection> {
+    const tunnel = await connectToTunnelLockdown(tcpSocket, credentials);
 
-    // Check if we already have an active tunnel for this address
     const existingTunnel = this.tunnelRegistry.get(tunnel.Address);
-
     if (existingTunnel?.isActive) {
       log.info(`Reusing existing tunnel for address: ${tunnel.Address}`);
-
-      // Verify the tunnel is still functional
       try {
-        // A simple check to see if the tunnel is still functional
-        if (tunnel.tunnelManager?.emit instanceof Function) {
-          // Close the new tunnel since we're reusing an existing one
+        if (tunnel.tunnelManager) {
           try {
             await tunnel.closer();
           } catch (error) {
             log.warn(`Error closing redundant tunnel: ${error}`);
           }
-
-          // Update the last used timestamp
           existingTunnel.lastUsed = Date.now();
           return existingTunnel.tunnel;
-        } else {
-          log.warn(
-            'Existing tunnel appears to be non-functional, creating a new one',
-          );
-          // Mark the existing tunnel as inactive
-          existingTunnel.isActive = false;
         }
       } catch (error) {
         log.warn(
           `Error checking tunnel functionality: ${error}, creating a new one`,
         );
-        // Mark the existing tunnel as inactive
         existingTunnel.isActive = false;
       }
     }
 
-    // Register the new tunnel
     log.info(`Creating new tunnel for address: ${tunnel.Address}`);
+    this.tunnelRegistry.set(tunnel.Address, {
+      tunnel,
+      lastUsed: Date.now(),
+      isActive: true,
+    });
+
+    return tunnel;
+  }
+
+  /**
+   * Establishes an Apple TV tunnel via native OpenSSL TLS-PSK forwarding.
+   */
+  async getTunnelPsk(
+    tcpSocket: Socket,
+    credentials: TunnelPskTlsCredentials,
+    options?: { onDead?: (reason: string) => void },
+  ): Promise<TunnelConnection> {
+    const tunnel = await connectToTunnelPsk(tcpSocket, credentials, options);
+
+    const existingTunnel = this.tunnelRegistry.get(tunnel.Address);
+    if (existingTunnel?.isActive) {
+      log.info(`Reusing existing tunnel for address: ${tunnel.Address}`);
+      try {
+        if (tunnel.tunnelManager) {
+          try {
+            await tunnel.closer();
+          } catch (error) {
+            log.warn(`Error closing redundant tunnel: ${error}`);
+          }
+          existingTunnel.lastUsed = Date.now();
+          return existingTunnel.tunnel;
+        }
+      } catch (error) {
+        log.warn(
+          `Error checking tunnel functionality: ${error}, creating a new one`,
+        );
+        existingTunnel.isActive = false;
+      }
+    }
+
+    log.info(`Creating new Apple TV tunnel for address: ${tunnel.Address}`);
     this.tunnelRegistry.set(tunnel.Address, {
       tunnel,
       lastUsed: Date.now(),
@@ -181,8 +207,11 @@ export { discoverServices, servicesToCatalog } from './tunnel-rsd-discovery.js';
 export { TunnelReadinessCoordinator } from './tunnel-readiness.js';
 export {
   watchTunnelRegistrySockets,
+  watchTunnelRegistryOnDead,
   type TunnelRegistrySocketWatch,
+  type TunnelRegistryOnDeadWatch,
   type WatchTunnelRegistryOptions,
+  type WatchTunnelRegistryOnDeadOptions,
 } from './tunnel-registry-lifecycle.js';
 // Re-export TunnelConnection type from appium-ios-tuntap
 export type { TunnelConnection };

--- a/src/lib/tunnel/index.ts
+++ b/src/lib/tunnel/index.ts
@@ -55,8 +55,13 @@ class TunnelManagerService {
   async getTunnel(
     tcpSocket: Socket,
     credentials: TunnelLockdownTlsCredentials,
+    options?: { onDead?: (reason: string) => void },
   ): Promise<TunnelConnection> {
-    const tunnel = await connectToTunnelLockdown(tcpSocket, credentials);
+    const tunnel = await connectToTunnelLockdown(
+      tcpSocket,
+      credentials,
+      options,
+    );
 
     const existingTunnel = this.tunnelRegistry.get(tunnel.Address);
     if (existingTunnel?.isActive) {

--- a/src/lib/tunnel/tunnel-registry-lifecycle.ts
+++ b/src/lib/tunnel/tunnel-registry-lifecycle.ts
@@ -27,6 +27,22 @@ export interface WatchTunnelRegistryOptions {
   }) => void | Promise<void>;
 }
 
+export interface TunnelRegistryOnDeadWatch {
+  udid: string;
+  /** Register a handler invoked when the native forwarder exits unexpectedly. */
+  registerOnDead: (handler: (reason: string) => void) => void;
+}
+
+export interface WatchTunnelRegistryOnDeadOptions {
+  registry: TunnelRegistry;
+  watches: TunnelRegistryOnDeadWatch[];
+  onRemove?: (udid: string) => void | Promise<void>;
+  onTunnelDead?: (ctx: {
+    udid: string;
+    address: string;
+  }) => void | Promise<void>;
+}
+
 /**
  * Removes a tunnel from the registry when its upstream CoreDeviceProxy socket dies.
  *
@@ -99,6 +115,78 @@ export function watchTunnelRegistrySockets(
     teardownFns.push(() => {
       socket.off('close', onSocketEnd);
       socket.off('error', onSocketEnd);
+    });
+  }
+
+  return { stop };
+}
+
+/**
+ * Removes a tunnel from the registry when its native forwarder dies (Apple TV PSK path).
+ */
+export function watchTunnelRegistryOnDead(
+  options: WatchTunnelRegistryOnDeadOptions,
+): { stop: () => void } {
+  const { registry, watches, onRemove, onTunnelDead } = options;
+
+  const stopped = { value: false };
+  const teardownFns: Array<() => void> = [];
+
+  const stop = (): void => {
+    if (stopped.value) {
+      return;
+    }
+    stopped.value = true;
+    for (const fn of teardownFns) {
+      try {
+        fn();
+      } catch {
+        /* ignore */
+      }
+    }
+    teardownFns.length = 0;
+  };
+
+  for (const watch of watches) {
+    const { udid } = watch;
+    let finalized = false;
+
+    const finalize = async (reason: string): Promise<void> => {
+      if (finalized || stopped.value) {
+        return;
+      }
+      finalized = true;
+
+      if (!registry.tunnels[udid]) {
+        return;
+      }
+
+      const address = registry.tunnels[udid].address;
+
+      delete registry.tunnels[udid];
+      log.info(
+        `Tunnel registry: removed ${udid} (${reason}). Remaining: ${Object.keys(registry.tunnels).length}`,
+      );
+
+      try {
+        await onRemove?.(udid);
+      } catch (err) {
+        log.warn(`onRemove failed for ${udid}: ${err}`);
+      }
+
+      try {
+        await onTunnelDead?.({ udid, address });
+      } catch (err) {
+        log.warn(`onTunnelDead failed for ${udid}: ${err}`);
+      }
+    };
+
+    watch.registerOnDead((reason) => {
+      void finalize(`native forwarder died: ${reason}`);
+    });
+
+    teardownFns.push(() => {
+      watch.registerOnDead(() => {});
     });
   }
 

--- a/src/lib/tunnel/tunnel-registry-lifecycle.ts
+++ b/src/lib/tunnel/tunnel-registry-lifecycle.ts
@@ -122,7 +122,7 @@ export function watchTunnelRegistrySockets(
 }
 
 /**
- * Removes a tunnel from the registry when its native forwarder dies (Apple TV PSK path).
+ * Removes a tunnel from the registry when its native forwarder dies (lockdown or TLS-PSK).
  */
 export function watchTunnelRegistryOnDead(
   options: WatchTunnelRegistryOnDeadOptions,

--- a/src/services/ios/tunnel-service/index.ts
+++ b/src/services/ios/tunnel-service/index.ts
@@ -1,3 +1,4 @@
+import type { Socket } from 'node:net';
 import type { ConnectionOptions, TLSSocket } from 'node:tls';
 
 import { upgradeSocketToTLS } from '../../../lib/lockdown/index.js';
@@ -8,6 +9,73 @@ import { createUsbmux } from '../../../lib/usbmux/index.js';
 
 const log = getLogger('TunnelService');
 const LABEL = 'appium-internal';
+
+export interface CoreDeviceProxyTcpSession {
+  socket: Socket;
+  cert: string;
+  key: string;
+}
+
+/**
+ * Starts CoreDeviceProxy over plain TCP (no Node TLS). Use with
+ * {@link connectToTunnelLockdown} in appium-ios-tuntap.
+ */
+export async function startCoreDeviceProxyTcp(
+  lockdownClient: LockdownService,
+  deviceID: number | string,
+  udid: string,
+): Promise<CoreDeviceProxyTcpSession> {
+  await lockdownClient.waitForTLSUpgrade();
+
+  const response = await lockdownClient.sendAndReceive({
+    Label: LABEL,
+    Request: 'StartService',
+    Service: 'com.apple.internal.devicecompute.CoreDeviceProxy',
+    EscrowBag: null,
+  });
+
+  lockdownClient.close();
+
+  if (!response.Port) {
+    throw new Error('Service didnt return a port');
+  }
+
+  log.debug(`Connecting to CoreDeviceProxy service on port: ${response.Port}`);
+
+  const usbmux = await createUsbmux();
+  try {
+    const pairRecord = await usbmux.readPairRecord(udid);
+    if (
+      !pairRecord ||
+      !pairRecord.HostCertificate ||
+      !pairRecord.HostPrivateKey
+    ) {
+      throw new Error(
+        'Missing required pair record or certificates for TLS upgrade',
+      );
+    }
+
+    const coreDeviceSocket = await usbmux.connect(
+      Number(deviceID),
+      Number(response.Port),
+    );
+
+    log.debug(
+      'Socket connected to CoreDeviceProxy (raw TCP, native TLS in tuntap)',
+    );
+
+    return {
+      socket: coreDeviceSocket,
+      cert: pairRecord.HostCertificate,
+      key: pairRecord.HostPrivateKey,
+    };
+  } catch (err) {
+    await usbmux
+      .close()
+      .catch((closeErr) => log.error(`Error closing usbmux: ${closeErr}`));
+    throw err;
+  }
+}
 
 /**
  * Starts a CoreDeviceProxy session over an existing TLS-upgraded lockdown connection.

--- a/src/services/ios/tunnel-service/index.ts
+++ b/src/services/ios/tunnel-service/index.ts
@@ -1,10 +1,7 @@
 import type { Socket } from 'node:net';
-import type { ConnectionOptions, TLSSocket } from 'node:tls';
 
-import { upgradeSocketToTLS } from '../../../lib/lockdown/index.js';
 import type { LockdownService } from '../../../lib/lockdown/index.js';
 import { getLogger } from '../../../lib/logger.js';
-import { PlistService } from '../../../lib/plist/plist-service.js';
 import { createUsbmux } from '../../../lib/usbmux/index.js';
 
 const log = getLogger('TunnelService');
@@ -70,82 +67,6 @@ export async function startCoreDeviceProxyTcp(
       key: pairRecord.HostPrivateKey,
     };
   } catch (err) {
-    await usbmux
-      .close()
-      .catch((closeErr) => log.error(`Error closing usbmux: ${closeErr}`));
-    throw err;
-  }
-}
-
-/**
- * Starts a CoreDeviceProxy session over an existing TLS-upgraded lockdown connection.
- *
- * @param lockdownClient - The TLS-upgraded lockdown client used to send the StartService request.
- * @param deviceID - The device identifier to be used in the Connect request.
- * @param udid - The device UDID used to retrieve the pair record.
- * @param tlsOptions - TLS options for upgrading the usbmuxd socket.
- * @returns A promise that resolves with a TLS-upgraded socket and PlistService for communication with CoreDeviceProxy.
- */
-export async function startCoreDeviceProxy(
-  lockdownClient: LockdownService,
-  deviceID: number | string,
-  udid: string,
-  tlsOptions: Partial<ConnectionOptions> = {},
-): Promise<{ socket: TLSSocket; plistService: PlistService }> {
-  // Wait for TLS upgrade to complete if in progress
-  await lockdownClient.waitForTLSUpgrade();
-
-  const response = await lockdownClient.sendAndReceive({
-    Label: LABEL,
-    Request: 'StartService',
-    Service: 'com.apple.internal.devicecompute.CoreDeviceProxy',
-    EscrowBag: null,
-  });
-
-  lockdownClient.close();
-
-  if (!response.Port) {
-    throw new Error('Service didnt return a port');
-  }
-
-  log.debug(`Connecting to CoreDeviceProxy service on port: ${response.Port}`);
-
-  const usbmux = await createUsbmux();
-  try {
-    const pairRecord = await usbmux.readPairRecord(udid);
-    if (
-      !pairRecord ||
-      !pairRecord.HostCertificate ||
-      !pairRecord.HostPrivateKey
-    ) {
-      throw new Error(
-        'Missing required pair record or certificates for TLS upgrade',
-      );
-    }
-
-    const coreDeviceSocket = await usbmux.connect(
-      Number(deviceID),
-      Number(response.Port),
-    );
-
-    log.debug('Socket connected to CoreDeviceProxy, upgrading to TLS...');
-
-    const fullTlsOptions = {
-      ...tlsOptions,
-      cert: pairRecord.HostCertificate,
-      key: pairRecord.HostPrivateKey,
-    };
-
-    const tlsSocket = await upgradeSocketToTLS(
-      coreDeviceSocket,
-      fullTlsOptions,
-    );
-
-    const plistService = new PlistService(tlsSocket);
-
-    return { socket: tlsSocket, plistService };
-  } catch (err) {
-    // If we haven't connected yet, we can safely close the usbmux
     await usbmux
       .close()
       .catch((closeErr) => log.error(`Error closing usbmux: ${closeErr}`));

--- a/test/unit/tunnel/tunnel-registry-lifecycle.spec.ts
+++ b/test/unit/tunnel/tunnel-registry-lifecycle.spec.ts
@@ -2,7 +2,10 @@ import { expect } from 'chai';
 import { once } from 'node:events';
 import { type AddressInfo, createConnection, createServer } from 'node:net';
 
-import { watchTunnelRegistrySockets } from '../../../src/lib/tunnel/tunnel-registry-lifecycle.js';
+import {
+  watchTunnelRegistryOnDead,
+  watchTunnelRegistrySockets,
+} from '../../../src/lib/tunnel/tunnel-registry-lifecycle.js';
 import type { TunnelRegistry } from '../../../src/lib/types.js';
 
 function makeRegistry(udid: string): TunnelRegistry {
@@ -95,5 +98,58 @@ describe('watchTunnelRegistrySockets', function () {
 
     client.destroy();
     await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+});
+
+describe('watchTunnelRegistryOnDead', function () {
+  it('removes registry entry when registerOnDead handler is invoked', async function () {
+    const registry = makeRegistry('dev-3');
+    let onDeadHandler = (_reason: string) => {};
+
+    let removedUdid: string | undefined;
+    const { stop } = watchTunnelRegistryOnDead({
+      registry,
+      watches: [
+        {
+          udid: 'dev-3',
+          registerOnDead: (handler) => {
+            onDeadHandler = handler;
+          },
+        },
+      ],
+      onRemove: (udid) => {
+        removedUdid = udid;
+      },
+    });
+
+    onDeadHandler('SSL read failed');
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(registry.tunnels['dev-3']).to.equal(undefined);
+    expect(removedUdid).to.equal('dev-3');
+
+    stop();
+  });
+
+  it('stop() ignores subsequent onDead notifications', async function () {
+    const registry = makeRegistry('dev-4');
+    let onDeadHandler = (_reason: string) => {};
+
+    const { stop } = watchTunnelRegistryOnDead({
+      registry,
+      watches: [
+        {
+          udid: 'dev-4',
+          registerOnDead: (handler) => {
+            onDeadHandler = handler;
+          },
+        },
+      ],
+    });
+
+    stop();
+    onDeadHandler('should be ignored');
+
+    expect(Object.keys(registry.tunnels)).to.have.lengthOf(1);
   });
 });


### PR DESCRIPTION
## Summary

Adapt **appium-ios-remotexpc** to **appium-ios-tuntap v1.0.0**, which moves TLS, CDTunnel handshake, and utun↔device forwarding into a native OpenSSL forwarder. Callers pass **plain TCP** plus PEM (iOS) or PSK (Apple TV) credentials; Node no longer upgrades sockets to `TLSSocket` before tunnel setup.

## Architecture

**Before (iOS)**

```
lockdown → Node TLS upgrade → TLSSocket → TunnelManager.getTunnel(socket)
```

**After (iOS)**

```
lockdown → raw TCP (CoreDeviceProxy) + pair-record PEM → TunnelManager.getTunnel(socket, { cert, key })
                                              ↳ native OpenSSL in tuntap
```

**Before (Apple TV)**

```
pair-verify → Node TLS-PSK TLSSocket → TunnelManager.getTunnel(socket)
```

**After (Apple TV)**

```
pair-verify → raw TCP (listener port) + encryptionKey → TunnelManager.getTunnelPsk(socket, { psk })
                                              ↳ native OpenSSL TLS-PSK in tuntap
```

## What changed

### Dependency

- Bump `appium-ios-tuntap` to `^1.0.0`

### iOS tunnel path

- Add **`startCoreDeviceProxyTcp()`** — starts CoreDeviceProxy over plain TCP; returns `{ socket, cert, key }` from the usbmux pair record
- **`TunnelManager.getTunnel(tcpSocket, { cert, key }, { onDead? })`** — passes raw TCP + PEM into `connectToTunnelLockdown`
- **Remove `startCoreDeviceProxy()`** — Node `TLSSocket` + `PlistService` path deleted (breaking; use TCP + native TLS instead)

### Apple TV tunnel path

- **`AppleTVTunnelService.startTunnel()`** returns `{ tcpSocket, psk, device }` instead of `{ socket: TLSSocket, device }`
- Remove Node **`tls.connect`** TLS-PSK path; PSK handshake runs in tuntap
- Add **`TunnelManager.getTunnelPsk(tcpSocket, { psk }, { onDead? })`**
- Remove unused **`TlsPskConnectionOptions`** from `src/lib/apple-tv/tunnel/types.ts`

### Registry lifecycle and reconnect

- Add **`watchTunnelRegistryOnDead()`** — removes registry entries when the native forwarder exits (required because the forwarder dup’s the TCP fd; the upstream Node socket is no longer observable)
- **iOS and Apple TV tunnel scripts** use `watchTunnelRegistryOnDead` (not socket-based watching)
- **`scripts/tunnel-creation.mjs`**: USB+Network dedupe (`dedupeDevicesByUdid`, USB preferred), per-UDID lifecycle watch teardown before supersede/reconnect (avoids false-positive registry removal), one tunnel per UDID via `establishedTunnelsByUdid` Map
- **`scripts/start-appletv-tunnel.mjs`**: same lifecycle-watch pattern; `getTunnelPsk` + `onDead` reconnect

### TunnelManager refactor

- Extract shared registry logic into private **`registerTunnel()`** (used by `getTunnel` and `getTunnelPsk`)

### Scripts and docs

- **`scripts/tunnel-creation.mjs`** — `startCoreDeviceProxyTcp` + credentialed `getTunnel`
- **`scripts/start-appletv-tunnel.mjs`** — restored end-to-end Apple TV path
- **`README.md`** — updated tunnel creation example
- Unit tests extended for **`watchTunnelRegistryOnDead`**

## Breaking changes

BREAKING CHANGE: `TunnelManager.getTunnel` now requires `(tcpSocket, { cert, key })`. Pass plain TCP from `startCoreDeviceProxyTcp`; do not upgrade to Node `TLSSocket` first.

BREAKING CHANGE: `startCoreDeviceProxy` removed. Use `startCoreDeviceProxyTcp` + `TunnelManager.getTunnel(socket, { cert, key })`.

BREAKING CHANGE: `AppleTVTunnelService.startTunnel()` returns `{ tcpSocket, psk, device }` instead of `{ socket: TLSSocket, device }`. Use `TunnelManager.getTunnelPsk(tcpSocket, { psk })`.

BREAKING CHANGE: Requires `appium-ios-tuntap@^1.0.0` (native forwarder; tunnel connect is macOS/Linux only until Windows forwarder lands in tuntap).

## Migration

**iOS**

```js
// Before
const { socket } = await startCoreDeviceProxy(lockdown, deviceId, udid, tlsOptions);
const tunnel = await TunnelManager.getTunnel(socket);

// After
const { socket, cert, key } = await startCoreDeviceProxyTcp(lockdown, deviceId, udid);
const tunnel = await TunnelManager.getTunnel(socket, { cert, key }, {
  onDead: (reason) => { /* reconnect / registry cleanup */ },
});
```

**Apple TV**

```js
// Before
const { socket } = await appleTvTunnelService.startTunnel(undefined, udid);
const tunnel = await TunnelManager.getTunnel(socket);

// After
const { tcpSocket, psk } = await appleTvTunnelService.startTunnel(undefined, udid);
const tunnel = await TunnelManager.getTunnelPsk(tcpSocket, { psk }, {
  onDead: (reason) => { /* reconnect / registry cleanup */ },
});
```

## Follow-ups

- **appium-xcuitest-driver** migration to `startCoreDeviceProxyTcp` + credentialed `getTunnel`
- **Windows hosts:** tunnel connect still requires tuntap Windows forwarder work