### PR TITLE
feat(coredevice): add device control service to control orientation

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test:all": "node --test --test-timeout=60000 \"build/test/unit/**/*.spec.js\" \"build/test/integration/**/*.spec.js\"",
     "test:app-service": "node --test --test-timeout=60000 \"build/test/integration/app-service.spec.js\"",
     "test:coredevice-device-info": "node --test --test-timeout=60000 \"build/test/integration/device-info-coredevice.spec.js\"",
+    "test:device-control": "node --test --test-timeout=60000 \"build/test/integration/device-control.spec.js\"",
     "test:crash-reports": "node --test --test-timeout=60000 \"build/test/integration/crash-reports.spec.js\"",
     "test:diagnostics": " node --test --test-timeout=60000 \"build/test/integration/diagnostics.spec.js\"",
     "test:dvt-service": "node --test --test-timeout=60000 \"build/test/integration/dvt-service.spec.js\"",

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,8 @@ export type {
   CoreDeviceDisplayInfo,
   CoreDeviceLockState,
 } from './services/ios/device-info/index.js';
+export {DeviceControlService} from './services/ios/device-control/index.js';
+export type {DeviceOrientationState, RotateDirection} from './services/ios/device-control/index.js';
 export type {SyslogEntry, SyslogLabel, SyslogLogLevel} from './services/ios/syslog-service/syslog-entry-parser.js';
 
 export type {

--- a/src/services.ts
+++ b/src/services.ts
@@ -8,6 +8,7 @@ import AfcService from './services/ios/afc/index.js';
 import {AppService} from './services/ios/app-service/index.js';
 import {type Service} from './services/ios/base-service.js';
 import {CrashReportsService} from './services/ios/crash-reports/index.js';
+import {DeviceControlService} from './services/ios/device-control/index.js';
 import {CoreDeviceInfoService} from './services/ios/device-info/index.js';
 import DiagnosticsService from './services/ios/diagnostic-service/index.js';
 import {DVTSecureSocketProxyService} from './services/ios/dvt/index.js';
@@ -133,6 +134,14 @@ export async function startPasteboardService(udid: string): Promise<PasteboardSe
 export async function startCoreDeviceInfoService(udid: string): Promise<CoreDeviceInfoService> {
   await requireCatalogService(udid, CoreDeviceInfoService.RSD_SERVICE_NAME);
   return new CoreDeviceInfoService(udid);
+}
+
+/**
+ * Start the CoreDevice device-control service for the given device UDID.
+ */
+export async function startDeviceControlService(udid: string): Promise<DeviceControlService> {
+  await requireCatalogService(udid, DeviceControlService.RSD_SERVICE_NAME);
+  return new DeviceControlService(udid);
 }
 
 const RSD_SYSLOG_BINARY_SERVICE_NAME = 'com.apple.os_trace_relay.shim.remote';

--- a/src/services/ios/device-control/index.ts
+++ b/src/services/ios/device-control/index.ts
@@ -15,7 +15,13 @@ export interface DeviceOrientationState {
   currentDeviceOrientation?: string;
   /** The most recent non-flat orientation (ignores face-up/face-down). */
   currentDeviceNonFlatOrientation?: string;
-  /** Whether iOS orientation lock is engaged; when `true`, rotation may be prevented. */
+  /**
+   * Device-reported orientation-lock flag. Do **not** rely on this to detect
+   * Control Center Rotation Lock: on iOS 26.5 it was observed to stay `false`
+   * even while that lock was active and preventing rotation. To tell whether a
+   * rotation was actually applied, compare {@link currentDeviceOrientation}
+   * before and after {@link DeviceControlService.rotate}.
+   */
   currentDeviceOrientationLocked?: boolean;
   [key: string]: unknown;
 }
@@ -51,7 +57,14 @@ export class DeviceControlService extends CoreDeviceService {
    *
    * Four consecutive same-direction calls cycle a full turn
    * (`portrait → landscapeLeft → portraitUpsideDown → landscapeRight → portrait`
-   * for `'left'`). Only works when iOS orientation lock is not set.
+   * for `'left'`).
+   *
+   * Rotation only applies when Control Center Rotation Lock is off. When the
+   * lock is on the call still resolves normally (it does **not** throw), but the
+   * returned {@link DeviceOrientationState.currentDeviceOrientation} is
+   * unchanged — the only reliable signal that rotation was blocked. There is no
+   * read-only request to query orientation in advance; the device rejects any
+   * non-rotate message by resetting the connection.
    */
   async rotate(direction: RotateDirection): Promise<DeviceOrientationState> {
     if (direction !== 'left' && direction !== 'right') {

--- a/src/services/ios/device-control/index.ts
+++ b/src/services/ios/device-control/index.ts
@@ -1,0 +1,69 @@
+import type {XPCDictionary} from '../../../lib/types.js';
+import {CoreDeviceService} from '../core-device/core-device-service.js';
+
+const ORIENTATION_FEATURE = 'com.apple.coredevice.feature.remote.devicecontrol.orientation';
+
+/** Rotation direction: `'left'` = counter-clockwise, `'right'` = clockwise. */
+export type RotateDirection = 'left' | 'right';
+
+/** Orientation state returned by {@link DeviceControlService.rotate}. */
+export interface DeviceOrientationState {
+  /**
+   * The resulting device orientation, e.g. `'portrait'`, `'landscapeLeft'`,
+   * `'portraitUpsideDown'`, `'landscapeRight'`.
+   */
+  currentDeviceOrientation?: string;
+  /** The most recent non-flat orientation (ignores face-up/face-down). */
+  currentDeviceNonFlatOrientation?: string;
+  /** Whether iOS orientation lock is engaged (rotation still applies). */
+  currentDeviceOrientationLocked?: boolean;
+  [key: string]: unknown;
+}
+
+/**
+ * CoreDevice device-control service (`com.apple.coredevice.devicecontrol`).
+ *
+ * Rotates the device 90° at a time. Unlike most CoreDevice services this uses a
+ * raw message (no invocation envelope) whose `messageType` drives dispatch, sent
+ * via the base {@link CoreDeviceService.sendReceive}.
+ *
+ * @example
+ * ```ts
+ * const deviceControl = await Services.startDeviceControlService(udid);
+ * try {
+ *   const state = await deviceControl.rotate('left'); // 90° counter-clockwise
+ *   console.log(state.currentDeviceOrientation);
+ * } finally {
+ *   await deviceControl.close();
+ * }
+ * ```
+ */
+export class DeviceControlService extends CoreDeviceService {
+  static readonly RSD_SERVICE_NAME = 'com.apple.coredevice.devicecontrol';
+
+  constructor(udid: string) {
+    super(udid, DeviceControlService.RSD_SERVICE_NAME);
+  }
+
+  /**
+   * Rotates the device 90° in `direction` (`'left'` = counter-clockwise,
+   * `'right'` = clockwise) and returns the resulting orientation state.
+   *
+   * Four consecutive same-direction calls cycle a full turn
+   * (`portrait → landscapeLeft → portraitUpsideDown → landscapeRight → portrait`
+   * for `'left'`). Only works when iOS orientation lock is not set.
+   */
+  async rotate(direction: RotateDirection): Promise<DeviceOrientationState> {
+    if (direction !== 'left' && direction !== 'right') {
+      throw new TypeError(`direction must be 'left' or 'right', got '${String(direction)}'`);
+    }
+    const reply = await this.sendReceive({
+      featureIdentifier: ORIENTATION_FEATURE,
+      messageType: 'OrientationRequest',
+      payload: {rotate: {_0: direction}},
+    } as XPCDictionary);
+    return reply as DeviceOrientationState;
+  }
+}
+
+export default DeviceControlService;

--- a/src/services/ios/device-control/index.ts
+++ b/src/services/ios/device-control/index.ts
@@ -15,7 +15,7 @@ export interface DeviceOrientationState {
   currentDeviceOrientation?: string;
   /** The most recent non-flat orientation (ignores face-up/face-down). */
   currentDeviceNonFlatOrientation?: string;
-  /** Whether iOS orientation lock is engaged (rotation still applies). */
+  /** Whether iOS orientation lock is engaged; when `true`, rotation may be prevented. */
   currentDeviceOrientationLocked?: boolean;
   [key: string]: unknown;
 }

--- a/test/integration/device-control.spec.ts
+++ b/test/integration/device-control.spec.ts
@@ -1,0 +1,55 @@
+import {after, before, describe, it} from 'node:test';
+
+import {expect} from 'chai';
+
+import {type DeviceControlService} from '../../src/index.js';
+import * as Services from '../../src/services.js';
+import {requireDeviceUdid} from './helpers/device.js';
+
+/**
+ * Integration tests for the CoreDevice device-control service
+ * (`com.apple.coredevice.devicecontrol`).
+ *
+ * Requires a physical iOS device with a running tunnel registry. These tests
+ * physically rotate the device, then rotate back to restore the original
+ * orientation (a 'left' step is undone by a 'right' step).
+ */
+describe('DeviceControlService', {timeout: 60000}, function () {
+  let deviceControl: DeviceControlService | null = null;
+  let udid: string;
+
+  before(async function () {
+    udid = requireDeviceUdid();
+    deviceControl = await Services.startDeviceControlService(udid);
+  });
+
+  after(async function () {
+    try {
+      await deviceControl?.close();
+    } catch {
+      // Ignore cleanup errors in tests
+    }
+  });
+
+  it('rotates the device and returns the resulting orientation', async function () {
+    const state = await deviceControl!.rotate('left');
+    expect(state).to.be.an('object');
+    expect(state.currentDeviceOrientation).to.be.a('string');
+
+    // Restore: 'right' undoes the 'left' step.
+    await deviceControl!.rotate('right');
+  });
+
+  it('consecutive left rotations change the orientation', async function () {
+    const first = await deviceControl!.rotate('left');
+    const second = await deviceControl!.rotate('left');
+
+    expect(first.currentDeviceOrientation).to.be.a('string');
+    expect(second.currentDeviceOrientation).to.be.a('string');
+    expect(second.currentDeviceOrientation).to.not.equal(first.currentDeviceOrientation);
+
+    // Restore: undo the two 'left' steps.
+    await deviceControl!.rotate('right');
+    await deviceControl!.rotate('right');
+  });
+});

--- a/test/unit/device-control/device-control-service.spec.ts
+++ b/test/unit/device-control/device-control-service.spec.ts
@@ -105,8 +105,11 @@ describe('DeviceControlService', function () {
     }));
     const service = new TestDeviceControlService(fake);
 
-    await service.rotate('left');
-    await service.close();
+    try {
+      await service.rotate('left');
+    } finally {
+      await service.close();
+    }
 
     expect(fake.closeCalls).to.equal(1);
   });

