### PR TITLE
fix: Loading pair records from strongbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "typescript": "^6.0.2"
   },
   "dependencies": {
-    "@appium/strongbox": "^1.0.0-rc.1",
+    "@appium/strongbox": "^1.1.2",
     "@appium/support": "^7.2.2",
     "@xmldom/xmldom": "^0.x",
     "appium-ios-tuntap": "^1.0.0",

--- a/src/lib/apple-tv/storage/pairing-storage.ts
+++ b/src/lib/apple-tv/storage/pairing-storage.ts
@@ -1,6 +1,6 @@
 import { BaseItem, strongbox } from '@appium/strongbox';
-import { readdir } from 'node:fs/promises';
-import { dirname } from 'node:path';
+import { util } from '@appium/support';
+import { basename } from 'node:path';
 
 import {
   APPLETV_PAIRING_PREFIX,
@@ -17,7 +17,6 @@ const log = getLogger('PairingStorage');
 /** Manages persistent storage of pairing credentials as plist files */
 export class PairingStorage implements PairingStorageInterface {
   private readonly box;
-  private strongboxDir?: string;
 
   constructor(private readonly config: PairingConfig) {
     this.box = strongbox(STRONGBOX_CONTAINER_NAME);
@@ -92,22 +91,23 @@ export class PairingStorage implements PairingStorageInterface {
 
   async getAvailableDeviceIds(): Promise<string[]> {
     try {
-      if (!this.strongboxDir) {
-        const dummyItem = await this.box.createItem('_temp');
-        this.strongboxDir = dirname(dummyItem.id);
-        // Clean up the temporary item after extracting the directory path
-        await dummyItem.clear();
+      const deviceIds = new Set<string>();
+      const slugPrefix = this.getStrongboxSlugPrefix();
+
+      for (const item of await this.box.listItems()) {
+        for (const itemName of [item.name, basename(item.id)]) {
+          if (itemName.startsWith(APPLETV_PAIRING_PREFIX)) {
+            deviceIds.add(itemName.slice(APPLETV_PAIRING_PREFIX.length));
+          } else if (itemName.startsWith(slugPrefix)) {
+            deviceIds.add(itemName.slice(slugPrefix.length));
+          }
+        }
       }
 
-      const files = await readdir(this.strongboxDir);
-      const deviceIds = files
-        .filter((file: string) => file.startsWith(APPLETV_PAIRING_PREFIX))
-        .map((file: string) => file.replace(APPLETV_PAIRING_PREFIX, ''));
-
       log.debug(
-        `Found ${deviceIds.length} pair record(s): ${deviceIds.join(', ')}`,
+        `Found ${util.pluralize('pair record', deviceIds.size, true)}: ${[...deviceIds].join(', ')}`,
       );
-      return deviceIds;
+      return [...deviceIds];
     } catch (error) {
       log.debug('Error getting available device IDs:', error);
       return [];
@@ -124,5 +124,11 @@ export class PairingStorage implements PairingStorageInterface {
       public_key: publicKey,
       remote_unlock_host_key: remoteUnlockHostKey,
     });
+  }
+
+  private getStrongboxSlugPrefix(): string {
+    const sentinel = 'x';
+    const item = new BaseItem(`${APPLETV_PAIRING_PREFIX}${sentinel}`, this.box);
+    return basename(item.id).slice(0, -sentinel.length);
   }
 }

--- a/test/unit/apple-tv/pairing-storage.spec.ts
+++ b/test/unit/apple-tv/pairing-storage.spec.ts
@@ -1,0 +1,64 @@
+import { expect } from 'chai';
+import esmock from 'esmock';
+
+function slugify(value: string): string {
+  return value
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .trim()
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+describe('PairingStorage', function () {
+  it('discovers Apple TV pair records stored with slugified Strongbox filenames', async function () {
+    const container = '/tmp/appium-ios-remotexpc';
+    const box = {
+      container,
+      listItems: async () => [
+        {
+          name: 'appletv-pairing-device-1',
+          id: `${container}/appletv-pairing-device-1`,
+        },
+        {
+          name: 'appletv_pairing_device-2',
+          id: `${container}/appletv-pairing-device-2`,
+        },
+        {
+          name: 'pair-record-device-3',
+          id: `${container}/pair-record-device-3`,
+        },
+      ],
+    };
+
+    const { PairingStorage } = await esmock(
+      '../../../src/lib/apple-tv/storage/pairing-storage.js',
+      {
+        '@appium/strongbox': {
+          strongbox: () => box,
+          BaseItem: class {
+            id: string;
+
+            constructor(
+              public readonly name: string,
+              parent: { container: string },
+            ) {
+              this.id = `${parent.container}/${slugify(name)}`;
+            }
+          },
+        },
+      },
+    );
+
+    const storage = new PairingStorage({
+      timeout: 1,
+      discoveryTimeout: 1,
+      maxRetries: 1,
+    });
+
+    expect(await storage.getAvailableDeviceIds()).to.deep.equal([
+      'device-1',
+      'device-2',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Fix Apple TV pairing credential discovery when Strongbox stores item filenames in slugified form.
- Use Strongbox `listItems()` instead of manually scanning the storage directory, while supporting both original and slugified pair-record names.
- Add unit coverage for slugified Apple TV pair records and align `@appium/strongbox` with the local Appium package version.
