### PR TITLE
feat: Add `com.apple.coredevice.hid.indigo` service

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:pair-record": "mocha test/integration/read-pair-record-test.ts --exit --timeout 1m",
     "test:diagnostics": "mocha test/integration/diagnostics-test.ts --exit --timeout 1m",
     "test:notification": "mocha test/integration/notification-proxy-test.ts --exit --timeout 1m",
+    "test:hid-indigo": "mocha test/integration/hid-indigo-test.ts --exit --timeout 1m",
     "test:image-mounter": "mocha test/integration/mobile-image-mounter-test.ts --exit --timeout 1m",
     "test:mobile-config": "mocha test/integration/mobile-config-test.ts --exit --timeout 1m",
     "test:springboard": "mocha test/integration/springboard-service-test.ts --exit --timeout 1m",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
   createLockdownServiceForTunnel,
 } from './lib/lockdown/index.js';
 import { DevicePortForwarder } from './lib/port-forwarding/index.js';
+import type { RsdServiceCatalogClient as RsdServiceCatalogClientType } from './lib/remote-xpc/rsd-service-catalog-client.js';
 import {
   TunnelManager,
   TunnelReadinessCoordinator,
@@ -29,7 +30,11 @@ export type {
   DevicePortForwarderOptions,
   UpstreamSocketConnector,
 } from './lib/port-forwarding/index.js';
-export type { RemoteXpcConnection } from './lib/remote-xpc/remote-xpc-connection.js';
+export type { RsdServiceCatalogClient } from './lib/remote-xpc/rsd-service-catalog-client.js';
+/**
+ * @deprecated Use RsdServiceCatalogClient instead.
+ */
+export type RemoteXpcConnection = RsdServiceCatalogClientType;
 export type { AfcService } from './services/ios/afc/index.js';
 export { AfcConnectionError } from './services/ios/afc/errors.js';
 export type {
@@ -39,6 +44,18 @@ export type {
   ZipConduitStreamStats,
 } from './services/ios/zipconduit/index.js';
 export type { InstallationProxyService } from './services/ios/installation-proxy/index.js';
+export {
+  HID_BUTTON_STATE_CANCELED,
+  HID_BUTTON_STATE_DOWN,
+  HID_BUTTON_STATE_UP,
+  HidIndigoService,
+} from './services/ios/hid-indigo/index.js';
+export type {
+  HidButtonEventOptions,
+  HidButtonName,
+  HidButtonPressOptions,
+  HidButtonState,
+} from './services/ios/hid-indigo/index.js';
 export type {
   SyslogEntry,
   SyslogLabel,

--- a/src/lib/remote-xpc/handshake.ts
+++ b/src/lib/remote-xpc/handshake.ts
@@ -76,8 +76,10 @@ class Handshake {
 
       // Step 2: Send SETTINGS frame on stream 0.
       const settings: Record<number, number> = {
-        [SettingsFrame.MAX_CONCURRENT_STREAMS]: 100,
-        [SettingsFrame.INITIAL_WINDOW_SIZE]: 1048576,
+        [SettingsFrame.MAX_CONCURRENT_STREAMS]:
+          Http2Constants.DEFAULT_SETTINGS_MAX_CONCURRENT_STREAMS,
+        [SettingsFrame.INITIAL_WINDOW_SIZE]:
+          Http2Constants.DEFAULT_SETTINGS_INITIAL_WINDOW_SIZE,
       };
       const settingsFrame: SettingsFrame = new SettingsFrame(0, settings, []);
       await this.sendFrame(settingsFrame.serialize());
@@ -85,7 +87,7 @@ class Handshake {
       // Step 3: Send WINDOW_UPDATE frame on stream 0.
       const windowUpdateFrame: WindowUpdateFrame = new WindowUpdateFrame(
         0,
-        983041,
+        Http2Constants.DEFAULT_WIN_SIZE_INCR,
       );
       await this.sendFrame(windowUpdateFrame.serialize());
 
@@ -100,7 +102,19 @@ class Handshake {
       // Step 5: Send first DataFrame on stream 1 (empty payload).
       await this.sendRequest({});
 
-      // Step 6: Send second DataFrame on stream 1 with specific flags.
+      // Step 6: Send a HEADERS frame on stream 3 before terminating stream 1.
+      // CoreDevice services validate this ordering and close the connection if
+      // the stream-1 terminator arrives before the reply channel exists.
+      const headersFrameReply: HeadersFrame = new HeadersFrame(
+        Http2Constants.REPLY_CHANNEL,
+        Buffer.from(''),
+        ['END_HEADERS'],
+      );
+      await this.sendFrame(headersFrameReply.serialize());
+
+      // Step 7: Send second DataFrame on stream 1 with specific flags.
+      // The receiving daemon expects this frame order:
+      // Headers#1, Data#1(init), Headers#3, Data#1(term), Data#3(init).
       const dataMessage: XPCMessage = {
         flags: 0x0201,
         id: 0,
@@ -114,14 +128,6 @@ class Handshake {
       );
       await this.sendFrame(dataFrame.serialize());
       this._nextMessageId[Http2Constants.ROOT_CHANNEL]++;
-
-      // Step 7: Send a HEADERS frame on stream 3.
-      const headersFrameReply: HeadersFrame = new HeadersFrame(
-        Http2Constants.REPLY_CHANNEL,
-        Buffer.from(''),
-        ['END_HEADERS'],
-      );
-      await this.sendFrame(headersFrameReply.serialize());
 
       // Step 8: Open REPLY_CHANNEL with INIT_HANDSHAKE flags.
       const replyMessage: XPCMessage = {

--- a/src/lib/remote-xpc/remote-xpc-framed-transport.ts
+++ b/src/lib/remote-xpc/remote-xpc-framed-transport.ts
@@ -1,0 +1,248 @@
+import { EventEmitter } from 'node:events';
+import net from 'node:net';
+
+import { getLogger } from '../logger.js';
+import { DataFrame } from './handshake-frames.js';
+import Handshake from './handshake.js';
+import {
+  Http2FrameParser,
+  buildWindowUpdateFrames,
+} from './http2-frame-parser.js';
+import { decodeMessage } from './xpc-protocol.js';
+
+const log = getLogger('RemoteXpcFramedTransport');
+
+const DEFAULT_SOCKET_CLOSE_TIMEOUT_MS = 1000;
+const DEFAULT_SOCKET_END_TIMEOUT_MS = 500;
+
+export interface RemoteXpcFramedTransportConnectOptions {
+  timeoutMs: number;
+  handshakeDelayMs?: number;
+}
+
+/**
+ * Shared RemoteXPC transport: owns TCP socket lifecycle, HTTP/2/XPC handshake,
+ * DATA frame parsing, window updates, and XPC message reassembly.
+ */
+export class RemoteXpcFramedTransport extends EventEmitter {
+  private readonly address: [string, number];
+  private socket: net.Socket | null = null;
+  private frameParser = new Http2FrameParser();
+  private pendingXpcData = Buffer.alloc(0);
+  private connected = false;
+  private closing = false;
+
+  constructor(address: [string, number]) {
+    super();
+    this.address = address;
+  }
+
+  get isConnected(): boolean {
+    return this.connected;
+  }
+
+  async connect(
+    options: RemoteXpcFramedTransportConnectOptions,
+  ): Promise<void> {
+    if (this.connected) {
+      return;
+    }
+
+    this.resetParsers();
+    const socket = net.createConnection({
+      host: this.address[0],
+      port: this.address[1],
+      family: 6,
+      noDelay: true,
+      keepAlive: true,
+    });
+    this.socket = socket;
+    this.registerSocketHandlers(socket);
+
+    await this.waitForSocketConnect(socket, options.timeoutMs);
+
+    if (options.handshakeDelayMs) {
+      await new Promise<void>((resolve) =>
+        setTimeout(resolve, options.handshakeDelayMs),
+      );
+    }
+
+    try {
+      await new Handshake(socket).perform();
+      this.connected = true;
+    } catch (error) {
+      await this.close();
+      throw error;
+    }
+  }
+
+  sendDataFrame(payload: Buffer, streamId = 1): void {
+    if (!this.socket?.writable) {
+      throw new Error('RemoteXPC socket is not writable');
+    }
+    this.socket.write(new DataFrame(streamId, payload, []).serialize());
+  }
+
+  async close(): Promise<void> {
+    this.closing = true;
+    this.connected = false;
+
+    const socket = this.socket;
+    if (!socket) {
+      this.closing = false;
+      return;
+    }
+
+    this.socket = null;
+    await this.shutdownSocket(socket);
+    this.closing = false;
+  }
+
+  private waitForSocketConnect(
+    socket: net.Socket,
+    timeoutMs: number,
+  ): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        socket.destroy();
+        reject(
+          new Error(`RemoteXPC connection timed out after ${timeoutMs}ms`),
+        );
+      }, timeoutMs);
+
+      const cleanupConnectListeners = (): void => {
+        clearTimeout(timeout);
+        socket.off('error', onError);
+      };
+
+      const onError = (error: Error): void => {
+        cleanupConnectListeners();
+        reject(error);
+      };
+
+      socket.once('error', onError);
+      socket.once('connect', () => {
+        cleanupConnectListeners();
+        resolve();
+      });
+    });
+  }
+
+  private registerSocketHandlers(socket: net.Socket): void {
+    socket.on('data', (data: Buffer | string) => {
+      const chunk = Buffer.isBuffer(data) ? data : Buffer.from(data, 'hex');
+      this.handleData(chunk);
+    });
+    socket.on('error', (error: Error) => {
+      if (this.closing) {
+        return;
+      }
+      log.error(`RemoteXPC transport error: ${error.message}`);
+      this.connected = false;
+      this.emit('error', error);
+    });
+    socket.on('close', () => {
+      this.connected = false;
+      this.emit('close');
+    });
+  }
+
+  private handleData(chunk: Buffer): void {
+    if (!this.socket) {
+      return;
+    }
+
+    let frames;
+    try {
+      frames = this.frameParser.append(chunk);
+    } catch (error) {
+      this.emit(
+        'error',
+        error instanceof Error ? error : new Error(String(error)),
+      );
+      return;
+    }
+
+    for (const frame of frames) {
+      if (frame.type !== 'data') {
+        continue;
+      }
+
+      const { streamId, data, bodyLen } = frame.frame;
+      for (const windowUpdate of buildWindowUpdateFrames(streamId, bodyLen)) {
+        this.socket.write(windowUpdate);
+      }
+      this.ingestXpcData(data);
+    }
+  }
+
+  private ingestXpcData(chunk: Buffer): void {
+    let pending = Buffer.concat([this.pendingXpcData, chunk]);
+    this.pendingXpcData = Buffer.alloc(0);
+
+    while (pending.length > 0) {
+      try {
+        const { message, bytesConsumed } = decodeMessage(pending);
+        pending = pending.subarray(bytesConsumed);
+        if (message.body) {
+          this.emit('message', message.body);
+        }
+      } catch {
+        this.pendingXpcData = pending;
+        return;
+      }
+    }
+  }
+
+  private shutdownSocket(socket: net.Socket): Promise<void> {
+    return new Promise<void>((resolve) => {
+      let finished = false;
+      const finish = (): void => {
+        if (finished) {
+          return;
+        }
+        finished = true;
+        resolve();
+      };
+
+      const closeTimeout = setTimeout(() => {
+        log.warn('RemoteXPC socket close timed out, destroying socket');
+        socket.destroy();
+        finish();
+      }, DEFAULT_SOCKET_CLOSE_TIMEOUT_MS);
+
+      socket.once('close', () => {
+        clearTimeout(closeTimeout);
+        finish();
+      });
+      socket.on('error', () => {});
+
+      try {
+        socket.removeAllListeners('data');
+        socket.end(Buffer.alloc(0), () => {
+          setTimeout(() => {
+            if (!finished && !socket.destroyed) {
+              clearTimeout(closeTimeout);
+              socket.destroy();
+              finish();
+            }
+          }, DEFAULT_SOCKET_END_TIMEOUT_MS);
+        });
+      } catch (error) {
+        log.error(
+          `Unexpected error during RemoteXPC socket close: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+        clearTimeout(closeTimeout);
+        socket.destroy();
+        finish();
+      }
+    });
+  }
+
+  private resetParsers(): void {
+    this.frameParser = new Http2FrameParser();
+    this.pendingXpcData = Buffer.alloc(0);
+  }
+}

--- a/src/lib/remote-xpc/rsd-service-catalog-client.ts
+++ b/src/lib/remote-xpc/rsd-service-catalog-client.ts
@@ -1,18 +1,12 @@
-import net from 'node:net';
-
 import { getLogger } from '../logger.js';
-import Handshake from './handshake.js';
-import {
-  Http2FrameParser,
-  buildWindowUpdateFrames,
-} from './http2-frame-parser.js';
+import { RemoteXpcFramedTransport } from './remote-xpc-framed-transport.js';
 import {
   type Service,
-  ServiceCatalogCollector,
   type ServicesResponse,
+  servicesFromXpcBody,
 } from './service-catalog.js';
 
-const log = getLogger('RemoteXpcConnection');
+const log = getLogger('RsdServiceCatalogClient');
 
 // Timeout constants
 /** Max time to wait for the TCP socket to connect. */
@@ -31,11 +25,8 @@ export const CONNECTION_DEFAULT_OPERATION_TIMEOUT_MS =
 /** TunnelManager retry budget; never shorter than a single connect attempt. */
 export const CONNECTION_OVERALL_TIMEOUT_MS =
   CONNECTION_DEFAULT_OPERATION_TIMEOUT_MS;
-const SOCKET_CLOSE_TIMEOUT_MS = 1000; // 1 second
-const SOCKET_END_TIMEOUT_MS = 500; // 0.5 seconds
-const SOCKET_WRITE_TIMEOUT_MS = 500; // 0.5 seconds
 
-export interface RemoteXpcConnectOptions {
+export interface RsdServiceCatalogClientConnectOptions {
   /** Max time for this connect attempt (TCP + handshake + services). */
   timeoutMs?: number;
 }
@@ -47,10 +38,9 @@ interface ConnectSession {
   isSettled(): boolean;
 }
 
-class RemoteXpcConnection {
+class RsdServiceCatalogClient {
   private readonly _address: [string, number];
-  private _socket: net.Socket | undefined;
-  private _handshake: Handshake | undefined;
+  private _transport: RemoteXpcFramedTransport | undefined;
   private _isConnected: boolean;
   private _services: Service[] | undefined;
   /** Timer set during connect() to detect missing services after handshake */
@@ -60,8 +50,7 @@ class RemoteXpcConnection {
 
   constructor(address: [string, number]) {
     this._address = address;
-    this._socket = undefined;
-    this._handshake = undefined;
+    this._transport = undefined;
     this._isConnected = false;
     this._services = undefined;
     this._serviceExtractionTimer = undefined;
@@ -77,10 +66,11 @@ class RemoteXpcConnection {
   }
 
   /**
-   * Connect to the remote device and perform handshake
-   * @returns Promise that resolves with the list of available services
+   * Connect to Remote Service Discovery and return the advertised services.
    */
-  async connect(options?: RemoteXpcConnectOptions): Promise<ServicesResponse> {
+  async connect(
+    options?: RsdServiceCatalogClientConnectOptions,
+  ): Promise<ServicesResponse> {
     if (this._isConnected) {
       throw new Error('Already connected');
     }
@@ -96,29 +86,32 @@ class RemoteXpcConnection {
       );
 
       try {
-        this._socket = this.createConnectSocket();
-        this.registerConnectSocketHandlers(session, this._socket);
+        const transport = new RemoteXpcFramedTransport(this._address);
+        this._transport = transport;
+        this.registerTransportHandlers(session, transport);
+        void this.connectTransport(session, transport, operationTimeoutMs);
       } catch (error) {
-        log.error(`Failed to create connection: ${error}`);
+        log.error(`Failed to create RSD catalog client: ${error}`);
         session.settleFailure(error);
       }
     });
   }
 
   /**
-   * Close the connection
+   * Close the RSD catalog connection.
    */
   async close(): Promise<void> {
     this._isClosing = true;
     this.clearServiceExtractionTimer();
 
-    const socket = this._socket;
-    if (!socket) {
+    const transport = this._transport;
+    if (!transport) {
       return;
     }
 
     this._isConnected = false;
-    await this.shutdownSocket(socket);
+    await transport.close();
+    this.cleanupResources();
   }
 
   /**
@@ -201,24 +194,11 @@ class RemoteXpcConnection {
     };
   }
 
-  private createConnectSocket(): net.Socket {
-    return net.connect({
-      host: this._address[0],
-      port: this._address[1],
-      family: 6,
-      noDelay: true,
-      keepAlive: true,
-    });
-  }
-
-  private registerConnectSocketHandlers(
+  private registerTransportHandlers(
     session: ConnectSession,
-    socket: net.Socket,
+    transport: RemoteXpcFramedTransport,
   ): void {
-    const frameParser = new Http2FrameParser();
-    const catalogCollector = new ServiceCatalogCollector();
-
-    socket.once('error', (error: Error) => {
+    transport.once('error', (error: Error) => {
       if (!this._isClosing) {
         log.error(`Connection error: ${error}`);
       }
@@ -226,18 +206,11 @@ class RemoteXpcConnection {
       session.settleFailure(error);
     });
 
-    socket.on('data', (data: Buffer | string) => {
-      const chunk = Buffer.isBuffer(data) ? data : Buffer.from(data, 'hex');
-      this.processIncomingData(
-        session,
-        socket,
-        frameParser,
-        catalogCollector,
-        chunk,
-      );
-    });
+    transport.on('message', (body) =>
+      this.processIncomingMessage(session, body),
+    );
 
-    socket.once('close', () => {
+    transport.once('close', () => {
       this._isConnected = false;
 
       if (!session.isSettled()) {
@@ -246,73 +219,39 @@ class RemoteXpcConnection {
         );
       }
     });
-
-    socket.once('connect', () => {
-      void this.onConnectSocketReady(session, socket);
-    });
   }
 
-  private processIncomingData(
+  private processIncomingMessage(
     session: ConnectSession,
-    socket: net.Socket,
-    frameParser: Http2FrameParser,
-    catalogCollector: ServiceCatalogCollector,
-    chunk: Buffer,
+    body: Parameters<typeof servicesFromXpcBody>[0],
   ): void {
     if (session.isSettled()) {
       return;
     }
 
-    let frames;
-    try {
-      frames = frameParser.append(chunk);
-    } catch (error) {
-      session.settleFailure(error);
-      return;
-    }
-
-    for (const frame of frames) {
-      if (frame.type !== 'data') {
-        continue;
-      }
-
-      const { streamId, data, bodyLen } = frame.frame;
-      for (const windowUpdate of buildWindowUpdateFrames(streamId, bodyLen)) {
-        socket.write(windowUpdate);
-      }
-
-      const servicesResponse = catalogCollector.ingestDataPayload(data);
-      if (servicesResponse) {
-        session.settleSuccess(servicesResponse);
-        return;
-      }
+    const servicesResponse = servicesFromXpcBody(body);
+    if (servicesResponse) {
+      session.settleSuccess(servicesResponse);
     }
   }
 
-  private async onConnectSocketReady(
+  private async connectTransport(
     session: ConnectSession,
-    socket: net.Socket,
+    transport: RemoteXpcFramedTransport,
+    operationTimeoutMs: number,
   ): Promise<void> {
-    this._isConnected = true;
-
     try {
-      await this.performHandshake(socket);
+      await transport.connect({
+        timeoutMs: operationTimeoutMs,
+        handshakeDelayMs: HANDSHAKE_DELAY_MS,
+      });
+      this._isConnected = true;
       this.schedulePostHandshakeServiceTimeout(session);
     } catch (error) {
       log.error(`Handshake failed: ${error}`);
       session.settleFailure(error);
       await this.close();
     }
-  }
-
-  private async performHandshake(socket: net.Socket): Promise<void> {
-    this._handshake = new Handshake(socket);
-
-    await new Promise<void>((resolve) =>
-      setTimeout(resolve, HANDSHAKE_DELAY_MS),
-    );
-
-    await this._handshake.perform();
   }
 
   private schedulePostHandshakeServiceTimeout(session: ConnectSession): void {
@@ -350,75 +289,6 @@ class RemoteXpcConnection {
     this._serviceExtractionTimer = undefined;
   }
 
-  private shutdownSocket(socket: net.Socket): Promise<void> {
-    return new Promise<void>((resolve) => {
-      let finished = false;
-      const finish = (): void => {
-        if (finished) {
-          return;
-        }
-        finished = true;
-        resolve();
-      };
-
-      const closeTimeout = setTimeout(() => {
-        log.warn('Socket close timed out, destroying socket');
-        this.forceCleanup();
-        finish();
-      }, SOCKET_CLOSE_TIMEOUT_MS);
-
-      const onClosed = (): void => {
-        clearTimeout(closeTimeout);
-        this.cleanupResources();
-        finish();
-      };
-
-      socket.once('close', onClosed);
-      socket.on('error', () => {});
-
-      try {
-        this.cleanupSocket();
-        socket.setTimeout(SOCKET_WRITE_TIMEOUT_MS);
-        socket.end(Buffer.alloc(0), () => {
-          setTimeout(() => {
-            if (!finished && this._socket) {
-              clearTimeout(closeTimeout);
-              this.forceCleanup();
-              finish();
-            }
-          }, SOCKET_END_TIMEOUT_MS);
-        });
-      } catch (error) {
-        log.error(
-          `Unexpected error during close: ${error instanceof Error ? error.message : String(error)}`,
-        );
-        clearTimeout(closeTimeout);
-        this.forceCleanup();
-        finish();
-      }
-    });
-  }
-
-  /**
-   * Remove data listeners used by the service-discovery phase.
-   *
-   * We intentionally keep close/error listeners registered by close() so that
-   * transport teardown events (for example ECONNRESET) are handled gracefully.
-   */
-  private cleanupSocket(): void {
-    if (this._socket) {
-      try {
-        // Stop the service-discovery parser from processing additional frames
-        // while shutdown is in progress.
-        this._socket.removeAllListeners('data');
-      } catch (error) {
-        log.error(
-          `Error removing socket data listeners: ${error instanceof Error ? error.message : String(error)}`,
-        );
-      }
-    }
-  }
-
   /**
    * Clean up all resources
    */
@@ -427,10 +297,9 @@ class RemoteXpcConnection {
       clearTimeout(this._serviceExtractionTimer);
       this._serviceExtractionTimer = undefined;
     }
-    this._socket = undefined;
+    this._transport = undefined;
     this._isConnected = false;
     this._isClosing = false;
-    this._handshake = undefined;
     this._services = undefined;
   }
 
@@ -439,9 +308,8 @@ class RemoteXpcConnection {
    */
   private forceCleanup(): void {
     try {
-      if (this._socket) {
-        // Destroy the socket forcefully
-        this._socket.destroy();
+      if (this._transport) {
+        void this._transport.close();
       }
     } catch (error) {
       log.error(
@@ -453,4 +321,4 @@ class RemoteXpcConnection {
   }
 }
 
-export { RemoteXpcConnection, type Service, type ServicesResponse };
+export { RsdServiceCatalogClient, type Service, type ServicesResponse };

--- a/src/lib/remote-xpc/xpc-protocol.ts
+++ b/src/lib/remote-xpc/xpc-protocol.ts
@@ -165,7 +165,7 @@ export function encodeMessage(message: XPCMessage): Buffer {
   encodeDictionary(bodyWriter, body);
   const bodyBuffer = bodyWriter.concat();
 
-  // Write header: flags, BodyLen (payload length + 8 for the body header), msg id.
+  // Write header: flags, payload length + 8 for the body header, msg id.
   writer.writeUInt32LE(message.flags);
   writer.writeBigUInt64LE(BigInt(bodyBuffer.length + 8));
   writer.writeBigUInt64LE(messageId);
@@ -314,6 +314,11 @@ function encodeObject(writer: Writer, value: XPCValue): void {
     }
     return;
   }
+  if (typeof value === 'bigint') {
+    writer.writeUInt32LE(XPC_TYPES.uint64);
+    writer.writeBigUInt64LE(value);
+    return;
+  }
   if (typeof value === 'string') {
     writer.writeUInt32LE(XPC_TYPES.string);
     const strBuf = Buffer.from(value, 'utf8');
@@ -342,13 +347,13 @@ function encodeObject(writer: Writer, value: XPCValue): void {
   }
   if (Array.isArray(value)) {
     const inner = new Writer();
+    inner.writeUInt32LE(value.length);
     for (let i = 0; i < value.length; i++) {
       encodeObject(inner, value[i]);
     }
     const payload = inner.concat();
     writer.writeUInt32LE(XPC_TYPES.array);
     writer.writeUInt32LE(payload.length); // payload length.
-    writer.writeUInt32LE(value.length); // number of objects.
     writer.writeBuffer(payload);
     return;
   }

--- a/src/lib/tunnel/tunnel-rsd-discovery.ts
+++ b/src/lib/tunnel/tunnel-rsd-discovery.ts
@@ -1,5 +1,5 @@
 import { getLogger } from '../logger.js';
-import { RemoteXpcConnection } from '../remote-xpc/remote-xpc-connection.js';
+import { RsdServiceCatalogClient } from '../remote-xpc/rsd-service-catalog-client.js';
 import type { Service } from '../remote-xpc/service-catalog.js';
 import type { TunnelServiceCatalog } from '../types.js';
 
@@ -43,7 +43,7 @@ async function discoverServicesOnce(
   address: string,
   rsdPort: number,
 ): Promise<Service[]> {
-  const remoteXPC = new RemoteXpcConnection([address, rsdPort]);
+  const remoteXPC = new RsdServiceCatalogClient([address, rsdPort]);
   try {
     await remoteXPC.connect();
     return remoteXPC.getServices();

--- a/src/services.ts
+++ b/src/services.ts
@@ -22,6 +22,7 @@ import { NetworkMonitor } from './services/ios/dvt/instruments/network-monitor.j
 import { Notifications } from './services/ios/dvt/instruments/notifications.js';
 import { ProcessControl } from './services/ios/dvt/instruments/process-control.js';
 import { Screenshot } from './services/ios/dvt/instruments/screenshot.js';
+import { HidIndigoService } from './services/ios/hid-indigo/index.js';
 import { HouseArrestService } from './services/ios/house-arrest/index.js';
 import { InstallationProxyService } from './services/ios/installation-proxy/index.js';
 import { MisagentService } from './services/ios/misagent/index.js';
@@ -110,6 +111,16 @@ export async function startPowerAssertionService(
 ): Promise<PowerAssertionService> {
   await requireCatalogService(udid, PowerAssertionService.RSD_SERVICE_NAME);
   return new PowerAssertionService(udid);
+}
+
+/**
+ * Start the CoreDevice HID Indigo service for the given device UDID.
+ */
+export async function startHidIndigoService(
+  udid: string,
+): Promise<HidIndigoService> {
+  await requireCatalogService(udid, HidIndigoService.RSD_SERVICE_NAME);
+  return new HidIndigoService(udid);
 }
 
 const RSD_SYSLOG_BINARY_SERVICE_NAME = 'com.apple.os_trace_relay.shim.remote';

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -5,6 +5,7 @@ import {
 import * as afc from './ios/afc/index.js';
 import * as crashReports from './ios/crash-reports/index.js';
 import * as diagnostics from './ios/diagnostic-service/index.js';
+import * as hidIndigo from './ios/hid-indigo/index.js';
 import * as houseArrest from './ios/house-arrest/index.js';
 import * as installationProxy from './ios/installation-proxy/index.js';
 import * as mobileImageMounter from './ios/mobile-image-mounter/index.js';
@@ -16,6 +17,7 @@ import * as webinspector from './ios/webinspector/index.js';
 export {
   crashReports,
   diagnostics,
+  hidIndigo,
   houseArrest,
   installationProxy,
   mobileImageMounter,

--- a/src/services/ios/diagnostic-service/index.ts
+++ b/src/services/ios/diagnostic-service/index.ts
@@ -210,7 +210,7 @@ class DiagnosticsService
   /**
    * Sends an IORegistry request and returns the diagnostics response.
    * The shim's StartService greeting is drained in connectToDiagnosticService,
-   * so this is a plain single send/recv — matches pymobiledevice3.
+   * so this is a plain single send/recv.
    */
   private async queryIORegistry(
     conn: ServiceConnection,

--- a/src/services/ios/dvt/instruments/screenshot.ts
+++ b/src/services/ios/dvt/instruments/screenshot.ts
@@ -1,4 +1,7 @@
+import { getLogger } from '../../../../lib/logger.js';
 import { BaseInstrument } from './base-instrument.js';
+
+const log = getLogger('Screenshot');
 
 /**
  * Screenshot service for capturing device screenshots
@@ -28,6 +31,7 @@ export class Screenshot extends BaseInstrument {
       );
     }
 
+    log.info(`Screenshot captured successfully (${result.length} bytes)`);
     return result;
   }
 }

--- a/src/services/ios/dvt/instruments/screenshot.ts
+++ b/src/services/ios/dvt/instruments/screenshot.ts
@@ -1,7 +1,4 @@
-import { getLogger } from '../../../../lib/logger.js';
 import { BaseInstrument } from './base-instrument.js';
-
-const log = getLogger('Screenshot');
 
 /**
  * Screenshot service for capturing device screenshots
@@ -31,7 +28,6 @@ export class Screenshot extends BaseInstrument {
       );
     }
 
-    log.info(`Screenshot captured successfully (${result.length} bytes)`);
     return result;
   }
 }

--- a/src/services/ios/hid-indigo/index.ts
+++ b/src/services/ios/hid-indigo/index.ts
@@ -1,0 +1,184 @@
+import {
+  Http2Constants,
+  XpcConstants,
+} from '../../../lib/remote-xpc/constants.js';
+import { RemoteXpcFramedTransport } from '../../../lib/remote-xpc/remote-xpc-framed-transport.js';
+import { encodeMessage } from '../../../lib/remote-xpc/xpc-protocol.js';
+import type { XPCDictionary } from '../../../lib/types.js';
+import { BaseService } from '../base-service.js';
+
+const CONNECT_TIMEOUT_MS = 10_000;
+const CLOSE_DELIVERY_DELAY_MS = 100;
+
+export const HID_BUTTON_STATE_DOWN = 1;
+export const HID_BUTTON_STATE_UP = 2;
+export const HID_BUTTON_STATE_CANCELED = 3;
+
+export type HidButtonState = 'down' | 'up' | 'canceled';
+
+export interface HidButtonEventOptions {
+  usagePage: number;
+  usageCode: number;
+  state: HidButtonState;
+}
+
+export interface HidButtonPressOptions {
+  holdSeconds?: number;
+  pressCount?: number;
+}
+
+const BUTTON_STATES: Record<HidButtonState, number> = {
+  down: HID_BUTTON_STATE_DOWN,
+  up: HID_BUTTON_STATE_UP,
+  canceled: HID_BUTTON_STATE_CANCELED,
+};
+
+const NAMED_BUTTONS = {
+  home: { usagePage: 0x0c, usageCode: 0x40, holdSeconds: 0.05 },
+  lock: { usagePage: 0x0c, usageCode: 0x30, holdSeconds: 0.5 },
+  'volume-up': { usagePage: 0x0c, usageCode: 0xe9, holdSeconds: 0.05 },
+  'volume-down': { usagePage: 0x0c, usageCode: 0xea, holdSeconds: 0.05 },
+  mute: { usagePage: 0x0c, usageCode: 0xe2, holdSeconds: 0.05 },
+  siri: { usagePage: 0x0c, usageCode: 0xcf, holdSeconds: 1 },
+} as const;
+
+export type HidButtonName = keyof typeof NAMED_BUTTONS;
+
+/**
+ * CoreDevice HID Indigo service for dispatching hardware button events.
+ */
+export class HidIndigoService extends BaseService {
+  static readonly RSD_SERVICE_NAME = 'com.apple.coredevice.hid.indigo';
+
+  private transport: RemoteXpcFramedTransport | null = null;
+  private nextMessageId = 1;
+
+  async pressButton(
+    name: HidButtonName,
+    options?: HidButtonPressOptions,
+  ): Promise<void>;
+  async pressButton(
+    usagePage: number,
+    usageCode: number,
+    options?: HidButtonPressOptions,
+  ): Promise<void>;
+  async pressButton(
+    arg1: HidButtonName | number,
+    arg2?: HidButtonPressOptions | number,
+    arg3?: HidButtonPressOptions,
+  ): Promise<void> {
+    const { usagePage, usageCode, options } = resolveButtonArgs(
+      arg1,
+      arg2,
+      arg3,
+    );
+    const pressCount = validatePressCount(options.pressCount ?? 1);
+    const defaultHoldSeconds =
+      typeof arg1 === 'string'
+        ? NAMED_BUTTONS[arg1 as HidButtonName].holdSeconds
+        : 0.05;
+    const holdMs = (options.holdSeconds ?? defaultHoldSeconds) * 1000;
+
+    for (let i = 0; i < pressCount; i++) {
+      await this.sendButton({ usagePage, usageCode, state: 'down' });
+      await delay(holdMs);
+      await this.sendButton({ usagePage, usageCode, state: 'up' });
+      await delay(CLOSE_DELIVERY_DELAY_MS);
+    }
+  }
+
+  async sendButton(options: HidButtonEventOptions): Promise<void> {
+    const transport = await this.getTransport();
+    transport.sendDataFrame(
+      encodeMessage({
+        flags:
+          XpcConstants.XPC_FLAGS_ALWAYS_SET |
+          XpcConstants.XPC_FLAGS_DATA_PRESENT,
+        id: this.nextMessageId++,
+        body: buildButtonEvent(options),
+      }),
+      Http2Constants.ROOT_CHANNEL,
+    );
+  }
+
+  async close(): Promise<void> {
+    if (!this.transport) {
+      return;
+    }
+
+    await this.transport.close();
+    this.transport = null;
+  }
+
+  protected async createTransport(): Promise<RemoteXpcFramedTransport> {
+    const transport = new RemoteXpcFramedTransport(
+      await this.resolveServiceAddress(HidIndigoService.RSD_SERVICE_NAME),
+    );
+    await transport.connect({ timeoutMs: CONNECT_TIMEOUT_MS });
+    return transport;
+  }
+
+  private async getTransport(): Promise<RemoteXpcFramedTransport> {
+    if (!this.transport?.isConnected) {
+      this.transport = await this.createTransport();
+    }
+    return this.transport;
+  }
+}
+
+function buildButtonEvent(options: HidButtonEventOptions): XPCDictionary {
+  return {
+    messageType: 'IndigoButtonEvent',
+    payload: {
+      state: BigInt(BUTTON_STATES[options.state]),
+      usagePage: BigInt(options.usagePage),
+      usageCode: BigInt(options.usageCode),
+    },
+    featureIdentifier: 'com.apple.coredevice.feature.remote.hid.button',
+  };
+}
+
+function resolveButtonArgs(
+  arg1: HidButtonName | number,
+  arg2?: HidButtonPressOptions | number,
+  arg3?: HidButtonPressOptions,
+): {
+  usagePage: number;
+  usageCode: number;
+  options: HidButtonPressOptions;
+} {
+  if (
+    typeof arg1 === 'string' &&
+    (arg2 === undefined || typeof arg2 !== 'number')
+  ) {
+    const button = NAMED_BUTTONS[arg1 as HidButtonName];
+    return {
+      usagePage: button.usagePage,
+      usageCode: button.usageCode,
+      options: (arg2 as HidButtonPressOptions | undefined) ?? {},
+    };
+  }
+
+  if (typeof arg1 === 'number' && typeof arg2 === 'number') {
+    return {
+      usagePage: arg1,
+      usageCode: arg2,
+      options: arg3 ?? {},
+    };
+  }
+
+  throw new Error(
+    'pressButton expects either a button name plus options, or usagePage and usageCode plus options',
+  );
+}
+
+function validatePressCount(value: number): number {
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error('pressCount must be a positive integer');
+  }
+  return value;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/test/integration/hid-indigo-test.ts
+++ b/test/integration/hid-indigo-test.ts
@@ -1,0 +1,42 @@
+import { expect } from 'chai';
+
+import type { HidIndigoService } from '../../src/index.js';
+import * as Services from '../../src/services.js';
+
+describe('HidIndigoService', function () {
+  this.timeout(60000);
+
+  let hidIndigoService: HidIndigoService | null = null;
+  const udid = process.env.UDID || '';
+
+  before(async function () {
+    if (!udid) {
+      throw new Error('set UDID env var to execute tests.');
+    }
+
+    hidIndigoService = await Services.startHidIndigoService(udid);
+  });
+
+  after(async function () {
+    try {
+      await hidIndigoService?.close();
+    } catch {
+      // Ignore cleanup errors in tests
+    }
+  });
+
+  it('should start the service and dispatch a home button press', async function () {
+    expect(hidIndigoService).to.not.be.null;
+
+    await hidIndigoService!.pressButton('home', { holdSeconds: 2 });
+  });
+
+  it('should dispatch a double home button press sequence', async function () {
+    expect(hidIndigoService).to.not.be.null;
+
+    await hidIndigoService!.pressButton('home', {
+      holdSeconds: 0.05,
+      pressCount: 2,
+    });
+  });
+});

--- a/test/unit/hid-indigo/hid-indigo-service.spec.ts
+++ b/test/unit/hid-indigo/hid-indigo-service.spec.ts
@@ -1,0 +1,82 @@
+import { expect } from 'chai';
+
+import { decodeMessage } from '../../../src/lib/remote-xpc/xpc-protocol.js';
+import {
+  HID_BUTTON_STATE_DOWN,
+  HID_BUTTON_STATE_UP,
+  HidIndigoService,
+} from '../../../src/services/ios/hid-indigo/index.js';
+
+class TestHidIndigoService extends HidIndigoService {
+  readonly sentPayloads: Buffer[] = [];
+  closeCalls = 0;
+
+  protected async createTransport(): Promise<any> {
+    return {
+      isConnected: true,
+      sendDataFrame: (payload: Buffer): void => {
+        this.sentPayloads.push(payload);
+      },
+      close: async (): Promise<void> => {
+        this.closeCalls++;
+      },
+    };
+  }
+}
+
+describe('HidIndigoService', function () {
+  it('sends home button down and up events', async function () {
+    const service = new TestHidIndigoService('test-udid');
+
+    await service.pressButton('home', { holdSeconds: 0 });
+
+    expect(service.sentPayloads).to.have.length(2);
+    expect(decodeBody(service.sentPayloads[0])).to.deep.equal({
+      featureIdentifier: 'com.apple.coredevice.feature.remote.hid.button',
+      messageType: 'IndigoButtonEvent',
+      payload: {
+        state: HID_BUTTON_STATE_DOWN,
+        usageCode: 0x40,
+        usagePage: 0x0c,
+      },
+    });
+    expect(decodeBody(service.sentPayloads[1])).to.deep.equal({
+      featureIdentifier: 'com.apple.coredevice.feature.remote.hid.button',
+      messageType: 'IndigoButtonEvent',
+      payload: {
+        state: HID_BUTTON_STATE_UP,
+        usageCode: 0x40,
+        usagePage: 0x0c,
+      },
+    });
+  });
+
+  it('sends multiple press sequences when pressCount is set', async function () {
+    const service = new TestHidIndigoService('test-udid');
+
+    await service.pressButton('home', {
+      holdSeconds: 0,
+      pressCount: 2,
+    });
+
+    expect(service.sentPayloads).to.have.length(4);
+  });
+
+  it('closes the active transport', async function () {
+    const service = new TestHidIndigoService('test-udid');
+
+    await service.sendButton({
+      usagePage: 0x0c,
+      usageCode: 0xe9,
+      state: 'down',
+    });
+    await service.close();
+
+    expect(service.closeCalls).to.equal(1);
+  });
+});
+
+function decodeBody(payload: Buffer): Record<string, unknown> {
+  const { message } = decodeMessage(payload);
+  return message.body as Record<string, unknown>;
+}

--- a/test/unit/services/start-services-cleanup.spec.ts
+++ b/test/unit/services/start-services-cleanup.spec.ts
@@ -148,6 +148,7 @@ describe('start*Service — registry catalog resolution', function () {
         'startNotificationProxyService',
         'com.apple.mobile.notification_proxy.shim.remote',
       ],
+      ['startHidIndigoService', 'com.apple.coredevice.hid.indigo'],
     ] as const) {
       it(`${fn} resolves ${serviceName} from the catalog`, async function () {
         const { services, resolveTunnelService } =

--- a/test/unit/tunnel/tunnel-rsd-discovery.spec.ts
+++ b/test/unit/tunnel/tunnel-rsd-discovery.spec.ts
@@ -13,8 +13,8 @@ describe('tunnel-rsd-discovery', function () {
     const { discoverServices, servicesToCatalog } = await esmock(
       '../../../src/lib/tunnel/tunnel-rsd-discovery.js',
       {
-        '../../../src/lib/remote-xpc/remote-xpc-connection.js': {
-          RemoteXpcConnection: class {
+        '../../../src/lib/remote-xpc/rsd-service-catalog-client.js': {
+          RsdServiceCatalogClient: class {
             connect = connect;
             getServices = getServices;
             close = closeSpy;
@@ -39,8 +39,8 @@ describe('tunnel-rsd-discovery', function () {
     const { discoverServices } = await esmock(
       '../../../src/lib/tunnel/tunnel-rsd-discovery.js',
       {
-        '../../../src/lib/remote-xpc/remote-xpc-connection.js': {
-          RemoteXpcConnection: class {
+        '../../../src/lib/remote-xpc/rsd-service-catalog-client.js': {
+          RsdServiceCatalogClient: class {
             async connect() {
               connectCount += 1;
               await new Promise((resolve) => setTimeout(resolve, 30));


### PR DESCRIPTION
## Summary

- Add the support of `com.apple.coredevice.hid.indigo` CoreDevice service to help with HID events emulation
- Refactor RemoteXPC service discovery to use a shared framed transport for socket lifecycle, HTTP/2 frame parsing, XPC message reassembly, and window updates.
- Rename RemoteXpcConnection to RsdServiceCatalogClient to better reflect its purpose, while keeping RemoteXpcConnection as a deprecated public type alias.
- Align RemoteXPC handshake ordering and XPC array/wrapper encoding with current pymobiledevice3 / devicectl behavior.


## Notes

- Public root export compatibility is preserved for RemoteXpcConnection; RsdServiceCatalogClient is additive.
- The main behavior risk is in shared RemoteXPC/RSD connectivity, so tunnel discovery coverage is the most relevant validation.