### PR TITLE
fix: prevent crash on unhandled usbmux socket errors

### DIFF
--- a/src/lib/usbmux/index.ts
+++ b/src/lib/usbmux/index.ts
@@ -99,6 +99,10 @@ export class Usbmux extends BaseSocketService {
     this._tag = 0;
     this._responseCallbacks = {};
     this._decoder.on('data', this._handleData.bind(this));
+
+    this.on('error', (err: Error) => {
+      log.error(`Usbmux socket error: ${err.message}`);
+    });
   }
 
   /**

--- a/test/unit/usbmux/usbmux.spec.ts
+++ b/test/unit/usbmux/usbmux.spec.ts
@@ -66,6 +66,15 @@ describe('usbmux', function () {
     assert.strictEqual(devices.length, 1);
   });
 
+  it('should not throw when the socket errors without an error listener', async function () {
+    ({server, socket} = await getServerWithFixtures(fixtures.DEVICE_LIST));
+    usbmux = new Usbmux(socket);
+
+    // Emitting on the service mirrors BaseSocketService re-emitting a socket
+    // error; without a listener Node would throw.
+    usbmux.emit('error', new Error('simulated usbmuxd failure'));
+  });
+
   it('should fail due to timeout', async function () {
     ({server, socket} = await getServerWithFixtures());
     usbmux = new Usbmux(socket);


### PR DESCRIPTION
`BaseSocketService` re-emits socket errors on the service instance, but no `Usbmux` consumer subscribes to `error`. An `error` event with no listener throws an uncaught exception, so any usbmuxd socket failure crashed the process.

This registers an `error` listener in the `Usbmux` constructor that logs the failure instead, with a unit test covering the no-listener case.
