### PR TITLE
fix: Fetch AppleTV device udid from M6 pairing record

### DIFF
--- a/src/lib/apple-tv/devicectl-enrichment.ts
+++ b/src/lib/apple-tv/devicectl-enrichment.ts
@@ -12,7 +12,12 @@ export async function enrichDiscoveredDevicesWithDevicectl(
     return devices;
   }
 
-  const records = await listDevicectlDeviceRecords();
+  let records: DevicectlDeviceRecord[];
+  try {
+    records = await listDevicectlDeviceRecords();
+  } catch {
+    return devices;
+  }
   if (records.length === 0) {
     return devices;
   }
@@ -81,6 +86,7 @@ function mergeMetadata(
   return {
     ...base,
     identifier: extra.identifier || base.identifier,
+    identifierSource: extra.identifier ? 'devicectl' : base.identifierSource,
     model: extra.model || base.model,
     version: extra.version || base.version,
     deviceType: extra.deviceType || base.deviceType,

--- a/src/lib/apple-tv/discovered-device-mapper.ts
+++ b/src/lib/apple-tv/discovered-device-mapper.ts
@@ -24,6 +24,7 @@ export function toAppleTVDevice(
   return {
     name: device.name,
     identifier,
+    identifierSource: device.metadata.identifierSource,
     hostname,
     ip: device.ip,
     port,

--- a/src/lib/apple-tv/encryption/opack2.ts
+++ b/src/lib/apple-tv/encryption/opack2.ts
@@ -20,6 +20,23 @@ type SerializableValue =
  */
 export class Opack2 {
   /**
+   * Deserializes an OPACK2 buffer into a JavaScript value.
+   *
+   * @param data - Buffer containing one OPACK2 value
+   * @returns The decoded JavaScript value
+   * @throws AppleTVError if the buffer is malformed or contains unsupported markers
+   */
+  static loads(data: Buffer): SerializableValue {
+    const { value, offset } = this.decode(data, 0);
+    if (offset !== data.length) {
+      throw new AppleTVError(
+        `Trailing bytes after OPACK2 payload: ${data.length - offset}`,
+      );
+    }
+    return value;
+  }
+
+  /**
    * Serializes a JavaScript object to OPACK2 binary format
    * @param obj - The object to serialize (supports primitives, arrays, objects, and Buffers)
    * @returns Buffer containing the serialized data
@@ -73,6 +90,272 @@ export class Opack2 {
     throw new AppleTVError(
       `Unsupported type for OPACK2 serialization: ${typeof obj}`,
     );
+  }
+
+  private static decode(
+    data: Buffer,
+    offset: number,
+  ): { value: SerializableValue; offset: number } {
+    this.ensureAvailable(data, offset, 1);
+    const marker = data[offset++];
+
+    if (marker === constants.OPACK2_NULL) {
+      return { value: null, offset };
+    }
+    if (marker === constants.OPACK2_TRUE) {
+      return { value: true, offset };
+    }
+    if (marker === constants.OPACK2_FALSE) {
+      return { value: false, offset };
+    }
+
+    if (
+      marker >= constants.OPACK2_SMALL_INT_OFFSET &&
+      marker <=
+        constants.OPACK2_SMALL_INT_OFFSET + constants.OPACK2_SMALL_INT_MAX
+    ) {
+      return { value: marker - constants.OPACK2_SMALL_INT_OFFSET, offset };
+    }
+
+    if (marker === constants.OPACK2_INT8_MARKER) {
+      this.ensureAvailable(data, offset, 1);
+      return { value: data[offset], offset: offset + 1 };
+    }
+    if (marker === constants.OPACK2_INT32_MARKER) {
+      this.ensureAvailable(data, offset, 4);
+      return { value: data.readUInt32LE(offset), offset: offset + 4 };
+    }
+    if (marker === constants.OPACK2_INT64_MARKER) {
+      this.ensureAvailable(data, offset, 8);
+      const value = data.readBigUInt64LE(offset);
+      if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+        throw new AppleTVError(
+          `OPACK2 integer exceeds JavaScript safe integer range: ${value}`,
+        );
+      }
+      return { value: Number(value), offset: offset + 8 };
+    }
+    if (marker === constants.OPACK2_FLOAT_MARKER) {
+      this.ensureAvailable(data, offset, 4);
+      return { value: data.readFloatLE(offset), offset: offset + 4 };
+    }
+
+    if (
+      marker >= constants.OPACK2_SMALL_STRING_BASE &&
+      marker <=
+        constants.OPACK2_SMALL_STRING_BASE + constants.OPACK2_SMALL_STRING_MAX
+    ) {
+      const length = marker - constants.OPACK2_SMALL_STRING_BASE;
+      return this.decodeString(data, offset, length);
+    }
+    if (marker === constants.OPACK2_STRING_8BIT_LEN_MARKER) {
+      const { length, offset: valueOffset } = this.decodeLength(
+        data,
+        offset,
+        1,
+      );
+      return this.decodeString(data, valueOffset, length);
+    }
+    if (marker === constants.OPACK2_STRING_16BIT_LEN_MARKER) {
+      const { length, offset: valueOffset } = this.decodeLength(
+        data,
+        offset,
+        2,
+      );
+      return this.decodeString(data, valueOffset, length);
+    }
+    if (marker === constants.OPACK2_STRING_32BIT_LEN_MARKER) {
+      const { length, offset: valueOffset } = this.decodeLength(
+        data,
+        offset,
+        4,
+      );
+      return this.decodeString(data, valueOffset, length);
+    }
+
+    if (
+      marker >= constants.OPACK2_SMALL_BYTES_BASE &&
+      marker <=
+        constants.OPACK2_SMALL_BYTES_BASE + constants.OPACK2_SMALL_BYTES_MAX
+    ) {
+      const length = marker - constants.OPACK2_SMALL_BYTES_BASE;
+      return this.decodeBytes(data, offset, length);
+    }
+    if (marker === constants.OPACK2_BYTES_8BIT_LEN_MARKER) {
+      const { length, offset: valueOffset } = this.decodeLength(
+        data,
+        offset,
+        1,
+      );
+      return this.decodeBytes(data, valueOffset, length);
+    }
+    if (marker === constants.OPACK2_BYTES_16BIT_LEN_MARKER) {
+      const { length, offset: valueOffset } = this.decodeLength(
+        data,
+        offset,
+        2,
+      );
+      return this.decodeBytes(data, valueOffset, length);
+    }
+    if (marker === constants.OPACK2_BYTES_32BIT_LEN_MARKER) {
+      const { length, offset: valueOffset } = this.decodeLength(
+        data,
+        offset,
+        4,
+      );
+      return this.decodeBytes(data, valueOffset, length);
+    }
+
+    if (
+      marker >= constants.OPACK2_SMALL_ARRAY_BASE &&
+      marker < constants.OPACK2_VARIABLE_ARRAY_MARKER
+    ) {
+      return this.decodeFixedArray(
+        data,
+        offset,
+        marker - constants.OPACK2_SMALL_ARRAY_BASE,
+      );
+    }
+    if (marker === constants.OPACK2_VARIABLE_ARRAY_MARKER) {
+      return this.decodeVariableArray(data, offset);
+    }
+
+    if (
+      marker >= constants.OPACK2_SMALL_DICT_BASE &&
+      marker < constants.OPACK2_VARIABLE_DICT_MARKER
+    ) {
+      return this.decodeFixedDict(
+        data,
+        offset,
+        marker - constants.OPACK2_SMALL_DICT_BASE,
+      );
+    }
+    if (marker === constants.OPACK2_VARIABLE_DICT_MARKER) {
+      return this.decodeVariableDict(data, offset);
+    }
+
+    throw new AppleTVError(
+      `Unsupported OPACK2 marker: 0x${marker.toString(16)}`,
+    );
+  }
+
+  private static decodeBytes(
+    data: Buffer,
+    offset: number,
+    length: number,
+  ): { value: Buffer; offset: number } {
+    this.ensureAvailable(data, offset, length);
+    return {
+      value: data.subarray(offset, offset + length),
+      offset: offset + length,
+    };
+  }
+
+  private static decodeFixedArray(
+    data: Buffer,
+    offset: number,
+    length: number,
+  ): { value: SerializableArray; offset: number } {
+    const result: SerializableArray = [];
+    let currentOffset = offset;
+    for (let i = 0; i < length; i++) {
+      const decoded = this.decode(data, currentOffset);
+      result.push(decoded.value);
+      currentOffset = decoded.offset;
+    }
+    return { value: result, offset: currentOffset };
+  }
+
+  private static decodeFixedDict(
+    data: Buffer,
+    offset: number,
+    length: number,
+  ): { value: SerializableObject; offset: number } {
+    const result: SerializableObject = {};
+    let currentOffset = offset;
+    for (let i = 0; i < length; i++) {
+      const key = this.decode(data, currentOffset);
+      if (typeof key.value !== 'string') {
+        throw new AppleTVError('OPACK2 dictionary key is not a string');
+      }
+      const value = this.decode(data, key.offset);
+      result[key.value] = value.value;
+      currentOffset = value.offset;
+    }
+    return { value: result, offset: currentOffset };
+  }
+
+  private static decodeLength(
+    data: Buffer,
+    offset: number,
+    byteLength: 1 | 2 | 4,
+  ): { length: number; offset: number } {
+    this.ensureAvailable(data, offset, byteLength);
+    if (byteLength === 1) {
+      return { length: data[offset], offset: offset + 1 };
+    }
+    if (byteLength === 2) {
+      return { length: data.readUInt16BE(offset), offset: offset + 2 };
+    }
+    return { length: data.readUInt32BE(offset), offset: offset + 4 };
+  }
+
+  private static decodeString(
+    data: Buffer,
+    offset: number,
+    length: number,
+  ): { value: string; offset: number } {
+    this.ensureAvailable(data, offset, length);
+    return {
+      value: data.subarray(offset, offset + length).toString('utf8'),
+      offset: offset + length,
+    };
+  }
+
+  private static decodeVariableArray(
+    data: Buffer,
+    offset: number,
+  ): { value: SerializableArray; offset: number } {
+    const result: SerializableArray = [];
+    let currentOffset = offset;
+    while (true) {
+      const decoded = this.decode(data, currentOffset);
+      currentOffset = decoded.offset;
+      if (decoded.value === null) {
+        return { value: result, offset: currentOffset };
+      }
+      result.push(decoded.value);
+    }
+  }
+
+  private static decodeVariableDict(
+    data: Buffer,
+    offset: number,
+  ): { value: SerializableObject; offset: number } {
+    const result: SerializableObject = {};
+    let currentOffset = offset;
+    while (true) {
+      const key = this.decode(data, currentOffset);
+      const value = this.decode(data, key.offset);
+      currentOffset = value.offset;
+      if (key.value === null && value.value === null) {
+        return { value: result, offset: currentOffset };
+      }
+      if (typeof key.value !== 'string') {
+        throw new AppleTVError('OPACK2 dictionary key is not a string');
+      }
+      result[key.value] = value.value;
+    }
+  }
+
+  private static ensureAvailable(
+    data: Buffer,
+    offset: number,
+    length: number,
+  ): void {
+    if (offset + length > data.length) {
+      throw new AppleTVError('Unexpected end of OPACK2 payload');
+    }
   }
 
   /**

--- a/src/lib/apple-tv/pairing-protocol/pairing-protocol.ts
+++ b/src/lib/apple-tv/pairing-protocol/pairing-protocol.ts
@@ -8,6 +8,7 @@ import {
 } from '../constants.js';
 import { encodeAppleTVDeviceInfo } from '../device-info/index.js';
 import {
+  Opack2,
   createEd25519Signature,
   decryptChaCha20Poly1305,
   encryptChaCha20Poly1305,
@@ -25,7 +26,12 @@ import {
   decodeTLV8ToDict,
   encodeTLV8,
 } from '../tlv/index.js';
-import type { AppleTVDevice, TLV8Item } from '../types.js';
+import type {
+  AppleTVDevice,
+  AppleTVPairingFlowResult,
+  Opack2Dictionary,
+  TLV8Item,
+} from '../types.js';
 import { generateHostId } from '../utils/uuid-generator.js';
 import { INFO_TYPE, PAIRING_MESSAGES, PAIRING_STATES } from './constants.js';
 import type {
@@ -80,7 +86,9 @@ export class PairingProtocol implements PairingProtocolInterface {
     private readonly userInput: UserInputInterface,
   ) {}
 
-  async executePairingFlow(device: AppleTVDevice): Promise<string> {
+  async executePairingFlow(
+    device: AppleTVDevice,
+  ): Promise<AppleTVPairingFlowResult> {
     this._sequenceNumber = 1;
 
     try {
@@ -111,9 +119,11 @@ export class PairingProtocol implements PairingProtocolInterface {
       );
 
       // Step 6: Receive M6 completion
-      await this.receiveM6Completion(encryptionKeys.decryptKey);
+      const remotePairingUdid = await this.receiveM6Completion(
+        encryptionKeys.decryptKey,
+      );
 
-      return this.createPairingResult(device, ltpk, ltsk);
+      return this.createPairingResult(device, ltpk, ltsk, remotePairingUdid);
     } catch (error) {
       log.error('Pairing flow failed:', error);
       throw error;
@@ -244,18 +254,21 @@ export class PairingProtocol implements PairingProtocolInterface {
    * Attempts to decrypt and validate final pairing state
    * @param decryptKey Decryption key for M6 encrypted data
    */
-  private async receiveM6Completion(decryptKey: Buffer): Promise<void> {
+  private async receiveM6Completion(
+    decryptKey: Buffer,
+  ): Promise<string | undefined> {
     const m6Response = await this.networkClient.receiveResponse();
     log.info('M6 Response received');
 
     try {
-      this.processM6Response(m6Response, decryptKey);
+      return this.processM6Response(m6Response, decryptKey);
     } catch (error) {
       log.warn(
         'M6 decryption failed - but pairing may still be successful:',
         (error as Error).message,
       );
     }
+    return undefined;
   }
 
   /**
@@ -592,9 +605,12 @@ export class PairingProtocol implements PairingProtocolInterface {
    * @param m6Response Network response containing M6 completion message
    * @param decryptKey Decryption key for M6 encrypted data
    */
-  private processM6Response(m6Response: any, decryptKey: Buffer): void {
+  private processM6Response(
+    m6Response: any,
+    decryptKey: Buffer,
+  ): string | undefined {
     if (!m6Response.message?.plain?._0?.event?._0?.pairingData?._0?.data) {
-      return;
+      return undefined;
     }
 
     const m6DataBase64 =
@@ -622,7 +638,41 @@ export class PairingProtocol implements PairingProtocolInterface {
       });
       const decryptedTLV = decodeTLV8ToDict(decrypted);
       log.debug('M6 decrypted content types:', Object.keys(decryptedTLV));
+      const remotePairingUdid = this.extractRemotePairingUdid(decryptedTLV);
+      if (remotePairingUdid) {
+        log.debug(`M6 INFO remotepairing_udid: ${remotePairingUdid}`);
+      }
+      return remotePairingUdid;
     }
+    return undefined;
+  }
+
+  private extractRemotePairingUdid(
+    decryptedTLV: Record<number, Buffer | undefined>,
+  ): string | undefined {
+    const info = decryptedTLV[PairingDataComponentType.INFO];
+    if (!info) {
+      return undefined;
+    }
+
+    const decodedInfo = Opack2.loads(info);
+    if (!this.isOpackDictionary(decodedInfo)) {
+      return undefined;
+    }
+
+    const remotePairingUdid = decodedInfo.remotepairing_udid;
+    return typeof remotePairingUdid === 'string' && remotePairingUdid
+      ? remotePairingUdid.toUpperCase()
+      : undefined;
+  }
+
+  private isOpackDictionary(value: unknown): value is Opack2Dictionary {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      !Array.isArray(value) &&
+      !Buffer.isBuffer(value)
+    );
   }
 
   /**
@@ -658,8 +708,42 @@ export class PairingProtocol implements PairingProtocolInterface {
     device: AppleTVDevice,
     ltpk: Buffer,
     ltsk: Buffer,
-  ): Promise<string> {
+    remotePairingUdid?: string,
+  ): Promise<AppleTVPairingFlowResult> {
+    const deviceId = this.resolvePairingDeviceId(device, remotePairingUdid);
     const storage = new PairingStorage(DEFAULT_PAIRING_CONFIG);
-    return await storage.save(device.identifier || device.name, ltpk, ltsk);
+    const pairingFile = await storage.save(
+      deviceId,
+      ltpk,
+      ltsk,
+      '',
+      remotePairingUdid,
+    );
+    return { deviceId, pairingFile };
+  }
+
+  private resolvePairingDeviceId(
+    device: AppleTVDevice,
+    remotePairingUdid?: string,
+  ): string {
+    if (remotePairingUdid) {
+      return remotePairingUdid.toUpperCase();
+    }
+
+    if (
+      process.platform === 'darwin' &&
+      device.identifierSource === 'devicectl' &&
+      device.identifier
+    ) {
+      log.warn(
+        'M6 INFO did not include remotepairing_udid; falling back to devicectl identifier',
+      );
+      return device.identifier.toUpperCase();
+    }
+
+    throw new PairingError(
+      'Apple TV pairing did not provide remotepairing_udid and no macOS devicectl fallback is available',
+      'REMOTE_PAIRING_UDID_MISSING',
+    );
   }
 }

--- a/src/lib/apple-tv/pairing-protocol/types.ts
+++ b/src/lib/apple-tv/pairing-protocol/types.ts
@@ -1,4 +1,4 @@
-import type { AppleTVDevice } from '../types.js';
+import type { AppleTVDevice, AppleTVPairingFlowResult } from '../types.js';
 
 /** Encryption keys derived from SRP session key for secure communication */
 export interface EncryptionKeys {
@@ -56,5 +56,5 @@ export interface UserInputInterface {
 
 /** Interface for executing the Apple TV pairing protocol flow */
 export interface PairingProtocolInterface {
-  executePairingFlow(device: AppleTVDevice): Promise<string>;
+  executePairingFlow(device: AppleTVDevice): Promise<AppleTVPairingFlowResult>;
 }

--- a/src/lib/apple-tv/pairing/pairing-service.ts
+++ b/src/lib/apple-tv/pairing/pairing-service.ts
@@ -13,6 +13,7 @@ import { PairingProtocol } from '../pairing-protocol/index.js';
 import type { UserInputInterface } from '../pairing-protocol/types.js';
 import type {
   AppleTVDevice,
+  AppleTVPairingFlowResult,
   AppleTVPairingResult,
   PairingConfig,
 } from '../types.js';
@@ -53,12 +54,12 @@ export class AppleTVPairingService {
       }
 
       const device = await this.selectDevice(devices, deviceSelector);
-      const pairingFile = await this.pairWithDevice(device);
+      const pairingResult = await this.pairWithDevice(device);
 
       return {
         success: true,
-        deviceId: device.identifier,
-        pairingFile,
+        deviceId: pairingResult.deviceId,
+        pairingFile: pairingResult.pairingFile,
       };
     } catch (error) {
       log.error('Pairing failed:', error);
@@ -70,7 +71,9 @@ export class AppleTVPairingService {
     }
   }
 
-  async pairWithDevice(device: AppleTVDevice): Promise<string> {
+  async pairWithDevice(
+    device: AppleTVDevice,
+  ): Promise<AppleTVPairingFlowResult> {
     try {
       // Use IP if available, otherwise fall back to hostname
       const connectionTarget = device.ip ?? device.hostname;

--- a/src/lib/apple-tv/storage/pairing-storage.ts
+++ b/src/lib/apple-tv/storage/pairing-storage.ts
@@ -27,6 +27,7 @@ export class PairingStorage implements PairingStorageInterface {
     ltpk: Buffer,
     ltsk: Buffer,
     remoteUnlockHostKey = '',
+    remotePairingUdid = '',
   ): Promise<string> {
     try {
       const itemName = `${APPLETV_PAIRING_PREFIX}${deviceId}`;
@@ -34,6 +35,7 @@ export class PairingStorage implements PairingStorageInterface {
         ltpk,
         ltsk,
         remoteUnlockHostKey,
+        remotePairingUdid,
       );
 
       const item = await this.box.createItemWithValue(itemName, plistContent);
@@ -82,6 +84,10 @@ export class PairingStorage implements PairingStorageInterface {
         privateKey,
         publicKey,
         remoteUnlockHostKey: (parsed.remote_unlock_host_key as string) || '',
+        remotePairingUdid:
+          typeof parsed.remote_pairing_udid === 'string'
+            ? parsed.remote_pairing_udid.toUpperCase()
+            : undefined,
       };
     } catch (error) {
       log.error(`Failed to load pair record for ${deviceId}:`, error);
@@ -118,11 +124,13 @@ export class PairingStorage implements PairingStorageInterface {
     publicKey: Buffer,
     privateKey: Buffer,
     remoteUnlockHostKey: string,
+    remotePairingUdid: string,
   ): string {
     return createXmlPlist({
       private_key: privateKey,
       public_key: publicKey,
       remote_unlock_host_key: remoteUnlockHostKey,
+      remote_pairing_udid: remotePairingUdid.toUpperCase(),
     });
   }
 

--- a/src/lib/apple-tv/storage/types.ts
+++ b/src/lib/apple-tv/storage/types.ts
@@ -2,6 +2,7 @@ export interface PairRecord {
   publicKey: Buffer;
   privateKey: Buffer;
   remoteUnlockHostKey: string;
+  remotePairingUdid?: string;
 }
 
 export interface PairingStorageInterface {
@@ -10,6 +11,7 @@ export interface PairingStorageInterface {
     ltpk: Buffer,
     ltsk: Buffer,
     remoteUnlockHostKey?: string,
+    remotePairingUdid?: string,
   ): Promise<string>;
   load(deviceId: string): Promise<PairRecord | null>;
   getAvailableDeviceIds(): Promise<string[]>;

--- a/src/lib/apple-tv/tunnel/tunnel-service.ts
+++ b/src/lib/apple-tv/tunnel/tunnel-service.ts
@@ -205,11 +205,19 @@ export class AppleTVTunnelService {
       this.logDiscoveredDevices(devices);
     }
 
+    let identifiersToTry = await this.validateAndGetPairRecords(deviceId);
+    if (
+      !deviceId &&
+      specificDeviceIdentifier &&
+      identifiersToTry.includes(specificDeviceIdentifier)
+    ) {
+      identifiersToTry = [specificDeviceIdentifier];
+    }
     const devicesToProcess = this.selectDevicesToProcess(
       devices,
       specificDeviceIdentifier,
+      identifiersToTry,
     );
-    const identifiersToTry = await this.validateAndGetPairRecords(deviceId);
 
     const failedAttempts: { identifier: string; error: string }[] = [];
 
@@ -286,6 +294,7 @@ export class AppleTVTunnelService {
   private selectDevicesToProcess(
     devices: AppleTVDevice[],
     specificDeviceIdentifier?: string,
+    pairRecordIds: string[] = [],
   ): AppleTVDevice[] {
     if (!specificDeviceIdentifier) {
       return devices;
@@ -296,6 +305,13 @@ export class AppleTVTunnelService {
     );
 
     if (filteredDevices.length === 0) {
+      if (pairRecordIds.includes(specificDeviceIdentifier)) {
+        appleTVLog.info(
+          `\nNo discovered device identifier matched ${specificDeviceIdentifier}; trying all discovered devices with the matching pair record.`,
+        );
+        return devices;
+      }
+
       appleTVLog.error(
         `\nDevice with identifier ${specificDeviceIdentifier} not found in discovered devices.`,
       );
@@ -375,15 +391,20 @@ export class AppleTVTunnelService {
           connectionTarget,
           listenerInfo.port,
         );
+        const tunnelDevice = this.withTunnelIdentifier(device, pairRecord);
 
         appleTVLog.debug('Step 6: Tunnel Establishment success');
         appleTVLog.info(`🔑 Using pair record: ${identifier}`);
         appleTVLog.info(
-          `📱 Connected to device: ${device.identifier} (${device.name})`,
+          `📱 Connected to device: ${tunnelDevice.identifier} (${tunnelDevice.name})`,
         );
         appleTVLog.info(`   Target: ${connectionTarget}:${device.port}`);
 
-        return { tcpSocket, psk: keys.encryptionKey, device };
+        return {
+          tcpSocket,
+          psk: keys.encryptionKey,
+          device: tunnelDevice,
+        };
       } catch (error: any) {
         const errorMessage = error.message || String(error);
         appleTVLog.debug(
@@ -420,6 +441,40 @@ export class AppleTVTunnelService {
       appleTVLog.error(`  - ${identifier}: ${error}`);
     });
     appleTVLog.error('=======================================\n');
+  }
+
+  private resolveTunnelIdentifier(
+    pairRecord: PairRecord,
+    device: AppleTVDevice,
+  ): string {
+    if (pairRecord.remotePairingUdid) {
+      return pairRecord.remotePairingUdid.toUpperCase();
+    }
+
+    if (
+      process.platform === 'darwin' &&
+      device.identifierSource === 'devicectl' &&
+      device.identifier
+    ) {
+      appleTVLog.warn(
+        'Pair record does not include remote_pairing_udid; falling back to devicectl identifier',
+      );
+      return device.identifier.toUpperCase();
+    }
+
+    throw new Error(
+      'Pair record does not include remote_pairing_udid and no macOS devicectl fallback is available',
+    );
+  }
+
+  private withTunnelIdentifier(
+    device: AppleTVDevice,
+    pairRecord: PairRecord,
+  ): AppleTVDevice {
+    return {
+      ...device,
+      identifier: this.resolveTunnelIdentifier(pairRecord, device),
+    };
   }
 
   private async performHandshake(): Promise<void> {

--- a/src/lib/apple-tv/types.ts
+++ b/src/lib/apple-tv/types.ts
@@ -4,6 +4,7 @@ export interface AppleTVDeviceInfo {
   btAddr: string;
   mac: Buffer;
   remotePairingSerialNumber: string;
+  remotePairingUdid?: string;
   accountID: string;
   model: string;
   name: string;
@@ -23,6 +24,11 @@ export interface PairingResult {
   error?: Error;
 }
 
+export interface AppleTVPairingFlowResult {
+  pairingFile: string;
+  deviceId: string;
+}
+
 /** Public type for Apple TV pairing results (e.g. from discoverAndPair). */
 export type AppleTVPairingResult = PairingResult;
 
@@ -30,6 +36,7 @@ export type AppleTVPairingResult = PairingResult;
 export interface AppleTVDevice {
   name: string;
   identifier: string;
+  identifierSource?: 'bonjour' | 'devicectl';
   hostname: string;
   ip?: string;
   port: number;

--- a/src/lib/discovery/mdns-discovery-backend.ts
+++ b/src/lib/discovery/mdns-discovery-backend.ts
@@ -99,6 +99,7 @@ async function instanceToDevice(
     const identifier = txt.identifier ?? name;
     const metadata: DiscoveredDeviceMetadata = {
       identifier,
+      identifierSource: 'bonjour',
       model: txt.model ?? '',
       version: txt.ver ?? '',
     };

--- a/src/lib/discovery/types.ts
+++ b/src/lib/discovery/types.ts
@@ -1,5 +1,6 @@
 export interface DiscoveredDeviceMetadata {
   identifier?: string;
+  identifierSource?: 'bonjour' | 'devicectl';
   model?: string;
   version?: string;
   deviceType?: string;

--- a/test/unit/apple-tv/devicectl-enrichment.spec.ts
+++ b/test/unit/apple-tv/devicectl-enrichment.spec.ts
@@ -66,6 +66,7 @@ describe('devicectl-enrichment', function () {
 
     expect(enriched).to.have.lengthOf(1);
     expect(enriched[0].metadata.identifier).to.equal('udid-123');
+    expect(enriched[0].metadata.identifierSource).to.equal('devicectl');
     expect(enriched[0].metadata.model).to.equal('AppleTV6,2');
     expect(enriched[0].metadata.version).to.equal('17.4');
     expect(enriched[0].metadata.deviceType).to.equal('tv');

--- a/test/unit/apple-tv/encryption/opack2.spec.ts
+++ b/test/unit/apple-tv/encryption/opack2.spec.ts
@@ -5,6 +5,43 @@ import { Opack2 } from '../../../../src/lib/apple-tv/encryption/opack2.js';
 import { AppleTVError } from '../../../../src/lib/apple-tv/errors.js';
 
 describe('Apple TV Encryption - Opack2', () => {
+  describe('loads', () => {
+    it('should decode primitive types', () => {
+      expect(Opack2.loads(Buffer.from([0x03]))).to.equal(null);
+      expect(Opack2.loads(Buffer.from([0x01]))).to.equal(true);
+      expect(Opack2.loads(Buffer.from([0x02]))).to.equal(false);
+      expect(Opack2.loads(Buffer.from([0x0a]))).to.equal(2);
+    });
+
+    it('should decode an Apple TV M6 INFO-shaped payload', () => {
+      const info = Opack2.dumps({
+        remotepairing_serial_number: 'SYNTHETIC123',
+        remotepairing_udid: 'synthetic-remote-pairing-udid',
+        model: 'AppleTV-Test',
+        name: 'Test Apple TV',
+      });
+
+      const decoded = Opack2.loads(info) as Record<string, unknown>;
+
+      expect(decoded.remotepairing_udid).to.equal(
+        'synthetic-remote-pairing-udid',
+      );
+      expect(decoded.remotepairing_serial_number).to.equal('SYNTHETIC123');
+      expect(decoded.model).to.equal('AppleTV-Test');
+      expect(decoded.name).to.equal('Test Apple TV');
+    });
+
+    it('should round-trip objects encoded with dumps', () => {
+      const value = {
+        name: 'Apple TV',
+        identifier: 'synthetic-remote-pairing-udid',
+        data: Buffer.from([1, 2, 3]),
+      };
+
+      expect(Opack2.loads(Opack2.dumps(value))).to.deep.equal(value);
+    });
+  });
+
   describe('dumps - primitive types', () => {
     it('should encode null', () => {
       const result = Opack2.dumps(null);

--- a/test/unit/apple-tv/tunnel-service.spec.ts
+++ b/test/unit/apple-tv/tunnel-service.spec.ts
@@ -6,6 +6,28 @@ import type { AppleTVDevice } from '../../../src/lib/apple-tv/types.js';
 import type { DiscoveredDevice } from '../../../src/lib/discovery/types.js';
 
 describe('AppleTVTunnelService', function () {
+  async function loadTunnelService() {
+    const { AppleTVTunnelService } = await esmock(
+      '../../../src/lib/apple-tv/tunnel/tunnel-service.js',
+      {
+        '../../../src/lib/apple-tv/network/index.js': {
+          NetworkClient: class {
+            disconnect() {}
+          },
+        },
+        '../../../src/lib/apple-tv/storage/pairing-storage.js': {
+          PairingStorage: class {},
+        },
+        '../../../src/lib/apple-tv/tunnel/remoted-controller.js': {
+          RemotedController: class {
+            resume() {}
+          },
+        },
+      },
+    );
+    return AppleTVTunnelService;
+  }
+
   it('uses the provided device discovery timeout', async function () {
     const discoverDevices = sinon.stub().resolves([
       {
@@ -124,5 +146,98 @@ describe('AppleTVTunnelService', function () {
 
     expect(error?.message).to.equal('No pair records found');
     expect(discoverDevices.called).to.equal(false);
+  });
+
+  it('uses remotePairingUdid from the pair record as the tunnel identifier', async function () {
+    const AppleTVTunnelService = await loadTunnelService();
+    const tunnelService = new AppleTVTunnelService();
+    const device: AppleTVDevice = {
+      name: 'Apple TV',
+      identifier: 'devicectl-udid',
+      identifierSource: 'devicectl',
+      hostname: 'apple-tv.local',
+      port: 49152,
+      model: 'AppleTV',
+      version: '17.0',
+    };
+
+    const tunnelDevice = (tunnelService as any).withTunnelIdentifier(device, {
+      publicKey: Buffer.alloc(0),
+      privateKey: Buffer.alloc(0),
+      remoteUnlockHostKey: '',
+      remotePairingUdid: 'synthetic-remote-pairing-udid',
+    });
+
+    expect(tunnelDevice.identifier).to.equal('SYNTHETIC-REMOTE-PAIRING-UDID');
+  });
+
+  it('falls back to devicectl identifiers only on macOS', async function () {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', {
+      value: 'darwin',
+      configurable: true,
+    });
+    try {
+      const AppleTVTunnelService = await loadTunnelService();
+      const tunnelService = new AppleTVTunnelService();
+      const device: AppleTVDevice = {
+        name: 'Apple TV',
+        identifier: 'synthetic-devicectl-udid',
+        identifierSource: 'devicectl',
+        hostname: 'apple-tv.local',
+        port: 49152,
+        model: 'AppleTV',
+        version: '17.0',
+      };
+
+      const tunnelDevice = (tunnelService as any).withTunnelIdentifier(device, {
+        publicKey: Buffer.alloc(0),
+        privateKey: Buffer.alloc(0),
+        remoteUnlockHostKey: '',
+      });
+
+      expect(tunnelDevice.identifier).to.equal('SYNTHETIC-DEVICECTL-UDID');
+    } finally {
+      Object.defineProperty(process, 'platform', {
+        value: originalPlatform,
+        configurable: true,
+      });
+    }
+  });
+
+  it('throws if no remotePairingUdid or macOS devicectl fallback is available', async function () {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', {
+      value: 'linux',
+      configurable: true,
+    });
+    try {
+      const AppleTVTunnelService = await loadTunnelService();
+      const tunnelService = new AppleTVTunnelService();
+      const device: AppleTVDevice = {
+        name: 'Apple TV',
+        identifier: 'bonjour-id',
+        identifierSource: 'bonjour',
+        hostname: 'apple-tv.local',
+        port: 49152,
+        model: 'AppleTV',
+        version: '17.0',
+      };
+
+      expect(() =>
+        (tunnelService as any).withTunnelIdentifier(device, {
+          publicKey: Buffer.alloc(0),
+          privateKey: Buffer.alloc(0),
+          remoteUnlockHostKey: '',
+        }),
+      ).to.throw(
+        'Pair record does not include remote_pairing_udid and no macOS devicectl fallback is available',
+      );
+    } finally {
+      Object.defineProperty(process, 'platform', {
+        value: originalPlatform,
+        configurable: true,
+      });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Decode the decrypted Apple TV M6 `INFO` OPACK2 payload and extract `remotepairing_udid`.
- Persist `remote_pairing_udid` in Apple TV pair records and use it as the primary tunnel registry UDID.
- Keep macOS `devicectl` identifiers as a fallback only when `remote_pairing_udid` is unavailable, and fail otherwise.
- Normalize Apple TV UDIDs to uppercase for consistency with `devicectl` and registry expectations.

Addresses https://github.com/appium/appium-ios-remotexpc/issues/159