### PR TITLE
chore: bump @appium/tsconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "description": "",
   "devDependencies": {
     "@appium/eslint-config-appium-ts": "^3.0.0",
-    "@appium/tsconfig": "^1.0.0-rc.1",
+    "@appium/tsconfig": "^1.1.2",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@trivago/prettier-plugin-sort-imports": "^6.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,6 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@appium/tsconfig/tsconfig.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "lib": ["ES2022"],
     "strict": true,
     "strictNullChecks": false,
     "outDir": "build",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,8 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@appium/tsconfig/tsconfig.json",
   "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
     "strict": true,
     "strictNullChecks": false,
     "outDir": "build",


### PR DESCRIPTION
I got:

```
src/services/ios/testmanagerd/xctest-common.ts:110:36 - error TS2550: Property 'at' does not exist on type 'string[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2022' or later.

110   return xctestBundleId.split('.').at(-1) || xctestBundleId;
```

looks like this was old tsconfig's es2020 use. My env didn't get expected new one while after removing node_modules... weirdly, so let me bump this version