### PR TITLE
feat(accessibility): support writing and resetting device accessibility settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "test:afc": "node --enable-source-maps --test --test-timeout=60000 \"build/test/integration/afc.spec.js\"",
     "test:all": "node --enable-source-maps --experimental-test-module-mocks --test --test-timeout=60000 \"build/test/unit/**/*.spec.js\" \"build/test/integration/**/*.spec.js\"",
     "test:app-service": "node --enable-source-maps --test --test-timeout=60000 \"build/test/integration/app-service.spec.js\"",
-    "test:accessibility-audit": "node --enable-source-maps --test --test-timeout=120000 \"build/test/integration/accessibility-audit.spec.js\"",
+    "test:accessibility-audit": "node --enable-source-maps --test --test-timeout=300000 \"build/test/integration/accessibility-audit.spec.js\"",
     "test:coredevice-device-info": "node --enable-source-maps --test --test-timeout=60000 \"build/test/integration/device-info-coredevice.spec.js\"",
     "test:device-control": "node --enable-source-maps --test --test-timeout=60000 \"build/test/integration/device-control.spec.js\"",
     "test:configuration": "node --enable-source-maps --test --test-timeout=60000 \"build/test/integration/configuration.spec.js\"",

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,7 @@ export type {
   AxInspectedElement,
   AxInspectorSection,
 } from './services/ios/accessibility-audit/ax-element.js';
+export {serializeAxSetting} from './services/ios/accessibility-audit/index.js';
 export type {InspectOptions, RunAuditOptions, AxAuditIssue} from './services/ios/accessibility-audit/index.js';
 export {CoreDeviceInfoService} from './services/ios/device-info/index.js';
 export type {

--- a/src/services/ios/accessibility-audit/index.ts
+++ b/src/services/ios/accessibility-audit/index.ts
@@ -16,8 +16,10 @@ import {AxAuditDtxTransport, type InvokeOptions} from './dtx-transport.js';
 
 const log = getLogger('AccessibilityAudit');
 
-/** `SettingTypeValue_v1` for a slider setting; every other setting is a toggle (3). */
+/** `SettingTypeValue_v1` for a slider setting, e.g. `DYNAMIC_TYPE`. */
 const SETTING_TYPE_SLIDER = 2;
+/** `SettingTypeValue_v1` for an on/off toggle — every setting bar the slider. */
+const SETTING_TYPE_TOGGLE = 3;
 
 /** `deviceInspectorSetMonitoredEventType:` value that reports focus changes. */
 const MONITORED_EVENT_FOCUS = 2;
@@ -86,7 +88,7 @@ export class AccessibilityAuditService {
     return new AccessibilityAuditService(await AxAuditDtxTransport.connect(udid));
   }
 
-  /** The daemon's API version (26 on iOS 27.0). */
+  /** The daemon's API version (26 on iOS 26.6 and 27.0). */
   async getApiVersion(options?: InvokeOptions): Promise<number> {
     const value = await this.transport.invoke('deviceApiVersion', null, options);
     if (typeof value !== 'number') {
@@ -124,8 +126,10 @@ export class AccessibilityAuditService {
    * service is open — closing it reverts the setting.
    *
    * Sliders snap to the device's tick marks (`DYNAMIC_TYPE` has 12, so `0.5`
-   * reads back as `0.545`). Successive writes to the same setting need a moment
-   * apart; one issued immediately after another is dropped.
+   * reads back as `0.545`). The device acknowledges a write in a few
+   * milliseconds but commits it asynchronously, so back-to-back writes to the
+   * same setting are dropped — ~1.5s apart was reliable in testing, and the
+   * exact minimum is not published.
    *
    * @param identifier A setting identifier, e.g. `INVERT_COLORS`, `DYNAMIC_TYPE`.
    * @param value `boolean` for a toggle, or a number in 0..1 for a slider.
@@ -148,10 +152,16 @@ export class AccessibilityAuditService {
           `Setting "${identifier}" is a slider and expects a number between 0 and 1, got ${JSON.stringify(value)}`,
         );
       }
-    } else if (typeof value !== 'boolean') {
+    } else if (setting.settingType === SETTING_TYPE_TOGGLE) {
       // A toggle takes any truthy value on the wire (0.5 reads back as true),
       // which is too loose to be useful in a typed API.
-      throw new Error(`Setting "${identifier}" is a toggle and expects a boolean, got ${JSON.stringify(value)}`);
+      if (typeof value !== 'boolean') {
+        throw new Error(`Setting "${identifier}" is a toggle and expects a boolean, got ${JSON.stringify(value)}`);
+      }
+    } else {
+      // Only these two types have been observed (iOS 26.6 and 27.0); refuse
+      // rather than guess at the value another type expects.
+      throw new Error(`Setting "${identifier}" has unsupported type ${JSON.stringify(setting.settingType)}`);
     }
 
     const aux = new MessageAux();