--- a/test/unit/device-control/device-control-service.spec.ts
+++ b/test/unit/device-control/device-control-service.spec.ts
@@ -1,0 +1,113 @@
+import {EventEmitter} from 'node:events';
+import {describe, it} from 'node:test';
+
+import {expect} from 'chai';
+
+import {decodeMessage} from '../../../src/lib/remote-xpc/xpc-protocol.js';
+import type {XPCDictionary} from '../../../src/lib/types.js';
+import {DeviceControlService} from '../../../src/services/ios/device-control/index.js';
+
+type Responder = (sentBody: XPCDictionary) => XPCDictionary | null;
+
+const ORIENTATION_FEATURE = 'com.apple.coredevice.feature.remote.devicecontrol.orientation';
+
+/**
+ * Fake framed transport: captures every sent XPC body and, for each request,
+ * emits a canned reply on the next microtask (mirroring a device response).
+ */
+class FakeTransport extends EventEmitter {
+  isConnected = true;
+  closeCalls = 0;
+  readonly sentBodies: XPCDictionary[] = [];
+
+  constructor(private responder: Responder) {
+    super();
+  }
+
+  sendDataFrame(payload: Buffer): void {
+    const {message} = decodeMessage(payload);
+    const body = message.body as XPCDictionary;
+    this.sentBodies.push(body);
+    const reply = this.responder(body);
+    if (reply) {
+      queueMicrotask(() => this.emit('message', reply));
+    }
+  }
+
+  async close(): Promise<void> {
+    this.closeCalls++;
+  }
+}
+
+class TestDeviceControlService extends DeviceControlService {
+  constructor(readonly fake: FakeTransport) {
+    super('test-udid');
+  }
+
+  protected async createTransport(): Promise<any> {
+    return this.fake;
+  }
+}
+
+describe('DeviceControlService', function () {
+  it('rotate("left") sends a raw OrientationRequest and returns the reply', async function () {
+    const orientation = {
+      currentDeviceOrientation: 'landscapeLeft',
+      currentDeviceNonFlatOrientation: 'landscapeLeft',
+      currentDeviceOrientationLocked: false,
+    };
+    const fake = new FakeTransport(() => orientation);
+    const service = new TestDeviceControlService(fake);
+
+    const result = await service.rotate('left');
+
+    expect(fake.sentBodies[0]).to.deep.equal({
+      featureIdentifier: ORIENTATION_FEATURE,
+      messageType: 'OrientationRequest',
+      payload: {rotate: {_0: 'left'}},
+    });
+    // Raw message — not wrapped in the CoreDevice invocation envelope.
+    expect(fake.sentBodies[0]).to.not.have.property('CoreDevice.featureIdentifier');
+    expect(result).to.deep.equal(orientation);
+  });
+
+  it('rotate("right") sends the clockwise direction', async function () {
+    const fake = new FakeTransport(() => ({
+      currentDeviceOrientation: 'landscapeRight',
+    }));
+    const service = new TestDeviceControlService(fake);
+
+    await service.rotate('right');
+
+    expect((fake.sentBodies[0].payload as XPCDictionary).rotate).to.deep.equal({
+      _0: 'right',
+    });
+  });
+
+  it('rejects an invalid direction without sending anything', async function () {
+    const fake = new FakeTransport(() => ({}));
+    const service = new TestDeviceControlService(fake);
+
+    let caught: unknown;
+    try {
+      // @ts-expect-error runtime guard is under test
+      await service.rotate('up');
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).to.be.instanceOf(TypeError);
+    expect(fake.sentBodies).to.have.length(0);
+  });
+
+  it('closes the active transport', async function () {
+    const fake = new FakeTransport(() => ({
+      currentDeviceOrientation: 'portrait',
+    }));
+    const service = new TestDeviceControlService(fake);
+
+    await service.rotate('left');
+    await service.close();
+
+    expect(fake.closeCalls).to.equal(1);
+  });
+});


### PR DESCRIPTION
Adds ability to rotate device orientation.

Only possible to rotate when iOS orientation lock is not set.