### PR TITLE
feat(coredevice): add `getOrientation` method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,11 @@ export type {
   CoreDeviceLockState,
 } from './services/ios/device-info/index.js';
 export {DeviceControlService} from './services/ios/device-control/index.js';
-export type {DeviceOrientationState, RotateDirection} from './services/ios/device-control/index.js';
+export type {
+  DeviceOrientationInfo,
+  DeviceOrientationState,
+  RotateDirection,
+} from './services/ios/device-control/index.js';
 export type {SyslogEntry, SyslogLabel, SyslogLogLevel} from './services/ios/syslog-service/syslog-entry-parser.js';
 
 export type {

--- a/src/services/ios/device-control/index.ts
+++ b/src/services/ios/device-control/index.ts
@@ -27,6 +27,27 @@ export interface DeviceOrientationState {
 }
 
 /**
+ * Result of {@link DeviceControlService.getOrientation}: the device's current
+ * orientation together with an empirically-determined rotation-lock flag.
+ */
+export interface DeviceOrientationInfo {
+  /**
+   * Current device orientation, e.g. `'portrait'`, `'landscapeLeft'`. Because
+   * the probe restores the device, this equals the orientation the device had
+   * before {@link DeviceControlService.getOrientation} was called.
+   */
+  orientation?: string;
+  /** The most recent non-flat orientation (ignores face-up/face-down). */
+  nonFlatOrientation?: string;
+  /**
+   * Whether device rotation is currently locked (e.g. Control Center Rotation
+   * Lock). Determined by attempting a rotation and reverting it: `true` when the
+   * attempted rotation left the orientation unchanged.
+   */
+  locked: boolean;
+}
+
+/**
  * CoreDevice device-control service (`com.apple.coredevice.devicecontrol`).
  *
  * Rotates the device 90° at a time. Unlike most CoreDevice services this uses a
@@ -76,6 +97,37 @@ export class DeviceControlService extends CoreDeviceService {
       payload: {rotate: {_0: direction}},
     } as XPCDictionary);
     return reply as DeviceOrientationState;
+  }
+
+  /**
+   * Probes the device's current orientation and whether rotation is locked,
+   * leaving the device's final orientation unchanged.
+   *
+   * CoreDevice exposes no read-only orientation query, and the device-reported
+   * {@link DeviceOrientationState.currentDeviceOrientationLocked} flag is
+   * unreliable. This method therefore rotates the device one 90° step and
+   * immediately reverts it:
+   *
+   * - If the orientation changed, rotation is **unlocked**.
+   * - If it stayed the same, rotation is **locked**.
+   *
+   * The two rotations cancel out, so the device ends where it began — though it
+   * does briefly rotate and rotate back while the probe runs.
+   *
+   * @example
+   * ```ts
+   * const {orientation, locked} = await deviceControl.getOrientation();
+   * console.log(`device is ${orientation}${locked ? ' (rotation locked)' : ''}`);
+   * ```
+   */
+  async getOrientation(): Promise<DeviceOrientationInfo> {
+    const rotated = await this.rotate('left');
+    const restored = await this.rotate('right');
+    return {
+      orientation: restored.currentDeviceOrientation,
+      nonFlatOrientation: restored.currentDeviceNonFlatOrientation,
+      locked: rotated.currentDeviceOrientation === restored.currentDeviceOrientation,
+    };
   }
 }
 

--- a/test/integration/device-control.spec.ts
+++ b/test/integration/device-control.spec.ts
@@ -40,7 +40,15 @@ describe('DeviceControlService', {timeout: 60000}, function () {
     await deviceControl!.rotate('right');
   });
 
-  it('consecutive left rotations change the orientation', async function () {
+  it('consecutive left rotations change the orientation', async function (t) {
+    // This assertion only holds when rotation is unlocked. If the device has
+    // Control Center Rotation Lock on, rotations are silently ignored, so skip
+    // rather than fail spuriously.
+    if ((await deviceControl!.getOrientation()).locked) {
+      t.skip('device rotation is locked (Control Center Rotation Lock is on)');
+      return;
+    }
+
     const first = await deviceControl!.rotate('left');
     const second = await deviceControl!.rotate('left');
 
@@ -51,5 +59,22 @@ describe('DeviceControlService', {timeout: 60000}, function () {
     // Restore: undo the two 'left' steps.
     await deviceControl!.rotate('right');
     await deviceControl!.rotate('right');
+  });
+
+  it('getOrientation reports current orientation and lock state', async function () {
+    const info = await deviceControl!.getOrientation();
+
+    expect(info).to.be.an('object');
+    expect(info.orientation).to.be.a('string');
+    expect(info.locked).to.be.a('boolean');
+  });
+
+  it('getOrientation is non-destructive: repeated calls are stable', async function () {
+    const before = await deviceControl!.getOrientation();
+    const after = await deviceControl!.getOrientation();
+
+    // The probe rotates and reverts, so repeated reads report the same state.
+    expect(after.orientation).to.equal(before.orientation);
+    expect(after.locked).to.equal(before.locked);
   });
 });


### PR DESCRIPTION
Workaround to - https://github.com/appium/appium-ios-remotexpc/pull/269#discussion_r3538088984 

Functionality:

Adds a method `getOrientation()`, it rotates the device one 90° step and immediately reverts it:
  - If the orientation changed, rotation is **unlocked**.
  - If it stayed the same, rotation is **locked**.

It is kind of a helper for convenient use.