### PR TITLE
fix: use an ephemeral relay port instead of a hardcoded 2222

### DIFF
--- a/src/lib/lockdown/index.ts
+++ b/src/lib/lockdown/index.ts
@@ -18,7 +18,8 @@ const deviceManagerLog = getLogger('DeviceManager');
 const LABEL = 'appium-internal';
 const DEFAULT_TIMEOUT = 5000;
 const DEFAULT_LOCKDOWN_PORT = 62078;
-const DEFAULT_RELAY_PORT = 2222;
+/** 0 lets the OS assign a free ephemeral port, so concurrent relays cannot collide. */
+const DEFAULT_RELAY_PORT = 0;
 /** RSD service name for lockdownd over a RemoteXPC tunnel (e.g. Apple TV Wi‑Fi). */
 const LOCKDOWN_REMOTE_UNTRUSTED = 'com.apple.mobile.lockdown.remote.untrusted';
 

--- a/src/lib/usbmux/index.ts
+++ b/src/lib/usbmux/index.ts
@@ -358,7 +358,7 @@ export class Usbmux extends BaseSocketService {
 export class RelayService {
   private readonly deviceID: string | number;
   private readonly devicePort: number;
-  private readonly relayPort: number;
+  private relayPort: number;
   private usbmuxClient: Socket | null;
   private server: Server | null;
 
@@ -366,9 +366,10 @@ export class RelayService {
    * Creates a new RelayService instance
    * @param deviceID - The device ID to connect to
    * @param devicePort - The port on the device to connect to
-   * @param relayPort - The local port to use for the relay server
+   * @param relayPort - The local port to use for the relay server. Defaults to 0, which lets the
+   * operating system assign a free ephemeral port so that concurrent relays cannot collide.
    */
-  constructor(deviceID: string | number, devicePort: number, relayPort: number = 2222) {
+  constructor(deviceID: string | number, devicePort: number, relayPort: number = 0) {
     this.deviceID = deviceID;
     this.devicePort = devicePort;
     this.relayPort = relayPort;
@@ -413,6 +414,12 @@ export class RelayService {
       }
 
       this.server.listen(this.relayPort, () => {
+        // Read back the port the OS actually assigned, so connect() dials the right one when
+        // relayPort is 0.
+        const address = this.server?.address();
+        if (address && typeof address === 'object') {
+          this.relayPort = address.port;
+        }
         log.info(`Relay server running on localhost:${this.relayPort}`);
         resolve();
       });
@@ -549,14 +556,10 @@ export async function createUsbmux(opts: Partial<SocketOptions> = {}): Promise<U
  * Connects to a device and sets up a relay service in one operation
  * @param deviceID - The device ID to connect to
  * @param port - The port on the device to connect to
- * @param relayPort - The local port to use for the relay server
+ * @param relayPort - The local port to use for the relay server. Defaults to 0 (ephemeral).
  * @returns Promise that resolves with a connected socket
  */
-export async function connectAndRelay(
-  deviceID: string | number,
-  port: number,
-  relayPort: number = 2222,
-): Promise<Socket> {
+export async function connectAndRelay(deviceID: string | number, port: number, relayPort: number = 0): Promise<Socket> {
   // Create and start the relay service
   const relay = new RelayService(deviceID, port, relayPort);
   let socket: Socket | undefined;


### PR DESCRIPTION
## Problem

`RelayService` binds a local TCP server on a hardcoded port (`2222`) purely so that it can
immediately connect to it over loopback. Because that port is a single global constant, any two
relays whose lifetimes overlap collide:

```
Error: listen EADDRINUSE: address already in use :::2222
```

Nothing outside the process ever references this port — `start()` binds it and `connect()`
immediately dials `127.0.0.1:<same port>` — so it never needed to be fixed.

This is easy to miss with a single device and unavoidable with several. Two code paths hit it
concurrently in normal use:

1. **`scripts/tunnel-creation.mjs` reconnect loops.** Startup processes devices sequentially, so no
   collision there. But `runReconnectAttempts` is per-UDID (`reconnectingByUdid` is keyed by UDID,
   not global), so N dropped devices retry *concurrently*, each once per second, each binding 2222.
   With `--reconnect-retries 0` they collide with each other indefinitely and never recover, even
   once the device is healthy again.

2. **`appium-xcuitest-driver`'s `withUsbMuxLockdown`**, which calls `createLockdownServiceByUDID`
   during session creation and takes the same relay path. Live test sessions therefore contend with
   each other and with the daemon above:

   ```
   org.openqa.selenium.WebDriverException: Failed to read lockdown via appium-ios-remotexpc
   USBMUX path for '<udid>': listen EADDRINUSE: address already in use :::2222
   ```

The knock-on effect is worse than the error itself. When a reconnect can never win the port, the
device stays absent from the tunnel registry. `getConnectedDevices()` in the XCUITest driver returns
tunnel-registry UDIDs only when the registry is reachable, so the driver then rejects a perfectly
healthy, USB-connected phone with `Unknown device or simulator UDID: '<udid>'` — an error that gives
no hint a port conflict is the cause.

## Evidence

From a 14-device iPhone farm running one shared `tunnel-creation.mjs` daemon since 2026-07-24. Two
devices stuck in unlimited reconnect, both on USB and visible to usbmuxd:

```
info DeviceManager Found device: DeviceID=21, SerialNumber=<udid>, ConnectionType=USB
ERR! TunnelCreation ❌ Failed to create tunnel for device <udid>: Error: listen EADDRINUSE: address already in use :::2222
WARN TunnelCreation Reconnecting dropped tunnel for <udid> (attempt 5807, unlimited mode)...
```

Attempt counters reached 7051 and 4029 for two devices. The log grew to 60 MB and the daemon
accumulated 242 minutes of CPU entirely from the retry/collide cycle. The tunnel registry served 12
entries while usbmuxd listed 14 devices — the two missing ones being exactly those stuck on the port.

## Reproduction

Needs one connected device and no tunnel:

```js
import {createLockdownServiceByUDID} from 'appium-ios-remotexpc';

const UDID = '<any connected udid>';
const one = async () => {
  try {
    const {lockdownService} = await createLockdownServiceByUDID(UDID);
    lockdownService.close();
    return 'ok';
  } catch (e) { return 'FAIL: ' + e.message; }
};
console.log(await Promise.all([one(), one()]));
```

Before: `[ 'FAIL: listen EADDRINUSE: address already in use :::2222', 'FAIL: ...' ]`
After: `[ 'ok', 'ok' ]`

## Change

Bind port `0` and read the OS-assigned port back off the listening server, so concurrent relays
cannot contend. Passing an explicit port still binds that port, so this is backward compatible —
only the default changes.

## Verification

Applied the equivalent change to the compiled output of 5.11.0 on the affected machine, with the
unpatched tunnel daemon still running and actively contending for 2222:

| scenario | before | after |
| --- | --- | --- |
| 2 concurrent `createLockdownServiceByUDID` | both `EADDRINUSE` | 2/2 succeeded |
| 6 concurrent | — | 6/6 succeeded |

On this branch: `npm run build`, `npm run lint`, and `npm run format:check` are clean. `npm run
test:unit` passes except for 15 pre-existing failures in `tunnel-registry-server.spec.ts`, which are
environmental on my machine — the spec writes the real strongbox `tunnelRegistryPort`, which is
root-owned there. Verified identical on unmodified `main` (15 failures, same `EACCES`), so they are
unrelated to this change.

## On test coverage

I did not add a unit test. `RelayService.start()` calls `createUsbmux()` intra-module before it
reaches the `listen()` call, so it cannot be intercepted with the existing `mockImport` helper, and
covering it would need either a real usbmuxd or an injectable usbmux factory. I did not want to
fold that refactor into a bug fix, but I'm happy to add it in whatever shape you prefer.

## Possibly worth separate issues

Neither is caused by this change, but both compound it:

1. **`tunnel-creation.mjs` never rescans for devices.** It calls `usbmux.listDevices()` once at
   startup then `await usbmux.close()`, with no attach/detach subscription. `devicesByUdid` is a
   startup snapshot and `reconnectTunnelByUdid` bails with `Cannot reconnect <udid>: device context
   not found` for anything absent from it, so a device plugged in after the daemon starts never
   receives a tunnel until a full restart.

2. **Unlimited reconnect has no backoff.** `runReconnectAttempts` retries on a flat `sleep(1000)`
   with no ceiling under `--reconnect-retries 0`. For a permanently-failing cause this is an
   unbounded hot loop — the 60 MB log and 242 CPU-minutes above. Exponential backoff, or throttling
   the log line, would make the failure mode much cheaper to live with.
