### PR TITLE
fix: stop leaked relay server when LockdownServiceFactory.createByUDID fails

### DIFF
--- a/src/lib/lockdown/index.ts
+++ b/src/lib/lockdown/index.ts
@@ -525,8 +525,11 @@ export class LockdownServiceFactory {
 
       return {lockdownService: service, device};
     } catch (err) {
-      // Clean up relay on error
-      service?.stopRelayService('Stopping relay after failure');
+      // Clean up relay on error. Route directly through `relay` (not `service`), since
+      // `service` is still undefined if relay.connect() itself is what failed.
+      await relay.stop().catch((stopErr) => {
+        log.error(`Error stopping relay after failure: ${stopErr}`);
+      });
       throw err;
     }
   }


### PR DESCRIPTION
If relay.connect() failed after relay.start() already succeeded, cleanup routed through service?.stopRelayService(...), which is a no-op since service is only assigned after a successful connect(). The already- listening relay server was never stopped, leaking its bound port for the rest of the process's life and breaking subsequent createLockdownServiceByUDID calls with EADDRINUSE.

See https://github.com/appium/appium-ios-remotexpc/pull/286 for more details