### PR TITLE
fix(display): stop captures when the recording's output file cannot be created

### DIFF
--- a/src/services/ios/display/audio/audio-stream-capture.ts
+++ b/src/services/ios/display/audio/audio-stream-capture.ts
@@ -242,7 +242,25 @@ export async function recordAudioToFile(
   const timer = setTimeout(() => controller.abort(), durationMs);
   timer.unref?.();
 
-  const writer = await M4aFileWriter.create(outputPath);
+  let writer: M4aFileWriter;
+  try {
+    writer = await M4aFileWriter.create(outputPath);
+  } catch (error) {
+    // The capture is already streaming and never escapes this function, so a
+    // caller cannot stop it. Left running, the device keeps sending into a
+    // receiver whose queue nobody drains.
+    clearTimeout(timer);
+    // Swallowed so it cannot mask the error being thrown, but logged: a failed
+    // stop means the device is still streaming, which is the leak itself.
+    await capture.stop().catch((stopError: unknown) => {
+      log.debug(
+        `Failed to stop the audio stream after the output file could not be created: ${
+          stopError instanceof Error ? stopError.message : String(stopError)
+        }`,
+      );
+    });
+    throw error;
+  }
   let written;
   try {
     for await (const unit of capture.accessUnits(controller.signal)) {

--- a/src/services/ios/display/recording/av-capture.ts
+++ b/src/services/ios/display/recording/av-capture.ts
@@ -125,7 +125,29 @@ export async function recordScreenAndAudioToFiles(
   }
 
   const videoOut = new AnnexBFileWriter(videoPath);
-  const audioOut = await M4aFileWriter.create(audioPath);
+  let audioOut: M4aFileWriter;
+  try {
+    audioOut = await M4aFileWriter.create(audioPath);
+  } catch (error) {
+    // Both captures are already streaming by now, and neither they nor the
+    // video writer escape this function, so a caller cannot release them. Left
+    // running, the device keeps encoding into a receiver whose queue nobody
+    // drains, and its RTCP keepalive keeps the session alive indefinitely.
+    // Each failure is swallowed so it cannot mask the error being thrown. The
+    // stop is still logged: if it fails the device is left streaming, which is
+    // the leak itself. One stop tears down both streams, so the second call and
+    // the file close are quiet.
+    await videoCapture.stop().catch((stopError: unknown) => {
+      log.debug(
+        `Failed to stop cleanly after the audio file could not be created: ${
+          stopError instanceof Error ? stopError.message : String(stopError)
+        }`,
+      );
+    });
+    await audioCapture.stop().catch((): void => undefined);
+    await videoOut.close().catch((): void => undefined);
+    throw error;
+  }
   let framesWritten = 0;
   let videoBytes = 0;
   let sawKeyFrame = false;

--- a/test/unit/display/audio/audio-stream-capture.spec.ts
+++ b/test/unit/display/audio/audio-stream-capture.spec.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import {mkdtemp, rm} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {after, before, describe, it} from 'node:test';
+
+import {recordAudioToFile} from '../../../../src/services/ios/display/audio/audio-stream-capture.js';
+import type {DisplayService, MediaStreamAnswer} from '../../../../src/services/ios/display/index.js';
+
+/** A stub service that negotiates without a device and counts teardowns. */
+function makeStubService(): {service: DisplayService; stopCalls: () => number} {
+  let stopCalls = 0;
+  const service = {
+    getTunnelLocalAddress: async (): Promise<string> => '::1',
+    getDeviceAddress: async (): Promise<string> => '::1',
+    startAudioStream: async (): Promise<MediaStreamAnswer> =>
+      // An empty streamConfig means no RTCP identity, so no keepalive timer is
+      // started — the negotiation is all this test needs.
+      ({clientSessionId: undefined, streamConfig: {}, connection: {}, raw: {}}) as unknown as MediaStreamAnswer,
+    stopAllMediaStreams: async (): Promise<number[]> => {
+      stopCalls += 1;
+      return [];
+    },
+  } as unknown as DisplayService;
+  return {service, stopCalls: () => stopCalls};
+}
+
+describe('recordAudioToFile', function () {
+  let directory: string;
+
+  before(async function () {
+    directory = await mkdtemp(join(tmpdir(), 'record-audio-'));
+  });
+
+  after(async function () {
+    await rm(directory, {force: true, recursive: true});
+  });
+
+  it('stops the capture when the output file cannot be created', async function () {
+    // The capture is started before the writer, so a writer that fails to open
+    // used to strand a live device stream: nothing stopped it, its UDP receiver
+    // stayed bound, and its queue grew with every packet nobody read. The
+    // capture never escapes the function, so no caller could clean it up.
+    const {service, stopCalls} = makeStubService();
+    const unwritablePath = join(directory, 'no', 'such', 'dir', 'audio.m4a');
+
+    await assert.rejects(() => recordAudioToFile(service, unwritablePath), /ENOENT/);
+
+    assert.strictEqual(stopCalls(), 1, 'the capture must be stopped before the error propagates');
+  });
+});

--- a/test/unit/display/recording/av-capture.spec.ts
+++ b/test/unit/display/recording/av-capture.spec.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import {mkdtemp, rm} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {after, before, describe, it} from 'node:test';
+
+import type {DisplayService, MediaStreamAnswer} from '../../../../src/services/ios/display/index.js';
+import {recordScreenAndAudioToFiles} from '../../../../src/services/ios/display/recording/av-capture.js';
+
+/** A stub service that negotiates without a device and counts teardowns. */
+function makeStubService(): {service: DisplayService; stopCalls: () => number} {
+  let stopCalls = 0;
+  // An empty streamConfig means no RTCP identity, so no keepalive timer is
+  // started — the negotiation is all this test needs.
+  const answer = {
+    clientSessionId: undefined,
+    streamConfig: {},
+    connection: {},
+    raw: {},
+  } as unknown as MediaStreamAnswer;
+  const service = {
+    getTunnelLocalAddress: async (): Promise<string> => '::1',
+    getDeviceAddress: async (): Promise<string> => '::1',
+    startVideoStream: async (): Promise<MediaStreamAnswer> => answer,
+    startAudioStream: async (): Promise<MediaStreamAnswer> => answer,
+    stopAllMediaStreams: async (): Promise<number[]> => {
+      stopCalls += 1;
+      return [];
+    },
+  } as unknown as DisplayService;
+  return {service, stopCalls: () => stopCalls};
+}
+
+describe('recordScreenAndAudioToFiles', function () {
+  let directory: string;
+
+  before(async function () {
+    directory = await mkdtemp(join(tmpdir(), 'record-av-'));
+  });
+
+  after(async function () {
+    await rm(directory, {force: true, recursive: true});
+  });
+
+  it('stops both captures when the audio file cannot be created', async function () {
+    // Both captures are streaming before either writer is opened, so a failing
+    // audio writer used to strand two live device streams plus the video file
+    // descriptor. None of them escape the function, so no caller could release
+    // them.
+    const {service, stopCalls} = makeStubService();
+
+    await assert.rejects(
+      () =>
+        recordScreenAndAudioToFiles(service, {
+          videoPath: join(directory, 'screen.h265'),
+          audioPath: join(directory, 'no', 'such', 'dir', 'audio.m4a'),
+        }),
+      /ENOENT/,
+    );
+
+    assert.strictEqual(stopCalls(), 2, 'both captures must be stopped before the error propagates');
+  });
+});


### PR DESCRIPTION
## The issue

`recordAudioToFile` and `recordScreenAndAudioToFiles` start their captures **before** opening the output file:

```ts
const videoCapture = await ScreenStreamCapture.start(service, {...});  // device streaming
audioCapture = await AudioStreamCapture.start(service, {...});         // device streaming

const videoOut = new AnnexBFileWriter(videoPath);
const audioOut = await M4aFileWriter.create(audioPath);   // <-- can reject
```

`M4aFileWriter.create` awaits the write stream's `'open'`, so an `audioPath` whose parent directory does not exist rejects once the device is already streaming. Nothing unwinds it: the `try`/`finally` that stops the captures does not begin until several statements later, so the rejection propagates straight out.

## What actually leaks

A file descriptor is the least of it:

- **The device keeps encoding and sending RTP**, because `stopAllMediaStreams` is never called.
- **The UDP receivers stay bound and their RTCP keepalives keep firing**, which is precisely what tells the device to keep the session alive past its 20s `RTCPTimeoutInterval`. The leak actively sustains itself.
- **Memory grows without bound.** `UdpMediaReceiver.enqueue` pushes into an unbounded array whenever no consumer is waiting, and after this failure there is no consumer, so inbound RTP accumulates for the lifetime of the process.

Neither capture escapes its function, so a caller cannot release them either. The leaked receiver also keeps the event loop alive, so a process that hits this never exits on its own.

## The fix

Both functions now release what they have already acquired before rethrowing.

`recordAudioToFile`:

```ts
let writer: M4aFileWriter;
try {
  writer = await M4aFileWriter.create(outputPath);
} catch (error) {
  clearTimeout(timer);
  await capture.stop().catch((stopError: unknown) => { log.debug(...); });
  throw error;
}
```

`recordScreenAndAudioToFiles` does the same for both captures plus the video writer.

Notes on the shape:

- Each cleanup failure is swallowed so it cannot mask the error being thrown, and **the original error is what propagates in every case**.
- A failed `stop()` is logged at debug rather than swallowed silently, since that case means the device is still streaming, which is the leak itself. The redundant second stop (one stop tears down both device streams) and the file close stay quiet, matching the existing `finally` blocks in the same functions.
- `let x: T` assigned inside the `try` with a `catch` that always throws stays definitely-assigned afterwards, so there is no `| undefined` union and no non-null assertion. This mirrors the existing `audioCapture` guard already in `av-capture.ts`.
- The catch parameter is named `stopError`, not `error`, so it cannot shadow the error being rethrown.

## Tests

Two new specs driving the real capture path against a stub `DisplayService`, asserting the teardown ran. Binding a real UDP receiver in a unit test is already established here (`test/unit/display/transport/rtp.spec.ts`).

Mutation-tested by reverting each guard in the compiled output:

```
✖ stops the capture when the output file cannot be created      0 !== 1
✖ stops both captures when the audio file cannot be created     0 !== 2
```

Exactly the leaked-teardown assertions, so they target this bug and nothing else. Worth noting: against the pre-fix build the test runner **hung** rather than failing, because the leaked receiver holds the event loop open — `--test-force-exit` was needed just to read the assertions. That is the leak demonstrating itself, and it is why the runs below deliberately omit that flag: a clean exit is evidence no handle is left behind.

| Check | Result |
| --- | --- |
| `tsc --noEmit` | clean |
| `oxlint` | clean |
| `oxfmt --check` | clean |
| Display unit tests (no `--test-force-exit`) | 166/166 pass, clean exit |

Not verified against hardware: these paths need an iOS 27 device (`npm run test:display`). What is verified is the unwind logic that was missing.

## Scope

Limited to this one issue. Two findings noted while reading the surrounding code are **not** addressed here:

1. In `recordScreenAndAudioToFiles`, `audioOut.close()` precedes `videoOut.close()` in the `finally`, so a throwing audio close skips the video close.
2. `parseRtpPacket` ignores the RTP padding bit (spec completeness; no evidence the device sets it).

One deliberate omission: `new AnnexBFileWriter(videoPath)` sits just outside the guarded region. It is synchronous and only throws on an invalid argument (a null byte in the path), not on a missing directory — pulling it inside would force a `| undefined` union on `videoOut` for no practical gain.
