### PR TITLE
fix: surface webinspector receive errors to the message iterator

### DIFF
--- a/src/services/ios/webinspector/index.ts
+++ b/src/services/ios/webinspector/index.ts
@@ -105,8 +105,15 @@ export class WebInspectorService extends BaseService {
       }
     };
 
+    let receiveError: unknown = null;
+    const errorHandler = (error: unknown) => {
+      receiveError = error;
+      stopHandler();
+    };
+
     this.messageEmitter.on('message', messageHandler);
     this.messageEmitter.once('stop', stopHandler);
+    this.messageEmitter.once('errorMessage', errorHandler);
 
     try {
       while (!stopped) {
@@ -133,9 +140,14 @@ export class WebInspectorService extends BaseService {
           yield message;
         }
       }
+
+      if (receiveError) {
+        throw receiveError;
+      }
     } finally {
       this.messageEmitter.off('message', messageHandler);
       this.messageEmitter.off('stop', stopHandler);
+      this.messageEmitter.off('errorMessage', errorHandler);
     }
   }
 
@@ -160,6 +172,7 @@ export class WebInspectorService extends BaseService {
     // Remove all listeners to prevent memory leaks and ensure clean restart
     this.messageEmitter.removeAllListeners('message');
     this.messageEmitter.removeAllListeners('stop');
+    this.messageEmitter.removeAllListeners('errorMessage');
   }
 
   /**
@@ -382,9 +395,9 @@ export class WebInspectorService extends BaseService {
               continue;
             }
 
-            // For other errors, log and exit
+            // For other errors, log and end the iterator
             log.error('Error receiving message:', error);
-            this.messageEmitter.emit('error', error);
+            this.messageEmitter.emit('errorMessage', error);
             break;
           }
         }

--- a/test/unit/webinspector/webinspector.spec.ts
+++ b/test/unit/webinspector/webinspector.spec.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import {describe, it} from 'node:test';
+
+import WebInspectorService from '../../../src/services/ios/webinspector/index.js';
+
+describe('WebInspectorService', function () {
+  describe('listenMessage', function () {
+    it('should throw receive errors to the consumer instead of crashing the process', async function () {
+      const service = new WebInspectorService('test-udid');
+      const receiveError = new Error('socket lost');
+
+      const fakeConnection = {
+        receive: async (): Promise<never> => {
+          throw receiveError;
+        },
+      };
+      (service as unknown as {connection: unknown}).connection = fakeConnection;
+
+      await assert.rejects(async () => {
+        for await (const _ of service.listenMessage()) {
+          // no messages expected
+        }
+      }, /socket lost/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Receive failures in the WebInspector listen loop were emitted on the unlistened `error` event, which crashed the process. They are now emitted as `errorMessage`, the iterator stops, and the error is rethrown to the `listenMessage` consumer.

## Changes

- Emit `errorMessage` instead of `error` on receive failure
- `listenMessage` stops on `errorMessage` and rethrows the error to the caller
- Clean up the `errorMessage` listener on iterator exit and in `stopListening`
- Add a unit test covering the error propagation