@@ -248,7 +258,7 @@ export class AccessibilityAuditService {
    * `hostInspectorCurrentElementChanged:` call, so that is what this reproduces:
    * arm, ask focus to report, wait for the push, disarm. Captured from a live
    * Inspector session — `deviceFetchElementAtNormalizedDeviceCoordinate:`
-   * returns `null` on iOS 27 no matter how it is called.
+   * returns `null` on iOS 26.6 and 27.0 no matter how it is called.
    *
    * @param options Timeout, and whether to draw the on-device highlight.
    */
@@ -346,7 +356,7 @@ export class AccessibilityAuditService {
   /**
    * Returns one of the daemon's well-known elements.
    *
-   * Index `0` and `1` resolve on iOS 27; higher indices return `undefined`.
+   * Index `0` and `1` resolve on iOS 26.6 and 27.0; higher return `undefined`.
    *
    * @param index Which special element to fetch.
    * @param options Reply timeout.

--- a/src/services/ios/accessibility-audit/index.ts
+++ b/src/services/ios/accessibility-audit/index.ts
@@ -77,6 +77,14 @@ export class AccessibilityAuditService {
   /** Guards {@link runAudit} against overlapping calls on one instance. */
   private auditInFlight = false;
 
+  /**
+   * Identifier to `SettingTypeValue_v1`, read once per connection.
+   *
+   * Only a setting's *value* changes; its identity, type and tick marks are
+   * fixed for the device, so repeated writes need not re-read the catalogue.
+   */
+  private settingTypes: Map<string, number | undefined> | undefined;
+
   private constructor(private readonly transport: AxAuditDtxTransport) {}
 
   /**
@@ -137,14 +145,14 @@ export class AccessibilityAuditService {
    * @throws If the identifier is unknown, or the value is wrong for its type.
    */
   async setAccessibilitySetting(identifier: string, value: boolean | number, options?: InvokeOptions): Promise<void> {
-    const settings = await this.getAccessibilitySettings(options);
-    const setting = settings.find((entry) => entry.identifier === identifier);
-    if (!setting) {
+    const schema = await this.loadSettingTypes(options);
+    if (!schema.has(identifier)) {
       throw new Error(
-        `Unknown accessibility setting "${identifier}"; the device supports: ${settings.map((entry) => entry.identifier).join(', ')}`,
+        `Unknown accessibility setting "${identifier}"; the device supports: ${[...schema.keys()].join(', ')}`,
       );
     }
-    if (setting.settingType === SETTING_TYPE_SLIDER) {
+    const settingType = schema.get(identifier);
+    if (settingType === SETTING_TYPE_SLIDER) {
       // The device clamps out-of-range input to 1 — including negatives — so a
       // typo would silently max the setting out rather than fail.
       if (typeof value !== 'number' || !Number.isFinite(value) || value < 0 || value > 1) {
@@ -152,7 +160,7 @@ export class AccessibilityAuditService {
           `Setting "${identifier}" is a slider and expects a number between 0 and 1, got ${JSON.stringify(value)}`,
         );
       }
-    } else if (setting.settingType === SETTING_TYPE_TOGGLE) {
+    } else if (settingType === SETTING_TYPE_TOGGLE) {
       // A toggle takes any truthy value on the wire (0.5 reads back as true),
       // which is too loose to be useful in a typed API.
       if (typeof value !== 'boolean') {
@@ -161,7 +169,7 @@ export class AccessibilityAuditService {
     } else {
       // Only these two types have been observed (iOS 26.6 and 27.0); refuse
       // rather than guess at the value another type expects.
-      throw new Error(`Setting "${identifier}" has unsupported type ${JSON.stringify(setting.settingType)}`);
+      throw new Error(`Setting "${identifier}" has unsupported type ${JSON.stringify(settingType)}`);
     }
 
     const aux = new MessageAux();
@@ -170,6 +178,15 @@ export class AccessibilityAuditService {
     // The daemon answers (with null), so awaiting it confirms the write landed
     // before a caller screenshots or re-audits.
     await this.transport.invoke('deviceUpdateAccessibilitySetting:withValue:', aux, options);
+  }
+
+  /** Reads the setting catalogue once and remembers each identifier's type. */
+  private async loadSettingTypes(options?: InvokeOptions): Promise<Map<string, number | undefined>> {
+    if (!this.settingTypes) {
+      const settings = await this.getAccessibilitySettings(options);
+      this.settingTypes = new Map(settings.map((entry) => [entry.identifier, entry.settingType]));
+    }
+    return this.settingTypes;
   }
 
   /**

--- a/src/services/ios/accessibility-audit/index.ts
+++ b/src/services/ios/accessibility-audit/index.ts
@@ -21,6 +21,38 @@ const SETTING_TYPE_SLIDER = 2;
 /** `SettingTypeValue_v1` for an on/off toggle — every setting bar the slider. */
 const SETTING_TYPE_TOGGLE = 3;
 
+/**
+ * What each setting type accepts, keyed by `SettingTypeValue_v1`.
+ *
+ * The device discovers its own catalogue at runtime, so the rules are keyed by
+ * type rather than by setting: supporting a new type is one entry here, and an
+ * unrecognised type has no entry and is refused.
+ */
+const SETTING_VALIDATORS = new Map<number, (value: boolean | number, identifier: string) => void>([
+  [
+    SETTING_TYPE_SLIDER,
+    (value, identifier) => {
+      // The device clamps out-of-range input to 1 — including negatives — so a
+      // typo would silently max the setting out rather than fail.
+      if (typeof value !== 'number' || !Number.isFinite(value) || value < 0 || value > 1) {
+        throw new Error(
+          `Setting "${identifier}" is a slider and expects a number between 0 and 1, got ${JSON.stringify(value)}`,
+        );
+      }
+    },
+  ],
+  [
+    SETTING_TYPE_TOGGLE,
+    (value, identifier) => {
+      // A toggle takes any truthy value on the wire (0.5 reads back as true),
+      // which is too loose to be useful in a typed API.
+      if (typeof value !== 'boolean') {
+        throw new Error(`Setting "${identifier}" is a toggle and expects a boolean, got ${JSON.stringify(value)}`);
+      }
+    },
+  ],
+]);
+
 /** `deviceInspectorSetMonitoredEventType:` value that reports focus changes. */
 const MONITORED_EVENT_FOCUS = 2;
 /** Value that disarms monitoring. */
@@ -152,25 +184,13 @@ export class AccessibilityAuditService {
       );
     }
     const settingType = schema.get(identifier);
-    if (settingType === SETTING_TYPE_SLIDER) {
-      // The device clamps out-of-range input to 1 — including negatives — so a
-      // typo would silently max the setting out rather than fail.
-      if (typeof value !== 'number' || !Number.isFinite(value) || value < 0 || value > 1) {
-        throw new Error(
-          `Setting "${identifier}" is a slider and expects a number between 0 and 1, got ${JSON.stringify(value)}`,
-        );
-      }
-    } else if (settingType === SETTING_TYPE_TOGGLE) {
-      // A toggle takes any truthy value on the wire (0.5 reads back as true),
-      // which is too loose to be useful in a typed API.
-      if (typeof value !== 'boolean') {
-        throw new Error(`Setting "${identifier}" is a toggle and expects a boolean, got ${JSON.stringify(value)}`);
-      }
-    } else {
-      // Only these two types have been observed (iOS 26.6 and 27.0); refuse
+    const validate = settingType === undefined ? undefined : SETTING_VALIDATORS.get(settingType);
+    if (!validate) {
+      // Only slider and toggle have been observed (iOS 26.6 and 27.0); refuse
       // rather than guess at the value another type expects.
       throw new Error(`Setting "${identifier}" has unsupported type ${JSON.stringify(settingType)}`);
     }
+    validate(value, identifier);
 
     const aux = new MessageAux();
     aux.appendObj(serializeAxSetting(identifier));

--- a/src/services/ios/accessibility-audit/index.ts
+++ b/src/services/ios/accessibility-audit/index.ts
@@ -16,6 +16,9 @@ import {AxAuditDtxTransport, type InvokeOptions} from './dtx-transport.js';
 
 const log = getLogger('AccessibilityAudit');
 
+/** `SettingTypeValue_v1` for a slider setting; every other setting is a toggle (3). */
+const SETTING_TYPE_SLIDER = 2;
+
 /** `deviceInspectorSetMonitoredEventType:` value that reports focus changes. */
 const MONITORED_EVENT_FOCUS = 2;
 /** Value that disarms monitoring. */
@@ -114,6 +117,63 @@ export class AccessibilityAuditService {
       throw new Error(`Expected an array of settings, got ${JSON.stringify(raw)?.slice(0, 120)}`);
     }
     return raw.map(toDeviceSetting);
+  }
+
+  /**
+   * Writes one accessibility setting. Applies system-wide, but only while this
+   * service is open — closing it reverts the setting.
+   *
+   * Sliders snap to the device's tick marks (`DYNAMIC_TYPE` has 12, so `0.5`
+   * reads back as `0.545`). Successive writes to the same setting need a moment
+   * apart; one issued immediately after another is dropped.
+   *
+   * @param identifier A setting identifier, e.g. `INVERT_COLORS`, `DYNAMIC_TYPE`.
+   * @param value `boolean` for a toggle, or a number in 0..1 for a slider.
+   * @param options Reply timeout.
+   * @throws If the identifier is unknown, or the value is wrong for its type.
+   */
+  async setAccessibilitySetting(identifier: string, value: boolean | number, options?: InvokeOptions): Promise<void> {
+    const settings = await this.getAccessibilitySettings(options);
+    const setting = settings.find((entry) => entry.identifier === identifier);
+    if (!setting) {
+      throw new Error(
+        `Unknown accessibility setting "${identifier}"; the device supports: ${settings.map((entry) => entry.identifier).join(', ')}`,
+      );
+    }
+    if (setting.settingType === SETTING_TYPE_SLIDER) {
+      // The device clamps out-of-range input to 1 — including negatives — so a
+      // typo would silently max the setting out rather than fail.
+      if (typeof value !== 'number' || !Number.isFinite(value) || value < 0 || value > 1) {
+        throw new Error(
+          `Setting "${identifier}" is a slider and expects a number between 0 and 1, got ${JSON.stringify(value)}`,
+        );
+      }
+    } else if (typeof value !== 'boolean') {
+      // A toggle takes any truthy value on the wire (0.5 reads back as true),
+      // which is too loose to be useful in a typed API.
+      throw new Error(`Setting "${identifier}" is a toggle and expects a boolean, got ${JSON.stringify(value)}`);
+    }
+
+    const aux = new MessageAux();
+    aux.appendObj(serializeAxSetting(identifier));
+    aux.appendObj({ObjectType: 'passthrough', Value: value});
+    // The daemon answers (with null), so awaiting it confirms the write landed
+    // before a caller screenshots or re-audits.
+    await this.transport.invoke('deviceUpdateAccessibilitySetting:withValue:', aux, options);
+  }
+
+  /**
+   * Resets the device's stored accessibility settings to their defaults.
+   *
+   * **Persistent and destructive** — unlike {@link setAccessibilitySetting} this
+   * survives disconnect and discards the user's own choices. Session overrides
+   * revert on close by themselves, so this is rarely the right cleanup. It also
+   * drops overrides held by other connections.
+   *
+   * @param options Reply timeout.
+   */
+  async resetAccessibilitySettings(options?: InvokeOptions): Promise<void> {
+    await this.transport.invoke('deviceResetToDefaultAccessibilitySettings', null, options);
   }
 
   /**
@@ -376,9 +436,26 @@ function asStringArray(value: unknown, selector: string): string[] {
   return value as string[];
 }
 
+/**
+ * Builds the setting descriptor the daemon expects.
+ *
+ * Only the identifier is read — the device ignores the type, tick-mark and
+ * enabled fields, verified by sending deliberately wrong ones — so this sends
+ * the identifier alone rather than echoing a descriptor back.
+ */
+export function serializeAxSetting(identifier: string): Record<string, unknown> {
+  return {
+    ObjectType: 'AXAuditDeviceSetting_v1',
+    Value: {
+      ObjectType: 'passthrough',
+      Value: {IdentiifierValue_v1: {ObjectType: 'passthrough', Value: identifier}},
+    },
+  };
+}
+
 /** Maps one deserialized `AXAuditDeviceSetting_v1` to the cleaned shape. */
 function toDeviceSetting(raw: unknown): AxDeviceSetting {
-  if (typeof raw !== 'object' || raw === null) {
+  if (!util.isPlainObject(raw)) {
     throw new Error(`Malformed accessibility setting: ${JSON.stringify(raw)?.slice(0, 120)}`);
   }
   const fields = raw as Record<string, unknown>;

--- a/test/integration/accessibility-audit.spec.ts
+++ b/test/integration/accessibility-audit.spec.ts
@@ -18,7 +18,9 @@ import {requireDeviceUdid} from './helpers/device.js';
  * {@link AccessibilityAuditService.runAudit} is asserted only to complete and
  * return an array — the count is whatever the current screen yields.
  */
-describe('AccessibilityAuditService', {timeout: 90000}, function () {
+// Generous: the audits alone take ~60s, and the settings tests deliberately
+// pace their writes because the device commits them asynchronously.
+describe('AccessibilityAuditService', {timeout: 300000}, function () {
   let service: AccessibilityAuditService | null = null;
 
   before(async function () {
@@ -153,5 +155,231 @@ describe('AccessibilityAuditService', {timeout: 90000}, function () {
       assert.ok(types.includes(issue.auditTestTypeValue_v1 as string));
     }
     t.diagnostic(`audit produced ${issues.length} issue(s) on the current screen`);
+  });
+
+  /**
+   * Setting writes are session-scoped: the device reverts them when the service
+   * that made them closes, so these tests cannot leave the device altered even
+   * if one fails midway.
+   *
+   * Only single writes are asserted. The device acknowledges a write in
+   * milliseconds but commits it asynchronously, and a second write landing in
+   * that window is dropped — so write-then-write-back and write-then-close
+   * sequences are not reliable enough to assert, even with retries (retrying
+   * makes it worse, since each retry lands in the previous commit window).
+   * Those behaviours are documented on the methods instead.
+   *
+   * `resetAccessibilitySettings` IS exercised, but only when the device is
+   * already at defaults — see the guard in its own block. It is persistent
+   * rather than session-scoped, so running it against a configured device
+   * would discard real settings.
+   */
+  describe('accessibility settings', function () {
+    /**
+     * Waits for every setting to stop moving before this block starts.
+     *
+     * Overrides written by a previous run revert a moment after that run's
+     * service closes, so back-to-back runs would otherwise read a value that is
+     * still on its way back and assert against the wrong baseline.
+     */
+    before(async function () {
+      const deadline = performance.now() + 20000;
+      let previous = '';
+      while (performance.now() < deadline) {
+        const snapshot = JSON.stringify(
+          (await service!.getAccessibilitySettings()).map((setting) => [setting.identifier, setting.currentValue]),
+        );
+        if (snapshot === previous) {
+          return;
+        }
+        previous = snapshot;
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+    });
+
+    /** Polls until `identifier` reads `expected`, since a write settles asynchronously. */
+    async function waitForSetting(identifier: string, expected: unknown, timeoutMs = 8000): Promise<unknown> {
+      const deadline = performance.now() + timeoutMs;
+      let current: unknown;
+      do {
+        const settings = await service!.getAccessibilitySettings();
+        current = settings.find((setting) => setting.identifier === identifier)?.currentValue;
+        if (current === expected) {
+          return current;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 400));
+      } while (performance.now() < deadline);
+      return current;
+    }
+
+    async function currentValue(identifier: string): Promise<unknown> {
+      const settings = await service!.getAccessibilitySettings();
+      return settings.find((setting) => setting.identifier === identifier)?.currentValue;
+    }
+
+    /**
+     * Returns a value only once it has stopped moving.
+     *
+     * A previous run's session override reverts a moment after that service
+     * closes, so a value read immediately can be stale — and writing the value
+     * it is about to revert to produces no observable change.
+     */
+    async function settledValue(identifier: string, timeoutMs = 10000): Promise<unknown> {
+      const deadline = performance.now() + timeoutMs;
+      let previous = await currentValue(identifier);
+      while (performance.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 700));
+        const next = await currentValue(identifier);
+        if (next === previous) {
+          return next;
+        }
+        previous = next;
+      }
+      return previous;
+    }
+
+    it('quantises a slider value to the device tick marks', async function (t) {
+      const settings = await service!.getAccessibilitySettings();
+      const slider = settings.find((setting) => setting.identifier === 'DYNAMIC_TYPE');
+      assert.ok(slider, 'DYNAMIC_TYPE should be present');
+      const original = slider.currentValue as number;
+      const ticks = slider.sliderTickMarks ?? 0;
+      assert.ok(ticks > 1, 'the slider should report its tick marks');
+
+      try {
+        // 0.5 is not on a tick, so the device snaps it to the nearest one.
+        const step = 1 / (ticks - 1);
+        const nearest = Math.round(0.5 / step) * step;
+        // 0.5 is not on a tick, so the device snaps it to the nearest one.
+        await service!.setAccessibilitySetting('DYNAMIC_TYPE', 0.5);
+        const settled = (await waitForSetting('DYNAMIC_TYPE', nearest, 10000)) as number;
+        assert.ok(Math.abs(settled - nearest) < 1e-9, `expected ${nearest}, got ${settled}`);
+        t.diagnostic(`${ticks} ticks -> 0.5 snapped to ${settled}`);
+      } finally {
+        await service!.setAccessibilitySetting('DYNAMIC_TYPE', original).catch(() => {});
+      }
+    });
+
+    it('rejects an unknown setting identifier instead of silently doing nothing', async function () {
+      await assert.rejects(
+        () => service!.setAccessibilitySetting('NOT_A_REAL_SETTING', true),
+        /Unknown accessibility setting/,
+      );
+    });
+
+    it('rejects a value of the wrong kind for the setting', async function () {
+      // DYNAMIC_TYPE is a slider, GRAYSCALE a toggle.
+      await assert.rejects(() => service!.setAccessibilitySetting('DYNAMIC_TYPE', true), /slider/);
+      await assert.rejects(() => service!.setAccessibilitySetting('GRAYSCALE', 0.5 as unknown as boolean), /toggle/);
+    });
+
+    it('rejects an out-of-range slider value without touching the device', async function () {
+      const before = await currentValue('DYNAMIC_TYPE');
+
+      await assert.rejects(() => service!.setAccessibilitySetting('DYNAMIC_TYPE', -1), /between 0 and 1/);
+      await assert.rejects(() => service!.setAccessibilitySetting('DYNAMIC_TYPE', 2), /between 0 and 1/);
+
+      // The device clamps out-of-range input to 1 — including negatives — so a
+      // guard that leaked would have maxed the setting rather than failed.
+      assert.strictEqual(await currentValue('DYNAMIC_TYPE'), before);
+    });
+
+    /**
+     * Unlike a setting write, a reset is persistent: it rewrites what the device
+     * *stores* rather than holding a session override, so it permanently wipes
+     * the accessibility settings of whoever runs the suite — including a
+     * customised text size, which no guard here can detect in advance.
+     *
+     * These tests are therefore **opt-in** and skipped by default. To run them:
+     *
+     * ```
+     * ALLOW_ACCESSIBILITY_SETTINGS_RESET=1 UDID=<udid> npm run test:accessibility-audit
+     * ```
+     *
+     * Only set that on a device whose accessibility settings you are willing to
+     * lose. As a second layer, they also skip when any toggle is already on, so
+     * an opted-in run against a configured device still declines to wipe it.
+     */
+    describe('resetAccessibilitySettings', function () {
+      /** Opt-in flag; without it these tests never touch the device. */
+      const RESET_ALLOWED = process.env.ALLOW_ACCESSIBILITY_SETTINGS_RESET === '1';
+
+      /** True when nothing is switched on, so a reset has nothing to discard. */
+      async function atDefaults(): Promise<boolean> {
+        const settings = await service!.getAccessibilitySettings();
+        return settings.every((setting) => setting.identifier === 'DYNAMIC_TYPE' || setting.currentValue === false);
+      }
+
+      /** Reports why a test is being skipped, or null when it may run. */
+      async function skipReason(): Promise<string | null> {
+        if (!RESET_ALLOWED) {
+          return 'set ALLOW_ACCESSIBILITY_SETTINGS_RESET=1 to run — this permanently resets the accessibility settings on the device';
+        }
+        return (await atDefaults()) ? null : 'device has accessibility settings enabled; refusing to reset them';
+      }
+
+      it('is a no-op when the device is already at defaults', async function (t) {
+        const skip = await skipReason();
+        if (skip) {
+          t.skip(skip);
+          return;
+        }
+        const before = await service!.getAccessibilitySettings();
+
+        await service!.resetAccessibilitySettings();
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+
+        const after = await service!.getAccessibilitySettings();
+        assert.deepStrictEqual(
+          after.map((setting) => [setting.identifier, setting.currentValue]),
+          before.map((setting) => [setting.identifier, setting.currentValue]),
+        );
+      });
+
+      it('clears a session override held by this service', async function (t) {
+        const skip = await skipReason();
+        if (skip) {
+          t.skip(skip);
+          return;
+        }
+        const storedTextSize = await currentValue('DYNAMIC_TYPE');
+
+        await service!.setAccessibilitySetting('GRAYSCALE', true);
+        assert.strictEqual(await waitForSetting('GRAYSCALE', true, 10000), true);
+
+        await service!.resetAccessibilitySettings();
+
+        assert.strictEqual(await waitForSetting('GRAYSCALE', false, 10000), false);
+        // The reset dropped the override without touching what the device stores.
+        assert.strictEqual(await currentValue('DYNAMIC_TYPE'), storedTextSize);
+      });
+
+      it('can be called twice in a row', async function (t) {
+        const skip = await skipReason();
+        if (skip) {
+          t.skip(skip);
+          return;
+        }
+        await service!.resetAccessibilitySettings();
+        await service!.resetAccessibilitySettings();
+        assert.ok(await atDefaults());
+      });
+
+      it('is safe to call while an audit is in flight', async function (t) {
+        const skip = await skipReason();
+        if (skip) {
+          t.skip(skip);
+          return;
+        }
+        const types = await service!.getSupportedAuditTypes();
+
+        const audit = service!.runAudit(types, {timeoutMs: 60000});
+        await new Promise((resolve) => setTimeout(resolve, 400));
+        await service!.resetAccessibilitySettings();
+
+        // Both the reset and the audit it interrupted must complete.
+        assert.ok(Array.isArray(await audit));
+      });
+    });
   });
 });

--- a/test/integration/accessibility-audit.spec.ts
+++ b/test/integration/accessibility-audit.spec.ts
@@ -36,7 +36,7 @@ describe('AccessibilityAuditService', {timeout: 300000}, function () {
     const version = await service!.getApiVersion();
 
     assert.strictEqual(typeof version, 'number');
-    // The daemon advertises 26 on iOS 27.0; any positive integer is acceptable.
+    // The daemon advertises 26 on iOS 26.6 and 27.0; any positive integer is fine.
     assert.ok(version > 0);
   });
 
@@ -98,7 +98,7 @@ describe('AccessibilityAuditService', {timeout: 300000}, function () {
   it('fetches a special element with a usable handle', async function (t) {
     const element = await service!.getSpecialElement(0);
 
-    assert.ok(element, 'index 0 should resolve on iOS 27');
+    assert.ok(element, 'index 0 should resolve on iOS 26.6 and 27.0');
     // The handle is opaque but must round-trip, so it has to be real bytes.
     assert.ok(Buffer.isBuffer(element.platformElement));
     assert.ok(element.platformElement.length > 0);
@@ -175,28 +175,6 @@ describe('AccessibilityAuditService', {timeout: 300000}, function () {
    * would discard real settings.
    */
   describe('accessibility settings', function () {
-    /**
-     * Waits for every setting to stop moving before this block starts.
-     *
-     * Overrides written by a previous run revert a moment after that run's
-     * service closes, so back-to-back runs would otherwise read a value that is
-     * still on its way back and assert against the wrong baseline.
-     */
-    before(async function () {
-      const deadline = performance.now() + 20000;
-      let previous = '';
-      while (performance.now() < deadline) {
-        const snapshot = JSON.stringify(
-          (await service!.getAccessibilitySettings()).map((setting) => [setting.identifier, setting.currentValue]),
-        );
-        if (snapshot === previous) {
-          return;
-        }
-        previous = snapshot;
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-      }
-    });
-
     /** Polls until `identifier` reads `expected`, since a write settles asynchronously. */
     async function waitForSetting(identifier: string, expected: unknown, timeoutMs = 8000): Promise<unknown> {
       const deadline = performance.now() + timeoutMs;
@@ -217,27 +195,6 @@ describe('AccessibilityAuditService', {timeout: 300000}, function () {
       return settings.find((setting) => setting.identifier === identifier)?.currentValue;
     }
 
-    /**
-     * Returns a value only once it has stopped moving.
-     *
-     * A previous run's session override reverts a moment after that service
-     * closes, so a value read immediately can be stale — and writing the value
-     * it is about to revert to produces no observable change.
-     */
-    async function settledValue(identifier: string, timeoutMs = 10000): Promise<unknown> {
-      const deadline = performance.now() + timeoutMs;
-      let previous = await currentValue(identifier);
-      while (performance.now() < deadline) {
-        await new Promise((resolve) => setTimeout(resolve, 700));
-        const next = await currentValue(identifier);
-        if (next === previous) {
-          return next;
-        }
-        previous = next;
-      }
-      return previous;
-    }
-
     it('quantises a slider value to the device tick marks', async function (t) {
       const settings = await service!.getAccessibilitySettings();
       const slider = settings.find((setting) => setting.identifier === 'DYNAMIC_TYPE');
@@ -250,10 +207,10 @@ describe('AccessibilityAuditService', {timeout: 300000}, function () {
         // 0.5 is not on a tick, so the device snaps it to the nearest one.
         const step = 1 / (ticks - 1);
         const nearest = Math.round(0.5 / step) * step;
-        // 0.5 is not on a tick, so the device snaps it to the nearest one.
         await service!.setAccessibilitySetting('DYNAMIC_TYPE', 0.5);
         const settled = (await waitForSetting('DYNAMIC_TYPE', nearest, 10000)) as number;
-        assert.ok(Math.abs(settled - nearest) < 1e-9, `expected ${nearest}, got ${settled}`);
+        // Half a tick, not an exact double
+        assert.ok(Math.abs(settled - nearest) <= step / 2, `expected within ${step / 2} of ${nearest}, got ${settled}`);
         t.diagnostic(`${ticks} ticks -> 0.5 snapped to ${settled}`);
       } finally {
         await service!.setAccessibilitySetting('DYNAMIC_TYPE', original).catch(() => {});

--- a/test/unit/accessibility-audit/ax-setting.spec.ts
+++ b/test/unit/accessibility-audit/ax-setting.spec.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import {describe, it} from 'node:test';
+
+import {serializeAxSetting} from '../../../src/services/ios/accessibility-audit/index.js';
+
+/**
+ * The descriptor sent with `deviceUpdateAccessibilitySetting:withValue:`.
+ *
+ * The device reads only the identifier — sending a deliberately wrong
+ * `SettingTypeValue_v1` or `SliderTickMarksValue_v1` still applies the setting —
+ * so this deliberately does not echo a full descriptor back.
+ */
+describe('serializeAxSetting', function () {
+  it('wraps the identifier in the AXAuditDeviceSetting_v1 envelope', function () {
+    assert.deepStrictEqual(serializeAxSetting('INVERT_COLORS'), {
+      ObjectType: 'AXAuditDeviceSetting_v1',
+      Value: {
+        ObjectType: 'passthrough',
+        Value: {IdentiifierValue_v1: {ObjectType: 'passthrough', Value: 'INVERT_COLORS'}},
+      },
+    });
+  });
+
+  it('carries the identifier verbatim, including the daemon typo key', function () {
+    const wire = serializeAxSetting('DYNAMIC_TYPE') as {Value: {Value: Record<string, {Value: string}>}};
+
+    // `IdentiifierValue_v1` is the daemon's own misspelling; matching it exactly
+    // is load-bearing, not a typo on our side.
+    assert.deepStrictEqual(Object.keys(wire.Value.Value), ['IdentiifierValue_v1']);
+    assert.strictEqual(wire.Value.Value.IdentiifierValue_v1.Value, 'DYNAMIC_TYPE');
+  });
+
+  it('sends no type, tick-mark or enabled fields', function () {
+    const wire = serializeAxSetting('GRAYSCALE') as {Value: {Value: Record<string, unknown>}};
+    const fields = Object.keys(wire.Value.Value);
+
+    for (const ignored of [
+      'SettingTypeValue_v1',
+      'SliderTickMarksValue_v1',
+      'EnabledValue_v1',
+      'CurrentValueNumber_v1',
+    ]) {
+      assert.ok(!fields.includes(ignored), `${ignored} should not be sent`);
+    }
+  });
+});


### PR DESCRIPTION
`AccessibilityAuditService` could read the device's nine accessibility settings but not change them. Adds the write side, so an app can be audited under Increase Contrast, Grayscale, Reduce Motion or a larger Dynamic Type without touching the Settings app.

### API

| Method | Notes |
| --- | --- |
| `setAccessibilitySetting(identifier, value, options?)` | `boolean` for a toggle, `0..1` for a slider |
| `resetAccessibilitySettings(options?)` | restores the device's stored defaults |

Also exports `serializeAxSetting` alongside the existing wire serialisers.

⚠️  `resetAccessibilitySettings(options?)` completely resets the user's prior settings if present.

`resetAccessibilitySettings` tests are **opt-in and skipped by default** — the call is persistent and would wipe the accessibility settings of whoever ran the suite:

    ALLOW_ACCESSIBILITY_SETTINGS_RESET=1 UDID=<udid> npm run test:accessibility-audit