### PR TITLE
fix(afc): make walk tolerant to untraversable directories

### DIFF
--- a/src/services/ios/afc/index.ts
+++ b/src/services/ios/afc/index.ts
@@ -479,14 +479,33 @@ export class AfcService {
     log.debug(`Successfully pushed file to '${remoteDst}'`);
   }
 
+  /**
+   * Recursively list `root` and everything below it. Untraversable directories are skipped
+   * rather than aborting the walk: the media sandbox exposes directories it refuses to read
+   * (e.g. `/PhotoData/UBF` answers GET_FILE_INFO but fails READ_DIR with PERM_DENIED).
+   */
   async walk(root: string): Promise<Array<{dir: string; dirs: string[]; files: string[]}>> {
     const out: Array<{dir: string; dirs: string[]; files: string[]}> = [];
-    const entries = await this.listdir(root);
+    let entries: string[];
+    try {
+      entries = await this.listdir(root);
+    } catch (error) {
+      log.debug(`Skipping '${root}' during walk, cannot list it:`, error);
+      return out;
+    }
     const dirs: string[] = [];
     const files: string[] = [];
     for (const e of entries) {
       const p = path.posix.join(root, e);
-      if (await this.isdir(p)) {
+      let isDir: boolean;
+      try {
+        isDir = await this.isdir(p);
+      } catch (error) {
+        // Unstattable entry: report it, but do not try to descend into it.
+        log.debug(`Cannot stat '${p}' during walk, treating it as a file:`, error);
+        isDir = false;
+      }
+      if (isDir) {
         dirs.push(e);
       } else {
         files.push(e);


### PR DESCRIPTION
Currently, the afc test suite errors out on the `walk()` method as some dirs throw permission denied error which errors out the whole process instead of just skipping and continuing with other valid dirs.

This change wraps the `listdir` call so an unreadable directory is skipped and logged at debug level, rather than killing the traversal. 


Error:
```
 npm run test:afc

  > appium-ios-remotexpc@5.14.3 test:afc
  > node --enable-source-maps --test --test-timeout=60000 "build/test/integration/afc.spec.js"

  ▶ AFC Service
    ✔ should list root directory and contain standard folders (133.59775ms)
    ✔ should write, read, rename and delete a file in Downloads (589.9565ms)
    ✔ should read and write files using streams (457.315375ms)
    ✔ should push and pull files between local and device (511.1235ms)
    ✖ should walk directories and include expected entries (10863.679292ms)
    ✔ should recursively pull directory with files (1755.675833ms)
    ✔ should respect overwrite option when pulling files (2186.041083ms)
    ✔ should not create empty directories when pulling with match pattern (2258.3675ms)
  ✖ AFC Service (18771.606667ms)
  ℹ tests 8
  ℹ suites 1
  ℹ pass 7
  ℹ fail 1
  ℹ cancelled 0
  ℹ skipped 0
  ℹ todo 0
  ℹ duration_ms 19277.089709

  ✖ failing tests:

  test at test/integration/afc.spec.ts:128:3
  ✖ should walk directories and include expected entries (10863.679292ms)
    Error: AFC operation READ_DIR failed with PERM_DENIED (10)
        at AfcService._doOperation (/Users/navinchandra/Documents/Projects/remote_xpc_project/appium-ios-remotexpc/src/services/ios/afc/index.ts:803:13)
        at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
        at async AfcService.listdir (/Users/navinchandra/Documents/Projects/remote_xpc_project/appium-ios-remotexpc/src/services/ios/afc/index.ts:125:18)
        at async AfcService.walk (/Users/navinchandra/Documents/Projects/remote_xpc_project/appium-ios-remotexpc/src/services/ios/afc/index.ts:484:21)
        at async AfcService.walk (/Users/navinchandra/Documents/Projects/remote_xpc_project/appium-ios-remotexpc/src/services/ios/afc/index.ts:497:20)
        at async AfcService.walk (/Users/navinchandra/Documents/Projects/remote_xpc_project/appium-ios-remotexpc/src/services/ios/afc/index.ts:497:20)
        at async TestContext.<anonymous> (/Users/navinchandra/Documents/Projects/remote_xpc_project/appium-ios-remotexpc/test/integration/afc.spec.ts:130:22)
        at async Test.run (node:internal/test_runner/test:980:9)
        at async Suite.processPendingSubtests (node:internal/test_runner/test:677:7)
```