### PR TITLE
refactor(xpc): centralize `asDictionary` helper

### DIFF
--- a/src/lib/remote-xpc/xpc-value.ts
+++ b/src/lib/remote-xpc/xpc-value.ts
@@ -1,0 +1,9 @@
+import type {XPCDictionary, XPCValue} from '../types.js';
+
+/**
+ * Coerces an XPC value to a dictionary, or `undefined` when it is not a plain
+ * object (an array, primitive, `null`, or `undefined`).
+ */
+export function asDictionary(value: XPCValue | undefined): XPCDictionary | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as XPCDictionary) : undefined;
+}

--- a/src/lib/remote-xpc/xpc-value.ts
+++ b/src/lib/remote-xpc/xpc-value.ts
@@ -1,9 +1,12 @@
+import {util} from '@appium/support';
+
 import type {XPCDictionary, XPCValue} from '../types.js';
 
 /**
  * Coerces an XPC value to a dictionary, or `undefined` when it is not a plain
- * object (an array, primitive, `null`, or `undefined`).
+ * object (an array, primitive, `Buffer`, `Uint8Array`, `Date`, `null`, or
+ * `undefined`).
  */
 export function asDictionary(value: XPCValue | undefined): XPCDictionary | undefined {
-  return value && typeof value === 'object' && !Array.isArray(value) ? (value as XPCDictionary) : undefined;
+  return util.isPlainObject(value) ? (value as XPCDictionary) : undefined;
 }

--- a/src/services/ios/app-service/index.ts
+++ b/src/services/ios/app-service/index.ts
@@ -1,4 +1,5 @@
 import {createPlist} from '../../../lib/plist/index.js';
+import {asDictionary} from '../../../lib/remote-xpc/xpc-value.js';
 import type {PlistDictionary, XPCDictionary, XPCValue} from '../../../lib/types.js';
 import {type CoreDeviceInvokeOptions, CoreDeviceService} from '../core-device/core-device-service.js';
 
