### PR TITLE
feat(coredevice): add configuration service (appearance & accessibility)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "test:app-service": "node --test --test-timeout=60000 \"build/test/integration/app-service.spec.js\"",
     "test:coredevice-device-info": "node --test --test-timeout=60000 \"build/test/integration/device-info-coredevice.spec.js\"",
     "test:device-control": "node --test --test-timeout=60000 \"build/test/integration/device-control.spec.js\"",
+    "test:configuration": "node --test --test-timeout=60000 \"build/test/integration/configuration.spec.js\"",
     "test:crash-reports": "node --test --test-timeout=60000 \"build/test/integration/crash-reports.spec.js\"",
     "test:diagnostics": " node --test --test-timeout=60000 \"build/test/integration/diagnostics.spec.js\"",
     "test:dvt-service": "node --test --test-timeout=60000 \"build/test/integration/dvt-service.spec.js\"",

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,13 @@ export type {
 export {DeviceControlService} from './services/ios/device-control/index.js';
 export type {DeviceOrientationState, RotateDirection} from './services/ios/device-control/index.js';
 export {ConfigurationService} from './services/ios/configuration/index.js';
-export type {ColorFilterState, SetColorFilterOptions, UserInterfaceStyle} from './services/ios/configuration/index.js';
+export type {
+  ColorFilterState,
+  ColorFilterType,
+  DeviceTextSize,
+  SetColorFilterOptions,
+  UserInterfaceStyle,
+} from './services/ios/configuration/index.js';
 export type {SyslogEntry, SyslogLabel, SyslogLogLevel} from './services/ios/syslog-service/syslog-entry-parser.js';
 
 export type {

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,8 @@ export type {
 } from './services/ios/device-info/index.js';
 export {DeviceControlService} from './services/ios/device-control/index.js';
 export type {DeviceOrientationState, RotateDirection} from './services/ios/device-control/index.js';
+export {ConfigurationService} from './services/ios/configuration/index.js';
+export type {ColorFilterState, SetColorFilterOptions, UserInterfaceStyle} from './services/ios/configuration/index.js';
 export type {SyslogEntry, SyslogLabel, SyslogLogLevel} from './services/ios/syslog-service/syslog-entry-parser.js';
 
 export type {

--- a/src/services.ts
+++ b/src/services.ts
@@ -7,6 +7,7 @@ import type {DVTInstruments, SyslogService as SyslogServiceType, XCTestServices}
 import AfcService from './services/ios/afc/index.js';
 import {AppService} from './services/ios/app-service/index.js';
 import {type Service} from './services/ios/base-service.js';
+import {ConfigurationService} from './services/ios/configuration/index.js';
 import {CrashReportsService} from './services/ios/crash-reports/index.js';
 import {DeviceControlService} from './services/ios/device-control/index.js';
 import {CoreDeviceInfoService} from './services/ios/device-info/index.js';
@@ -143,6 +144,18 @@ export async function startCoreDeviceInfoService(udid: string): Promise<CoreDevi
 export async function startDeviceControlService(udid: string): Promise<DeviceControlService> {
   await requireCatalogService(udid, DeviceControlService.RSD_SERVICE_NAME);
   return new DeviceControlService(udid);
+}
+
+/**
+ * Start the CoreDevice configuration service for the given device UDID.
+ *
+ * Reads and writes appearance and accessibility knobs (dark/light mode, Dynamic
+ * Type text size, Reduce Motion / Transparency, Increase Contrast, color
+ * filters, layout-debug borders, iOS 26 liquid-glass opacity) over RemoteXPC.
+ */
+export async function startConfigurationService(udid: string): Promise<ConfigurationService> {
+  await requireCatalogService(udid, ConfigurationService.RSD_SERVICE_NAME);
+  return new ConfigurationService(udid);
 }
 
 const RSD_SYSLOG_BINARY_SERVICE_NAME = 'com.apple.os_trace_relay.shim.remote';

--- a/src/services/ios/configuration/index.ts
+++ b/src/services/ios/configuration/index.ts
@@ -1,6 +1,6 @@
 import {asDictionary} from '../../../lib/remote-xpc/xpc-value.js';
 import type {XPCDictionary} from '../../../lib/types.js';
-import {type CoreDeviceInvokeOptions, CoreDeviceService} from '../core-device/core-device-service.js';
+import {type CoreDeviceInvokeOptions, CoreDeviceError, CoreDeviceService} from '../core-device/core-device-service.js';
 
 const ACTION = {
   GET_USER_INTERFACE_STYLE: 'com.apple.coredevice.action.getuserinterfacestyle',
@@ -12,6 +12,7 @@ const ACTION = {
   SET_DEVICE_TEXT_SIZE: 'com.apple.coredevice.action.setdevicetextsize',
   GET_REDUCE_MOTION: 'com.apple.coredevice.action.getreducemotion',
   SET_REDUCE_MOTION: 'com.apple.coredevice.action.setreducemotion',
+  GET_INCREASE_CONTRAST: 'com.apple.coredevice.action.getdeviceincreasecontrast',
   SET_INCREASE_CONTRAST: 'com.apple.coredevice.action.setdeviceincreasecontrast',
   GET_SHOW_BORDERS: 'com.apple.coredevice.action.getshowborders',
   SET_SHOW_BORDERS: 'com.apple.coredevice.action.setshowborders',
@@ -21,6 +22,31 @@ const ACTION = {
 
 /** Device appearance: `'dark'` or `'light'`. */
 export type UserInterfaceStyle = 'dark' | 'light';
+
+/**
+ * Dynamic Type content-size names accepted by the daemon's `setdevicetextsize`
+ * action. These are the seven standard sizes.
+ */
+const DEVICE_TEXT_SIZES = [
+  'extraSmall',
+  'small',
+  'medium',
+  'large',
+  'extraLarge',
+  'extraExtraLarge',
+  'extraExtraExtraLarge',
+] as const;
+
+/** A valid Dynamic Type content-size name. See {@link DEVICE_TEXT_SIZES}. */
+export type DeviceTextSize = (typeof DEVICE_TEXT_SIZES)[number];
+
+/**
+ * Color-filter presets that enable from `filterType` alone.
+ */
+const COLOR_FILTER_TYPES = ['Grayscale', 'Protanopia', 'Deuteranopia', 'Tritanopia'] as const;
+
+/** A color-filter preset that enables from a name alone. See {@link COLOR_FILTER_TYPES}. */
+export type ColorFilterType = (typeof COLOR_FILTER_TYPES)[number];
 
 /** Color-filter state returned by {@link ConfigurationService.getColorFilter}. */
 export interface ColorFilterState {
@@ -35,8 +61,8 @@ export interface ColorFilterState {
 
 /** Options for {@link ConfigurationService.setColorFilter}. */
 export interface SetColorFilterOptions {
-  /** Filter preset name (e.g. `'Protanopia'`). Required when enabling. */
-  filterType?: string;
+  /** Filter preset (e.g. `'Protanopia'`). Required when enabling. */
+  filterType?: ColorFilterType;
   /** Filter intensity 0.0..1.0. */
   intensity?: number;
 }
@@ -74,7 +100,11 @@ export class ConfigurationService extends CoreDeviceService {
   /** Returns the active appearance — `'dark'` or `'light'`. */
   async getUserInterfaceStyle(options: CoreDeviceInvokeOptions = {}): Promise<UserInterfaceStyle> {
     const output = await this.action(ACTION.GET_USER_INTERFACE_STYLE, {}, options);
-    return output.style as UserInterfaceStyle;
+    const style = output.style;
+    if (style !== 'dark' && style !== 'light') {
+      throw new CoreDeviceError(`Unexpected user-interface style from device: ${String(style)}`, output);
+    }
+    return style;
   }
 
   /** Sets the device appearance to `'dark'` or `'light'`. */
@@ -87,8 +117,7 @@ export class ConfigurationService extends CoreDeviceService {
 
   /**
    * Sets the system liquid-glass opacity (iOS 26). `opacity` is range-checked to
-   * `[0.0, 1.0]` and quantized to IEEE-754 binary32, matching what the device
-   * daemon accepts on the wire.
+   * `[0.0, 1.0]` and quantized to IEEE-754 binary32.
    *
    * ⚠️ Device-gated, not just OS-gated: hardware that does not support Liquid
    * Glass customization rejects this with `com.apple.dt.CoreDeviceError 21035`
@@ -99,7 +128,9 @@ export class ConfigurationService extends CoreDeviceService {
     if (!(opacity >= 0 && opacity <= 1)) {
       throw new RangeError(`opacity must be in [0.0, 1.0], got ${String(opacity)}`);
     }
-    await this.action(ACTION.SET_LIQUID_GLASS, {configuration: {opacity: toFloat32(opacity)}}, options);
+    // Quantize to IEEE-754 binary32: the daemon's Swift decoders reject floats
+    // whose low mantissa bits don't fit in Float32.
+    await this.action(ACTION.SET_LIQUID_GLASS, {configuration: {opacity: Math.fround(opacity)}}, options);
   }
 
   /**
@@ -112,40 +143,48 @@ export class ConfigurationService extends CoreDeviceService {
   }
 
   /**
-   * Sets the color filter. `filterType` is required when `enabled` is true
-   * (e.g. `'Grayscale'`).
+   * Sets the color filter. `filterType` is required when `enabled` is true and
+   * must be one of {@link ColorFilterType} (`'Grayscale'`, `'Protanopia'`,
+   * `'Deuteranopia'`, `'Tritanopia'`) — the presets verified to enable from a
+   * name. Names are case-sensitive; an unknown value throws a `TypeError`.
    *
-   * ⚠️ `intensity` is device-gated: on some devices any `intensity` value is
+   * ⚠️ `intensity` is device-gated: on the tested device any `intensity` value is
    * rejected with `com.apple.dt.CoreDeviceError 21056` ("The color filter
    * intensity value is not valid."), surfaced here as a {@link CoreDeviceError}.
-   * Omit it unless you know the target device accepts it. Some filter presets
-   * (e.g. `'colorTint'`) also need extra parameters and will not enable from
-   * `filterType` alone.
+   * Omit it unless you know the target device accepts it.
    */
   async setColorFilter(enabled: boolean, options: SetColorFilterOptions & CoreDeviceInvokeOptions = {}): Promise<void> {
     const {filterType, intensity, ...invokeOptions} = options;
     const colorFilter: XPCDictionary = {enabled};
+    // filterType/intensity only apply when enabling. When disabling we send just
+    // `{ enabled: false }` and intentionally drop them.
     if (enabled) {
       if (filterType === undefined) {
         throw new TypeError('filterType is required when enabling the color filter');
       }
+      if (!isOneOf(COLOR_FILTER_TYPES, filterType)) {
+        throw new TypeError(`filterType must be one of ${COLOR_FILTER_TYPES.join(', ')}, got '${String(filterType)}'`);
+      }
       colorFilter.filterType = {name: filterType};
       if (intensity !== undefined) {
-        colorFilter.intensity = toFloat32(intensity);
+        colorFilter.intensity = Math.fround(intensity);
       }
     }
     await this.action(ACTION.SET_COLOR_FILTER, {colorFilter}, invokeOptions);
   }
 
   /** Returns the Dynamic Type size name (e.g. `'medium'`, `'large'`). */
-  async getDeviceTextSize(options: CoreDeviceInvokeOptions = {}): Promise<string | undefined> {
+  async getDeviceTextSize(options: CoreDeviceInvokeOptions = {}): Promise<DeviceTextSize | undefined> {
     const output = await this.action(ACTION.GET_DEVICE_TEXT_SIZE, {}, options);
     const size = asDictionary(asDictionary(output.textSize)?.size);
-    return size ? Object.keys(size)[0] : undefined;
+    return size ? (Object.keys(size)[0] as DeviceTextSize) : undefined;
   }
 
   /** Sets the Dynamic Type size by name (`'medium'`, `'large'`, …). */
-  async setDeviceTextSize(size: string, options: CoreDeviceInvokeOptions = {}): Promise<void> {
+  async setDeviceTextSize(size: DeviceTextSize, options: CoreDeviceInvokeOptions = {}): Promise<void> {
+    if (!isOneOf(DEVICE_TEXT_SIZES, size)) {
+      throw new TypeError(`size must be one of ${DEVICE_TEXT_SIZES.join(', ')}, got '${String(size)}'`);
+    }
     await this.action(ACTION.SET_DEVICE_TEXT_SIZE, {textSize: {size: {[size]: {}}}}, options);
   }
 
@@ -159,7 +198,12 @@ export class ConfigurationService extends CoreDeviceService {
     await this.action(ACTION.SET_REDUCE_MOTION, {reduceMotion: {enabled}}, options);
   }
 
-  /** Toggles Increase Contrast. The daemon exposes no symmetric getter. */
+  /** Returns whether Increase Contrast is enabled. */
+  async getIncreaseContrast(options: CoreDeviceInvokeOptions = {}): Promise<boolean> {
+    return this.getEnabled(ACTION.GET_INCREASE_CONTRAST, 'increaseContrast', options);
+  }
+
+  /** Toggles Increase Contrast. */
   async setIncreaseContrast(enabled: boolean, options: CoreDeviceInvokeOptions = {}): Promise<void> {
     await this.action(ACTION.SET_INCREASE_CONTRAST, {increaseContrast: {enabled}}, options);
   }
@@ -201,12 +245,12 @@ export class ConfigurationService extends CoreDeviceService {
 }
 
 /**
- * Rounds `value` through IEEE-754 binary32.
- * The daemon's Swift decoders reject float knobs whose low mantissa bits do not
- * fit in Float32; quantizing here produces a bit pattern the device accepts.
+ * Type guard for membership in an `as const` list of string literals. Lets a
+ * single declaration be the source of truth for both a union type
+ * (`(typeof list)[number]`) and its runtime validation.
  */
-function toFloat32(value: number): number {
-  return Math.fround(value);
+function isOneOf<T extends readonly string[]>(values: T, value: string): value is T[number] {
+  return (values as readonly string[]).includes(value);
 }
 
 export default ConfigurationService;

--- a/src/services/ios/configuration/index.ts
+++ b/src/services/ios/configuration/index.ts
@@ -20,8 +20,13 @@ const ACTION = {
   SET_REDUCE_TRANSPARENCY: 'com.apple.coredevice.action.setreducetransparency',
 } as const;
 
-/** Device appearance: `'dark'` or `'light'`. */
-export type UserInterfaceStyle = 'dark' | 'light';
+/**
+ * Device appearance. Today the daemon only reports/accepts `'dark'` and
+ * `'light'`, so those are surfaced as literals for autocomplete — but the type
+ * stays open (`string & {}`) so a future OS that adds another style is neither
+ * rejected on read nor unrepresentable on write.
+ */
+export type UserInterfaceStyle = 'dark' | 'light' | (string & {});
 
 /**
  * Dynamic Type content-size names accepted by the daemon's `setdevicetextsize`
@@ -97,20 +102,30 @@ export class ConfigurationService extends CoreDeviceService {
     super(udid, ConfigurationService.RSD_SERVICE_NAME);
   }
 
-  /** Returns the active appearance — `'dark'` or `'light'`. */
+  /**
+   * Returns the active appearance. Normally `'dark'` or `'light'`, but any
+   * string the device reports is passed through unchanged (so a future OS style
+   * is not rejected). Only a missing/non-string value — a malformed reply —
+   * throws a {@link CoreDeviceError}.
+   */
   async getUserInterfaceStyle(options: CoreDeviceInvokeOptions = {}): Promise<UserInterfaceStyle> {
     const output = await this.action(ACTION.GET_USER_INTERFACE_STYLE, {}, options);
     const style = output.style;
-    if (style !== 'dark' && style !== 'light') {
-      throw new CoreDeviceError(`Unexpected user-interface style from device: ${String(style)}`, output);
+    if (typeof style !== 'string') {
+      throw new CoreDeviceError(`Missing user-interface style in device response: ${String(style)}`, output);
     }
     return style;
   }
 
-  /** Sets the device appearance to `'dark'` or `'light'`. */
+  /**
+   * Sets the device appearance. `'dark'` and `'light'` are the known values; any
+   * other non-empty string is forwarded to the device (which validates it), so a
+   * future OS style is not blocked client-side. An empty/non-string value throws
+   * a `TypeError`.
+   */
   async setUserInterfaceStyle(style: UserInterfaceStyle, options: CoreDeviceInvokeOptions = {}): Promise<void> {
-    if (style !== 'dark' && style !== 'light') {
-      throw new TypeError(`style must be 'dark' or 'light', got '${String(style)}'`);
+    if (typeof style !== 'string' || style.length === 0) {
+      throw new TypeError(`style must be a non-empty string, got '${String(style)}'`);
     }
     await this.action(ACTION.SET_USER_INTERFACE_STYLE, {style}, options);
   }

--- a/src/services/ios/configuration/index.ts
+++ b/src/services/ios/configuration/index.ts
@@ -1,0 +1,212 @@
+import {asDictionary} from '../../../lib/remote-xpc/xpc-value.js';
+import type {XPCDictionary} from '../../../lib/types.js';
+import {type CoreDeviceInvokeOptions, CoreDeviceService} from '../core-device/core-device-service.js';
+
+const ACTION = {
+  GET_USER_INTERFACE_STYLE: 'com.apple.coredevice.action.getuserinterfacestyle',
+  SET_USER_INTERFACE_STYLE: 'com.apple.coredevice.action.setuserinterfacestyle',
+  SET_LIQUID_GLASS: 'com.apple.coredevice.action.setliquidglassconfiguration',
+  GET_COLOR_FILTER: 'com.apple.coredevice.action.getcolorfilter',
+  SET_COLOR_FILTER: 'com.apple.coredevice.action.setcolorfilter',
+  GET_DEVICE_TEXT_SIZE: 'com.apple.coredevice.action.getdevicetextsize',
+  SET_DEVICE_TEXT_SIZE: 'com.apple.coredevice.action.setdevicetextsize',
+  GET_REDUCE_MOTION: 'com.apple.coredevice.action.getreducemotion',
+  SET_REDUCE_MOTION: 'com.apple.coredevice.action.setreducemotion',
+  SET_INCREASE_CONTRAST: 'com.apple.coredevice.action.setdeviceincreasecontrast',
+  GET_SHOW_BORDERS: 'com.apple.coredevice.action.getshowborders',
+  SET_SHOW_BORDERS: 'com.apple.coredevice.action.setshowborders',
+  GET_REDUCE_TRANSPARENCY: 'com.apple.coredevice.action.getreducetransparency',
+  SET_REDUCE_TRANSPARENCY: 'com.apple.coredevice.action.setreducetransparency',
+} as const;
+
+/** Device appearance: `'dark'` or `'light'`. */
+export type UserInterfaceStyle = 'dark' | 'light';
+
+/** Color-filter state returned by {@link ConfigurationService.getColorFilter}. */
+export interface ColorFilterState {
+  /** Whether the color filter is active. */
+  enabled: boolean;
+  /** Active filter preset (e.g. `'Protanopia'`); absent when disabled. */
+  filterType?: {name?: string; [key: string]: unknown};
+  /** Filter intensity 0.0..1.0; absent when disabled or unset. */
+  intensity?: number;
+  [key: string]: unknown;
+}
+
+/** Options for {@link ConfigurationService.setColorFilter}. */
+export interface SetColorFilterOptions {
+  /** Filter preset name (e.g. `'Protanopia'`). Required when enabling. */
+  filterType?: string;
+  /** Filter intensity 0.0..1.0. */
+  intensity?: number;
+}
+
+/**
+ * CoreDevice configuration service (`com.apple.coredevice.configuration`).
+ *
+ * Reads and writes the appearance and accessibility knobs that Xcode toggles
+ * through the same service: dark/light mode, Dynamic Type text size, Reduce
+ * Motion / Reduce Transparency / Increase Contrast, color filters, layout-debug
+ * borders, and (iOS 26) liquid-glass opacity. This is the only path here that
+ * reaches these settings — the DVT ConditionInducer does not expose them.
+ *
+ * Every method is a thin wrapper around a single `com.apple.coredevice.action.*`
+ * invocation (no feature identifier, only an action identifier).
+ *
+ * @example
+ * ```ts
+ * const config = await Services.startConfigurationService(udid);
+ * try {
+ *   await config.setUserInterfaceStyle('dark');
+ *   const style = await config.getUserInterfaceStyle(); // 'dark'
+ * } finally {
+ *   await config.close();
+ * }
+ * ```
+ */
+export class ConfigurationService extends CoreDeviceService {
+  static readonly RSD_SERVICE_NAME = 'com.apple.coredevice.configuration';
+
+  constructor(udid: string) {
+    super(udid, ConfigurationService.RSD_SERVICE_NAME);
+  }
+
+  /** Returns the active appearance — `'dark'` or `'light'`. */
+  async getUserInterfaceStyle(options: CoreDeviceInvokeOptions = {}): Promise<UserInterfaceStyle> {
+    const output = await this.action(ACTION.GET_USER_INTERFACE_STYLE, {}, options);
+    return output.style as UserInterfaceStyle;
+  }
+
+  /** Sets the device appearance to `'dark'` or `'light'`. */
+  async setUserInterfaceStyle(style: UserInterfaceStyle, options: CoreDeviceInvokeOptions = {}): Promise<void> {
+    if (style !== 'dark' && style !== 'light') {
+      throw new TypeError(`style must be 'dark' or 'light', got '${String(style)}'`);
+    }
+    await this.action(ACTION.SET_USER_INTERFACE_STYLE, {style}, options);
+  }
+
+  /**
+   * Sets the system liquid-glass opacity (iOS 26). `opacity` is range-checked to
+   * `[0.0, 1.0]` and quantized to IEEE-754 binary32, matching what the device
+   * daemon accepts on the wire.
+   *
+   * ⚠️ Device-gated, not just OS-gated: hardware that does not support Liquid
+   * Glass customization rejects this with `com.apple.dt.CoreDeviceError 21035`
+   * ("Liquid Glass configuration customization is not supported on this
+   * device."), surfaced here as a {@link CoreDeviceError} — even on iOS 26.
+   */
+  async setLiquidGlassOpacity(opacity: number, options: CoreDeviceInvokeOptions = {}): Promise<void> {
+    if (!(opacity >= 0 && opacity <= 1)) {
+      throw new RangeError(`opacity must be in [0.0, 1.0], got ${String(opacity)}`);
+    }
+    await this.action(ACTION.SET_LIQUID_GLASS, {configuration: {opacity: toFloat32(opacity)}}, options);
+  }
+
+  /**
+   * Returns the color-filter state. When the filter is disabled only `enabled`
+   * is present.
+   */
+  async getColorFilter(options: CoreDeviceInvokeOptions = {}): Promise<ColorFilterState> {
+    const output = await this.action(ACTION.GET_COLOR_FILTER, {}, options);
+    return (asDictionary(output.colorFilter) ?? {enabled: false}) as ColorFilterState;
+  }
+
+  /**
+   * Sets the color filter. `filterType` is required when `enabled` is true
+   * (e.g. `'Grayscale'`).
+   *
+   * ⚠️ `intensity` is device-gated: on some devices any `intensity` value is
+   * rejected with `com.apple.dt.CoreDeviceError 21056` ("The color filter
+   * intensity value is not valid."), surfaced here as a {@link CoreDeviceError}.
+   * Omit it unless you know the target device accepts it. Some filter presets
+   * (e.g. `'colorTint'`) also need extra parameters and will not enable from
+   * `filterType` alone.
+   */
+  async setColorFilter(enabled: boolean, options: SetColorFilterOptions & CoreDeviceInvokeOptions = {}): Promise<void> {
+    const {filterType, intensity, ...invokeOptions} = options;
+    const colorFilter: XPCDictionary = {enabled};
+    if (enabled) {
+      if (filterType === undefined) {
+        throw new TypeError('filterType is required when enabling the color filter');
+      }
+      colorFilter.filterType = {name: filterType};
+      if (intensity !== undefined) {
+        colorFilter.intensity = toFloat32(intensity);
+      }
+    }
+    await this.action(ACTION.SET_COLOR_FILTER, {colorFilter}, invokeOptions);
+  }
+
+  /** Returns the Dynamic Type size name (e.g. `'medium'`, `'large'`). */
+  async getDeviceTextSize(options: CoreDeviceInvokeOptions = {}): Promise<string | undefined> {
+    const output = await this.action(ACTION.GET_DEVICE_TEXT_SIZE, {}, options);
+    const size = asDictionary(asDictionary(output.textSize)?.size);
+    return size ? Object.keys(size)[0] : undefined;
+  }
+
+  /** Sets the Dynamic Type size by name (`'medium'`, `'large'`, …). */
+  async setDeviceTextSize(size: string, options: CoreDeviceInvokeOptions = {}): Promise<void> {
+    await this.action(ACTION.SET_DEVICE_TEXT_SIZE, {textSize: {size: {[size]: {}}}}, options);
+  }
+
+  /** Returns whether Reduce Motion is enabled. */
+  async getReduceMotion(options: CoreDeviceInvokeOptions = {}): Promise<boolean> {
+    return this.getEnabled(ACTION.GET_REDUCE_MOTION, 'reduceMotion', options);
+  }
+
+  /** Toggles Reduce Motion. */
+  async setReduceMotion(enabled: boolean, options: CoreDeviceInvokeOptions = {}): Promise<void> {
+    await this.action(ACTION.SET_REDUCE_MOTION, {reduceMotion: {enabled}}, options);
+  }
+
+  /** Toggles Increase Contrast. The daemon exposes no symmetric getter. */
+  async setIncreaseContrast(enabled: boolean, options: CoreDeviceInvokeOptions = {}): Promise<void> {
+    await this.action(ACTION.SET_INCREASE_CONTRAST, {increaseContrast: {enabled}}, options);
+  }
+
+  /** Returns whether the layout-debug borders overlay is enabled. */
+  async getShowBorders(options: CoreDeviceInvokeOptions = {}): Promise<boolean> {
+    return this.getEnabled(ACTION.GET_SHOW_BORDERS, 'showBorders', options);
+  }
+
+  /** Toggles the layout-debug borders overlay. */
+  async setShowBorders(enabled: boolean, options: CoreDeviceInvokeOptions = {}): Promise<void> {
+    await this.action(ACTION.SET_SHOW_BORDERS, {showBorders: {enabled}}, options);
+  }
+
+  /** Returns whether Reduce Transparency is enabled. */
+  async getReduceTransparency(options: CoreDeviceInvokeOptions = {}): Promise<boolean> {
+    return this.getEnabled(ACTION.GET_REDUCE_TRANSPARENCY, 'reduceTransparency', options);
+  }
+
+  /** Toggles Reduce Transparency. */
+  async setReduceTransparency(enabled: boolean, options: CoreDeviceInvokeOptions = {}): Promise<void> {
+    await this.action(ACTION.SET_REDUCE_TRANSPARENCY, {reduceTransparency: {enabled}}, options);
+  }
+
+  /** Invokes an action identifier (no feature identifier) and returns its output dict. */
+  private async action(
+    actionIdentifier: string,
+    input: XPCDictionary,
+    options: CoreDeviceInvokeOptions,
+  ): Promise<XPCDictionary> {
+    return asDictionary(await this.invoke(undefined, input, {...options, actionIdentifier})) ?? {};
+  }
+
+  /** Reads a `{ <key>: { enabled: bool } }`-shaped boolean knob. */
+  private async getEnabled(actionIdentifier: string, key: string, options: CoreDeviceInvokeOptions): Promise<boolean> {
+    const output = await this.action(actionIdentifier, {}, options);
+    return asDictionary(output[key])?.enabled === true;
+  }
+}
+
+/**
+ * Rounds `value` through IEEE-754 binary32.
+ * The daemon's Swift decoders reject float knobs whose low mantissa bits do not
+ * fit in Float32; quantizing here produces a bit pattern the device accepts.
+ */
+function toFloat32(value: number): number {
+  return Math.fround(value);
+}
+
+export default ConfigurationService;

--- a/test/integration/configuration.spec.ts
+++ b/test/integration/configuration.spec.ts
@@ -2,7 +2,12 @@ import {after, before, describe, it} from 'node:test';
 
 import {expect} from 'chai';
 
-import {CoreDeviceError, type ColorFilterType, type ConfigurationService} from '../../src/index.js';
+import {
+  CoreDeviceError,
+  type ColorFilterType,
+  type ConfigurationService,
+  type DeviceTextSize,
+} from '../../src/index.js';
 import * as Services from '../../src/services.js';
 import {requireDeviceUdid} from './helpers/device.js';
 
@@ -80,9 +85,8 @@ describe('ConfigurationService', {timeout: 60000}, function () {
     }
   });
 
-  it('getDeviceTextSize returns a known size', async function () {
-    const textSize = await service!.getDeviceTextSize();
-    expect(textSize, 'device text size').to.be.oneOf([
+  it('setDeviceTextSize applies every standard size and restores the original', async function () {
+    const sizes: DeviceTextSize[] = [
       'extraSmall',
       'small',
       'medium',
@@ -90,20 +94,36 @@ describe('ConfigurationService', {timeout: 60000}, function () {
       'extraLarge',
       'extraExtraLarge',
       'extraExtraExtraLarge',
-    ]);
+    ];
+    const original = await service!.getDeviceTextSize();
+    expect(original, 'original text size').to.be.oneOf(sizes);
+    try {
+      for (const size of sizes) {
+        await service!.setDeviceTextSize(size);
+        expect(await service!.getDeviceTextSize(), size).to.equal(size);
+      }
+    } finally {
+      if (original) {
+        await service!.setDeviceTextSize(original);
+      }
+    }
+    expect(await service!.getDeviceTextSize()).to.equal(original);
   });
 
-  it('color filter can be enabled (Grayscale), read back, and restored', async function () {
+  it('every color-filter preset enables, reports its name, and disables', async function () {
+    const presets: ColorFilterType[] = ['Grayscale', 'Protanopia', 'Deuteranopia', 'Tritanopia'];
     const original = await service!.getColorFilter();
     try {
-      // Enable a grayscale filter (no intensity — intensity is device-gated).
-      await service!.setColorFilter(true, {filterType: 'Grayscale'});
-      const enabled = await service!.getColorFilter();
-      expect(enabled.enabled).to.equal(true);
-      expect(enabled.filterType?.name).to.equal('Grayscale');
+      for (const preset of presets) {
+        // Enable each preset (no intensity — intensity is device-gated, 21056).
+        await service!.setColorFilter(true, {filterType: preset});
+        const enabled = await service!.getColorFilter();
+        expect(enabled.enabled, preset).to.equal(true);
+        expect(enabled.filterType?.name, preset).to.equal(preset);
 
-      await service!.setColorFilter(false);
-      expect((await service!.getColorFilter()).enabled).to.equal(false);
+        await service!.setColorFilter(false);
+        expect((await service!.getColorFilter()).enabled, `${preset} disabled`).to.equal(false);
+      }
     } finally {
       if (original.enabled && original.filterType?.name) {
         await service!.setColorFilter(true, {filterType: original.filterType.name as ColorFilterType});

--- a/test/integration/configuration.spec.ts
+++ b/test/integration/configuration.spec.ts
@@ -2,7 +2,7 @@ import {after, before, describe, it} from 'node:test';
 
 import {expect} from 'chai';
 
-import {CoreDeviceError, type ConfigurationService} from '../../src/index.js';
+import {CoreDeviceError, type ColorFilterType, type ConfigurationService} from '../../src/index.js';
 import * as Services from '../../src/services.js';
 import {requireDeviceUdid} from './helpers/device.js';
 
@@ -62,16 +62,35 @@ describe('ConfigurationService', {timeout: 60000}, function () {
     expect(await service!.getReduceMotion()).to.equal(original);
   });
 
-  it('read-only accessibility knobs return sensible types', async function () {
-    expect(await service!.getShowBorders()).to.be.a('boolean');
-    expect(await service!.getReduceTransparency()).to.be.a('boolean');
+  it('boolean accessibility knobs round-trip (transparency, borders, contrast)', async function () {
+    const knobs: [() => Promise<boolean>, (v: boolean) => Promise<void>][] = [
+      [() => service!.getReduceTransparency(), (v) => service!.setReduceTransparency(v)],
+      [() => service!.getShowBorders(), (v) => service!.setShowBorders(v)],
+      [() => service!.getIncreaseContrast(), (v) => service!.setIncreaseContrast(v)],
+    ];
+    for (const [get, set] of knobs) {
+      const original = await get();
+      try {
+        await set(!original);
+        expect(await get()).to.equal(!original);
+      } finally {
+        await set(original);
+      }
+      expect(await get()).to.equal(original);
+    }
+  });
 
+  it('getDeviceTextSize returns a known size', async function () {
     const textSize = await service!.getDeviceTextSize();
-    expect(textSize, 'device text size').to.be.a('string').that.is.not.empty;
-
-    const colorFilter = await service!.getColorFilter();
-    expect(colorFilter).to.be.an('object');
-    expect(colorFilter.enabled).to.be.a('boolean');
+    expect(textSize, 'device text size').to.be.oneOf([
+      'extraSmall',
+      'small',
+      'medium',
+      'large',
+      'extraLarge',
+      'extraExtraLarge',
+      'extraExtraExtraLarge',
+    ]);
   });
 
   it('color filter can be enabled (Grayscale), read back, and restored', async function () {
@@ -87,18 +106,11 @@ describe('ConfigurationService', {timeout: 60000}, function () {
       expect((await service!.getColorFilter()).enabled).to.equal(false);
     } finally {
       if (original.enabled && original.filterType?.name) {
-        await service!.setColorFilter(true, {filterType: original.filterType.name});
+        await service!.setColorFilter(true, {filterType: original.filterType.name as ColorFilterType});
       } else {
         await service!.setColorFilter(false);
       }
     }
-  });
-
-  it('setIncreaseContrast resolves (no getter exposed by the daemon)', async function () {
-    // No symmetric getter exists; assert the call is accepted. Restore to off
-    // (the common default) so we don't leave the device altered.
-    await service!.setIncreaseContrast(true);
-    await service!.setIncreaseContrast(false);
   });
 
   it('liquid glass opacity can be set and restored (iOS 26)', async function () {

--- a/test/integration/configuration.spec.ts
+++ b/test/integration/configuration.spec.ts
@@ -1,0 +1,114 @@
+import {after, before, describe, it} from 'node:test';
+
+import {expect} from 'chai';
+
+import {CoreDeviceError, type ConfigurationService} from '../../src/index.js';
+import * as Services from '../../src/services.js';
+import {requireDeviceUdid} from './helpers/device.js';
+
+/**
+ * Integration tests for the CoreDevice configuration service
+ * (`com.apple.coredevice.configuration`).
+ *
+ * Requires a physical iOS device with a running tunnel registry. Set the UDID
+ * env var to the target device.
+ *
+ * Every mutating test captures the device's original value and restores it, so
+ * the device is left as it was found. Appearance-affecting knobs (dark mode,
+ * color filter, liquid glass) will briefly change the screen while the test
+ * runs.
+ */
+describe('ConfigurationService', {timeout: 60000}, function () {
+  let service: ConfigurationService | null = null;
+
+  before(async function () {
+    const udid = requireDeviceUdid();
+    service = await Services.startConfigurationService(udid);
+  });
+
+  after(async function () {
+    try {
+      await service?.close();
+    } catch {
+      // Ignore cleanup errors in tests
+    }
+  });
+
+  it('getUserInterfaceStyle returns "dark" or "light"', async function () {
+    const style = await service!.getUserInterfaceStyle();
+    expect(style).to.be.oneOf(['dark', 'light']);
+  });
+
+  it('setUserInterfaceStyle round-trips (dark <-> light)', async function () {
+    const original = await service!.getUserInterfaceStyle();
+    const toggled = original === 'dark' ? 'light' : 'dark';
+    try {
+      await service!.setUserInterfaceStyle(toggled);
+      expect(await service!.getUserInterfaceStyle()).to.equal(toggled);
+    } finally {
+      await service!.setUserInterfaceStyle(original);
+    }
+    expect(await service!.getUserInterfaceStyle()).to.equal(original);
+  });
+
+  it('reduce motion round-trips', async function () {
+    const original = await service!.getReduceMotion();
+    try {
+      await service!.setReduceMotion(!original);
+      expect(await service!.getReduceMotion()).to.equal(!original);
+    } finally {
+      await service!.setReduceMotion(original);
+    }
+    expect(await service!.getReduceMotion()).to.equal(original);
+  });
+
+  it('read-only accessibility knobs return sensible types', async function () {
+    expect(await service!.getShowBorders()).to.be.a('boolean');
+    expect(await service!.getReduceTransparency()).to.be.a('boolean');
+
+    const textSize = await service!.getDeviceTextSize();
+    expect(textSize, 'device text size').to.be.a('string').that.is.not.empty;
+
+    const colorFilter = await service!.getColorFilter();
+    expect(colorFilter).to.be.an('object');
+    expect(colorFilter.enabled).to.be.a('boolean');
+  });
+
+  it('color filter can be enabled (Grayscale), read back, and restored', async function () {
+    const original = await service!.getColorFilter();
+    try {
+      // Enable a grayscale filter (no intensity — intensity is device-gated).
+      await service!.setColorFilter(true, {filterType: 'Grayscale'});
+      const enabled = await service!.getColorFilter();
+      expect(enabled.enabled).to.equal(true);
+      expect(enabled.filterType?.name).to.equal('Grayscale');
+
+      await service!.setColorFilter(false);
+      expect((await service!.getColorFilter()).enabled).to.equal(false);
+    } finally {
+      if (original.enabled && original.filterType?.name) {
+        await service!.setColorFilter(true, {filterType: original.filterType.name});
+      } else {
+        await service!.setColorFilter(false);
+      }
+    }
+  });
+
+  it('setIncreaseContrast resolves (no getter exposed by the daemon)', async function () {
+    // No symmetric getter exists; assert the call is accepted. Restore to off
+    // (the common default) so we don't leave the device altered.
+    await service!.setIncreaseContrast(true);
+    await service!.setIncreaseContrast(false);
+  });
+
+  it('liquid glass opacity can be set and restored (iOS 26)', async function () {
+    try {
+      await service!.setLiquidGlassOpacity(0.6);
+      await service!.setLiquidGlassOpacity(1);
+    } catch (error) {
+      // Device-gated (not just OS-gated): hardware without Liquid Glass support rejects with
+      // CoreDeviceError 21035 even on iOS 26. Tested on iPhone 11 might work on newer models
+      expect(error).to.be.instanceOf(CoreDeviceError);
+    }
+  });
+});

--- a/test/unit/configuration/configuration-service.spec.ts
+++ b/test/unit/configuration/configuration-service.spec.ts
@@ -1,0 +1,213 @@
+import {EventEmitter} from 'node:events';
+import {describe, it} from 'node:test';
+
+import {expect} from 'chai';
+
+import {decodeMessage} from '../../../src/lib/remote-xpc/xpc-protocol.js';
+import type {XPCDictionary, XPCValue} from '../../../src/lib/types.js';
+import {ConfigurationService} from '../../../src/services/ios/configuration/index.js';
+
+type Responder = (sentBody: XPCDictionary) => XPCDictionary | null;
+
+/**
+ * Fake framed transport: captures every sent XPC body and, for each request,
+ * emits a canned reply on the next microtask (mirroring a device response).
+ */
+class FakeTransport extends EventEmitter {
+  isConnected = true;
+  closeCalls = 0;
+  readonly sentBodies: XPCDictionary[] = [];
+
+  constructor(private responder: Responder) {
+    super();
+  }
+
+  sendDataFrame(payload: Buffer): void {
+    const {message} = decodeMessage(payload);
+    const body = message.body as XPCDictionary;
+    this.sentBodies.push(body);
+    const reply = this.responder(body);
+    if (reply) {
+      queueMicrotask(() => this.emit('message', reply));
+    }
+  }
+
+  async close(): Promise<void> {
+    this.closeCalls++;
+  }
+}
+
+class TestConfigurationService extends ConfigurationService {
+  constructor(readonly fake: FakeTransport) {
+    super('test-udid');
+  }
+
+  protected async createTransport(): Promise<any> {
+    return this.fake;
+  }
+}
+
+function actionId(body: XPCDictionary): string {
+  return body['CoreDevice.actionIdentifier'] as string;
+}
+
+function input(body: XPCDictionary): XPCDictionary {
+  return body['CoreDevice.input'] as XPCDictionary;
+}
+
+function reply(output: XPCValue): XPCDictionary {
+  return {'CoreDevice.output': output};
+}
+
+/** Awaits `promise` and returns the rejection error, failing if it resolves. */
+async function rejection(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  throw new Error('expected the promise to reject, but it resolved');
+}
+
+describe('ConfigurationService', function () {
+  it('getUserInterfaceStyle reads output.style', async function () {
+    const fake = new FakeTransport(() => reply({style: 'dark'}));
+    const service = new TestConfigurationService(fake);
+
+    const style = await service.getUserInterfaceStyle();
+
+    expect(actionId(fake.sentBodies[0])).to.equal('com.apple.coredevice.action.getuserinterfacestyle');
+    // Action-only invocations carry no feature identifier.
+    expect(fake.sentBodies[0]['CoreDevice.featureIdentifier']).to.equal(undefined);
+    expect(style).to.equal('dark');
+  });
+
+  it('setUserInterfaceStyle sends the style input', async function () {
+    const fake = new FakeTransport(() => reply({}));
+    const service = new TestConfigurationService(fake);
+
+    await service.setUserInterfaceStyle('light');
+
+    expect(actionId(fake.sentBodies[0])).to.equal('com.apple.coredevice.action.setuserinterfacestyle');
+    expect(input(fake.sentBodies[0])).to.deep.equal({style: 'light'});
+  });
+
+  it('setUserInterfaceStyle rejects an invalid style without sending a message', async function () {
+    const fake = new FakeTransport(() => reply({}));
+    const service = new TestConfigurationService(fake);
+
+    expect(await rejection(service.setUserInterfaceStyle('sepia' as any))).to.be.instanceOf(TypeError);
+    expect(fake.sentBodies).to.have.length(0);
+  });
+
+  it('setReduceMotion sends the enabled flag', async function () {
+    const fake = new FakeTransport(() => reply({}));
+    const service = new TestConfigurationService(fake);
+
+    await service.setReduceMotion(true);
+
+    expect(actionId(fake.sentBodies[0])).to.equal('com.apple.coredevice.action.setreducemotion');
+    expect(input(fake.sentBodies[0])).to.deep.equal({reduceMotion: {enabled: true}});
+  });
+
+  it('getReduceTransparency reads the nested enabled flag', async function () {
+    const fake = new FakeTransport(() => reply({reduceTransparency: {enabled: true}}));
+    const service = new TestConfigurationService(fake);
+
+    const enabled = await service.getReduceTransparency();
+
+    expect(actionId(fake.sentBodies[0])).to.equal('com.apple.coredevice.action.getreducetransparency');
+    expect(enabled).to.equal(true);
+  });
+
+  it('getDeviceTextSize returns the first size key', async function () {
+    const fake = new FakeTransport(() => reply({textSize: {size: {large: {}}}}));
+    const service = new TestConfigurationService(fake);
+
+    const size = await service.getDeviceTextSize();
+
+    expect(actionId(fake.sentBodies[0])).to.equal('com.apple.coredevice.action.getdevicetextsize');
+    expect(size).to.equal('large');
+  });
+
+  it('setDeviceTextSize encodes the size as an enum-style single-key dict', async function () {
+    const fake = new FakeTransport(() => reply({}));
+    const service = new TestConfigurationService(fake);
+
+    await service.setDeviceTextSize('extraLarge');
+
+    expect(input(fake.sentBodies[0])).to.deep.equal({textSize: {size: {extraLarge: {}}}});
+  });
+
+  it('getColorFilter returns the colorFilter dict', async function () {
+    const fake = new FakeTransport(() => reply({colorFilter: {enabled: true, filterType: {name: 'Protanopia'}}}));
+    const service = new TestConfigurationService(fake);
+
+    const state = await service.getColorFilter();
+
+    expect(state.enabled).to.equal(true);
+    expect(state.filterType?.name).to.equal('Protanopia');
+  });
+
+  it('setColorFilter(true) requires a filterType', async function () {
+    const fake = new FakeTransport(() => reply({}));
+    const service = new TestConfigurationService(fake);
+
+    expect(await rejection(service.setColorFilter(true))).to.be.instanceOf(TypeError);
+    expect(fake.sentBodies).to.have.length(0);
+  });
+
+  it('setColorFilter(true, ...) sends filterType and Float32-quantized intensity', async function () {
+    const fake = new FakeTransport(() => reply({}));
+    const service = new TestConfigurationService(fake);
+
+    await service.setColorFilter(true, {filterType: 'Protanopia', intensity: 0.5});
+
+    expect(actionId(fake.sentBodies[0])).to.equal('com.apple.coredevice.action.setcolorfilter');
+    const filter = input(fake.sentBodies[0]).colorFilter as XPCDictionary;
+    expect(filter.enabled).to.equal(true);
+    expect(filter.filterType).to.deep.equal({name: 'Protanopia'});
+    expect(filter.intensity).to.equal(0.5);
+  });
+
+  it('setColorFilter(false) sends only enabled=false', async function () {
+    const fake = new FakeTransport(() => reply({}));
+    const service = new TestConfigurationService(fake);
+
+    await service.setColorFilter(false, {filterType: 'Protanopia'});
+
+    expect(input(fake.sentBodies[0])).to.deep.equal({colorFilter: {enabled: false}});
+  });
+
+  it('setLiquidGlassOpacity quantizes to Float32 and nests under configuration', async function () {
+    const fake = new FakeTransport(() => reply({}));
+    const service = new TestConfigurationService(fake);
+
+    await service.setLiquidGlassOpacity(0.55);
+
+    expect(actionId(fake.sentBodies[0])).to.equal('com.apple.coredevice.action.setliquidglassconfiguration');
+    const config = input(fake.sentBodies[0]).configuration as XPCDictionary;
+    expect(config.opacity).to.be.a('number');
+    expect(config.opacity as number).to.be.closeTo(0.55, 1e-6);
+    // Round-trips exactly through IEEE-754 binary32.
+    expect(config.opacity).to.equal(Math.fround(0.55));
+  });
+
+  it('setLiquidGlassOpacity rejects out-of-range values without sending', async function () {
+    const fake = new FakeTransport(() => reply({}));
+    const service = new TestConfigurationService(fake);
+
+    expect(await rejection(service.setLiquidGlassOpacity(1.5))).to.be.instanceOf(RangeError);
+    expect(fake.sentBodies).to.have.length(0);
+  });
+
+  it('closes the active transport', async function () {
+    const fake = new FakeTransport(() => reply({style: 'dark'}));
+    const service = new TestConfigurationService(fake);
+
+    await service.getUserInterfaceStyle();
+    await service.close();
+
+    expect(fake.closeCalls).to.equal(1);
+  });
+});

--- a/test/unit/configuration/configuration-service.spec.ts
+++ b/test/unit/configuration/configuration-service.spec.ts
@@ -93,16 +93,34 @@ describe('ConfigurationService', function () {
     expect(input(fake.sentBodies[0])).to.deep.equal({style: 'light'});
   });
 
-  it('setUserInterfaceStyle rejects an invalid style without sending a message', async function () {
+  it('setUserInterfaceStyle rejects an empty/non-string style without sending a message', async function () {
     const fake = new FakeTransport(() => reply({}));
     const service = new TestConfigurationService(fake);
 
-    expect(await rejection(service.setUserInterfaceStyle('sepia' as any))).to.be.instanceOf(TypeError);
+    expect(await rejection(service.setUserInterfaceStyle('' as any))).to.be.instanceOf(TypeError);
+    expect(await rejection(service.setUserInterfaceStyle(undefined as any))).to.be.instanceOf(TypeError);
     expect(fake.sentBodies).to.have.length(0);
   });
 
-  it('getUserInterfaceStyle throws on an unexpected style rather than mis-casting', async function () {
+  it('setUserInterfaceStyle forwards an unknown-but-non-empty style to the device (forward-compat)', async function () {
+    const fake = new FakeTransport(() => reply({}));
+    const service = new TestConfigurationService(fake);
+
+    // A future OS style must not be blocked client-side; let the device decide.
+    await service.setUserInterfaceStyle('auto');
+
+    expect(input(fake.sentBodies[0])).to.deep.equal({style: 'auto'});
+  });
+
+  it('getUserInterfaceStyle passes an unknown string through (forward-compat)', async function () {
     const fake = new FakeTransport(() => reply({style: 'auto'}));
+    const service = new TestConfigurationService(fake);
+
+    expect(await service.getUserInterfaceStyle()).to.equal('auto');
+  });
+
+  it('getUserInterfaceStyle throws on a missing/non-string style (malformed reply)', async function () {
+    const fake = new FakeTransport(() => reply({}));
     const service = new TestConfigurationService(fake);
 
     expect(await rejection(service.getUserInterfaceStyle())).to.be.instanceOf(CoreDeviceError);

--- a/test/unit/configuration/configuration-service.spec.ts
+++ b/test/unit/configuration/configuration-service.spec.ts
@@ -3,6 +3,7 @@ import {describe, it} from 'node:test';
 
 import {expect} from 'chai';
 
+import {CoreDeviceError} from '../../../src/index.js';
 import {decodeMessage} from '../../../src/lib/remote-xpc/xpc-protocol.js';
 import type {XPCDictionary, XPCValue} from '../../../src/lib/types.js';
 import {ConfigurationService} from '../../../src/services/ios/configuration/index.js';
@@ -100,6 +101,13 @@ describe('ConfigurationService', function () {
     expect(fake.sentBodies).to.have.length(0);
   });
 
+  it('getUserInterfaceStyle throws on an unexpected style rather than mis-casting', async function () {
+    const fake = new FakeTransport(() => reply({style: 'auto'}));
+    const service = new TestConfigurationService(fake);
+
+    expect(await rejection(service.getUserInterfaceStyle())).to.be.instanceOf(CoreDeviceError);
+  });
+
   it('setReduceMotion sends the enabled flag', async function () {
     const fake = new FakeTransport(() => reply({}));
     const service = new TestConfigurationService(fake);
@@ -139,6 +147,14 @@ describe('ConfigurationService', function () {
     expect(input(fake.sentBodies[0])).to.deep.equal({textSize: {size: {extraLarge: {}}}});
   });
 
+  it('setDeviceTextSize rejects an unknown size without sending a message', async function () {
+    const fake = new FakeTransport(() => reply({}));
+    const service = new TestConfigurationService(fake);
+
+    expect(await rejection(service.setDeviceTextSize('humongous' as any))).to.be.instanceOf(TypeError);
+    expect(fake.sentBodies).to.have.length(0);
+  });
+
   it('getColorFilter returns the colorFilter dict', async function () {
     const fake = new FakeTransport(() => reply({colorFilter: {enabled: true, filterType: {name: 'Protanopia'}}}));
     const service = new TestConfigurationService(fake);
@@ -155,6 +171,25 @@ describe('ConfigurationService', function () {
 
     expect(await rejection(service.setColorFilter(true))).to.be.instanceOf(TypeError);
     expect(fake.sentBodies).to.have.length(0);
+  });
+
+  it('setColorFilter(true) rejects an unknown filterType without sending', async function () {
+    const fake = new FakeTransport(() => reply({}));
+    const service = new TestConfigurationService(fake);
+
+    // Case-sensitive: lowercase 'grayscale' is not a valid preset.
+    expect(await rejection(service.setColorFilter(true, {filterType: 'grayscale' as any}))).to.be.instanceOf(TypeError);
+    expect(fake.sentBodies).to.have.length(0);
+  });
+
+  it('getIncreaseContrast reads the nested enabled flag', async function () {
+    const fake = new FakeTransport(() => reply({increaseContrast: {enabled: true}}));
+    const service = new TestConfigurationService(fake);
+
+    const enabled = await service.getIncreaseContrast();
+
+    expect(actionId(fake.sentBodies[0])).to.equal('com.apple.coredevice.action.getdeviceincreasecontrast');
+    expect(enabled).to.equal(true);
   });
 
   it('setColorFilter(true, ...) sends filterType and Float32-quantized intensity', async function () {


### PR DESCRIPTION
Adds `ConfigurationService` (`com.apple.coredevice.configuration`) - the `devicectl` backend for the appearance and accessibility knobs Xcode toggles.

## API
| Setting | Methods |
|---|---|
| Appearance (dark/light) | `getUserInterfaceStyle` / `setUserInterfaceStyle` |
| Dynamic Type size | `getDeviceTextSize` / `setDeviceTextSize` |
| Reduce Motion | `getReduceMotion` / `setReduceMotion` |
| Reduce Transparency | `getReduceTransparency` / `setReduceTransparency` |
| Increase Contrast | `setIncreaseContrast` (no getter) |
| Color filter | `getColorFilter` / `setColorFilter` |
| Layout borders | `getShowBorders` / `setShowBorders` |
| Liquid glass (iOS 26) | `setLiquidGlassOpacity` |


## Device-gated behaviors (surfaces a descriptive `CoreDeviceError`)
- **Liquid glass**: hardware-gated - unsupported devices reject with error 21035 even on iOS 26 iPhone 11, this might work in newer models.
- **Color filter `intensity`**: rejected with error 21056 on some devices; omit it. 
  `setColorFilter(true, {filterType: 'Grayscale'})` works.