@@ -158,27 +159,28 @@ export class AppService extends CoreDeviceService {
       ? platformOptions
       : Buffer.from(platformOptions, 'utf8');
 
-    const output = asDict(
-      await this.invoke(
-        FEATURE_LAUNCH_APPLICATION,
-        {
-          applicationSpecifier: {
-            bundleIdentifier: {_0: bundleId},
+    const output =
+      asDictionary(
+        await this.invoke(
+          FEATURE_LAUNCH_APPLICATION,
+          {
+            applicationSpecifier: {
+              bundleIdentifier: {_0: bundleId},
+            },
+            options: {
+              arguments: options.arguments ?? [],
+              environmentVariables: options.environment ?? {},
+              standardIOUsesPseudoterminals: true,
+              startStopped: options.startSuspended ?? false,
+              terminateExisting: options.terminateExisting ?? true,
+              user: {shortName: 'mobile'},
+              platformSpecificOptions: platformOptionsBuffer,
+            },
+            standardIOIdentifiers: {},
           },
-          options: {
-            arguments: options.arguments ?? [],
-            environmentVariables: options.environment ?? {},
-            standardIOUsesPseudoterminals: true,
-            startStopped: options.startSuspended ?? false,
-            terminateExisting: options.terminateExisting ?? true,
-            user: {shortName: 'mobile'},
-            platformSpecificOptions: platformOptionsBuffer,
-          },
-          standardIOIdentifiers: {},
-        },
-        {timeoutMs: options.timeoutMs},
-      ),
-    );
+          {timeoutMs: options.timeoutMs},
+        ),
+      ) ?? {};
 
     return {
       ...output,
@@ -190,7 +192,7 @@ export class AppService extends CoreDeviceService {
    * Lists the processes currently running on the device.
    */
   async listProcesses(): Promise<AppServiceProcessToken[]> {
-    const output = asDict(await this.invoke(FEATURE_LIST_PROCESSES));
+    const output = asDictionary(await this.invoke(FEATURE_LIST_PROCESSES)) ?? {};
     return asArray(output.processTokens) as AppServiceProcessToken[];
   }
 
@@ -202,11 +204,13 @@ export class AppService extends CoreDeviceService {
    * reports `com.apple.dt.CoreDeviceError`).
    */
   async sendSignalToProcess(pid: number, signal: number): Promise<XPCDictionary> {
-    return asDict(
-      await this.invoke(FEATURE_SEND_SIGNAL, {
-        process: {processIdentifier: pid},
-        signal,
-      }),
+    return (
+      asDictionary(
+        await this.invoke(FEATURE_SEND_SIGNAL, {
+          process: {processIdentifier: pid},
+          signal,
+        }),
+      ) ?? {}
     );
   }
 
@@ -225,17 +229,12 @@ export class AppService extends CoreDeviceService {
    * `options` to bound how long to wait for a still-running process to exit.
    */
   async monitorProcessTermination(pid: number, options: CoreDeviceInvokeOptions = {}): Promise<XPCDictionary> {
-    return asDict(
-      await this.invoke(FEATURE_MONITOR_PROCESS_TERMINATION, {processToken: {processIdentifier: pid}}, options),
+    return (
+      asDictionary(
+        await this.invoke(FEATURE_MONITOR_PROCESS_TERMINATION, {processToken: {processIdentifier: pid}}, options),
+      ) ?? {}
     );
   }
-}
-
-function asDict(value: XPCValue): XPCDictionary {
-  if (value && typeof value === 'object' && !Array.isArray(value)) {
-    return value as XPCDictionary;
-  }
-  return {};
 }
 
 function asArray(value: XPCValue): XPCValue[] {

--- a/src/services/ios/device-info/index.ts
+++ b/src/services/ios/device-info/index.ts
@@ -1,4 +1,5 @@
-import type {XPCDictionary, XPCValue} from '../../../lib/types.js';
+import {asDictionary} from '../../../lib/remote-xpc/xpc-value.js';
+import type {XPCDictionary} from '../../../lib/types.js';
 import {type CoreDeviceInvokeOptions, CoreDeviceService} from '../core-device/core-device-service.js';
 
 const FEATURE_GET_DEVICE_INFO = 'com.apple.coredevice.feature.getdeviceinfo';
@@ -52,7 +53,7 @@ export class CoreDeviceInfoService extends CoreDeviceService {
    * device class, …).
    */
   async getDeviceInfo(options: CoreDeviceInvokeOptions = {}): Promise<CoreDeviceAttributes> {
-    return asDict(await this.invoke(FEATURE_GET_DEVICE_INFO, {}, options));
+    return asDictionary(await this.invoke(FEATURE_GET_DEVICE_INFO, {}, options)) ?? {};
   }
 
   /**
@@ -60,7 +61,7 @@ export class CoreDeviceInfoService extends CoreDeviceService {
    * mapping and screenshot geometry.
    */
   async getDisplayInfo(options: CoreDeviceInvokeOptions = {}): Promise<CoreDeviceDisplayInfo> {
-    return asDict(await this.invoke(FEATURE_GET_DISPLAY_INFO, {}, options));
+    return asDictionary(await this.invoke(FEATURE_GET_DISPLAY_INFO, {}, options)) ?? {};
   }
 
   /**
@@ -72,7 +73,7 @@ export class CoreDeviceInfoService extends CoreDeviceService {
    * {@link CoreDeviceError}.
    */
   async getLockState(options: CoreDeviceInvokeOptions = {}): Promise<CoreDeviceLockState> {
-    return asDict(await this.invoke(FEATURE_GET_LOCK_STATE, {}, options));
+    return asDictionary(await this.invoke(FEATURE_GET_LOCK_STATE, {}, options)) ?? {};
   }
 
   /**
@@ -84,15 +85,8 @@ export class CoreDeviceInfoService extends CoreDeviceService {
    * values. Pass `timeoutMs` via `options` to bound the wait.
    */
   async queryMobileGestalt(keys: string[], options: CoreDeviceInvokeOptions = {}): Promise<XPCDictionary> {
-    return asDict(await this.invoke(FEATURE_QUERY_MOBILEGESTALT, {keys}, options));
+    return asDictionary(await this.invoke(FEATURE_QUERY_MOBILEGESTALT, {keys}, options)) ?? {};
   }
-}
-
-function asDict(value: XPCValue): XPCDictionary {
-  if (value && typeof value === 'object' && !Array.isArray(value)) {
-    return value as XPCDictionary;
-  }
-  return {};
 }
 
 export default CoreDeviceInfoService;

--- a/src/services/ios/pasteboard/index.ts
+++ b/src/services/ios/pasteboard/index.ts
@@ -1,3 +1,4 @@
+import {asDictionary} from '../../../lib/remote-xpc/xpc-value.js';
 import type {XPCDictionary, XPCValue} from '../../../lib/types.js';
 import {CoreDeviceService} from '../core-device/core-device-service.js';
 import {
@@ -176,13 +177,6 @@ export class PasteboardService extends CoreDeviceService {
 function pickSnapshot(snapshotOrReply: XPCDictionary | PasteboardSnapshot | PasteboardPullReply): PasteboardSnapshot {
   const pasteboard = asDictionary(snapshotOrReply.pasteboard);
   return (pasteboard ?? snapshotOrReply) as PasteboardSnapshot;
-}
-
-function asDictionary(value: XPCValue | undefined): XPCDictionary | undefined {
-  if (value && typeof value === 'object' && !Array.isArray(value)) {
-    return value as XPCDictionary;
-  }
-  return undefined;
 }
 
 function decodeUtf8(value: XPCValue): string | undefined {


### PR DESCRIPTION
as discussed in - https://github.com/appium/appium-ios-remotexpc/pull/267#discussion_r3520226534