### PR TITLE
fix(port-forwarding): destroy upstream socket when client disconnects during connect

### DIFF
--- a/src/lib/port-forwarding/device-port-forwarder.ts
+++ b/src/lib/port-forwarding/device-port-forwarder.ts
@@ -83,6 +83,21 @@ export class DevicePortForwarder extends EventEmitter {
     this.activeSockets.add(localSocket);
     this.emit('clientConnected', localSocket);
 
+    const upstreamSocket = await this.openUpstreamForClient(localSocket);
+    if (!upstreamSocket) {
+      return;
+    }
+
+    this.activeSockets.add(upstreamSocket);
+    this.emit('upstreamConnected', upstreamSocket);
+    this.bridgeSockets(localSocket, upstreamSocket);
+  }
+
+  /**
+   * Opens the upstream socket while watching for the client going away.
+   * Returns undefined after cleanup if the connect fails or the client disconnected meanwhile.
+   */
+  private async openUpstreamForClient(localSocket: Socket): Promise<Socket | undefined> {
     let clientError: Error | undefined;
     let clientClosed = false;
     const onEarlyError = (err: Error): void => {
@@ -94,7 +109,7 @@ export class DevicePortForwarder extends EventEmitter {
     localSocket.once('error', onEarlyError);
     localSocket.once('close', onEarlyClose);
 
-    let upstreamSocket: Socket | undefined;
+    let upstreamSocket: Socket;
     try {
       upstreamSocket = await this.openUpstreamSocket();
     } catch (err) {
@@ -102,7 +117,7 @@ export class DevicePortForwarder extends EventEmitter {
       this.emit('upstreamConnectError', err);
       this.emit('clientDisconnected', localSocket, err);
       localSocket.destroy();
-      return;
+      return undefined;
     } finally {
       localSocket.off('error', onEarlyError);
       localSocket.off('close', onEarlyClose);
@@ -113,12 +128,16 @@ export class DevicePortForwarder extends EventEmitter {
       this.emit('clientDisconnected', localSocket, clientError);
       localSocket.destroy();
       upstreamSocket.destroy();
-      return;
+      return undefined;
     }
 
-    this.activeSockets.add(upstreamSocket);
-    this.emit('upstreamConnected', upstreamSocket);
+    return upstreamSocket;
+  }
 
+  /**
+   * Pipes the two sockets together and tears both down when either side closes or errors.
+   */
+  private bridgeSockets(localSocket: Socket, upstreamSocket: Socket): void {
     let cleanedUp = false;
     const teardown = (): void => {
       this.activeSockets.delete(localSocket);
@@ -135,6 +154,7 @@ export class DevicePortForwarder extends EventEmitter {
       upstreamSocket.destroy();
     };
 
+    let clientError: Error | undefined;
     localSocket.once('error', (err) => {
       clientError = err;
       teardown();

--- a/src/lib/port-forwarding/device-port-forwarder.ts
+++ b/src/lib/port-forwarding/device-port-forwarder.ts
@@ -83,6 +83,17 @@ export class DevicePortForwarder extends EventEmitter {
     this.activeSockets.add(localSocket);
     this.emit('clientConnected', localSocket);
 
+    let clientError: Error | undefined;
+    let clientClosed = false;
+    const onEarlyError = (err: Error): void => {
+      clientError = err;
+    };
+    const onEarlyClose = (): void => {
+      clientClosed = true;
+    };
+    localSocket.once('error', onEarlyError);
+    localSocket.once('close', onEarlyClose);
+
     let upstreamSocket: Socket | undefined;
     try {
       upstreamSocket = await this.openUpstreamSocket();
@@ -91,6 +102,17 @@ export class DevicePortForwarder extends EventEmitter {
       this.emit('upstreamConnectError', err);
       this.emit('clientDisconnected', localSocket, err);
       localSocket.destroy();
+      return;
+    } finally {
+      localSocket.off('error', onEarlyError);
+      localSocket.off('close', onEarlyClose);
+    }
+
+    if (clientClosed || localSocket.destroyed || clientError !== undefined) {
+      this.activeSockets.delete(localSocket);
+      this.emit('clientDisconnected', localSocket, clientError);
+      localSocket.destroy();
+      upstreamSocket.destroy();
       return;
     }
 
@@ -113,7 +135,6 @@ export class DevicePortForwarder extends EventEmitter {
       upstreamSocket.destroy();
     };
 
-    let clientError: Error | undefined;
     localSocket.once('error', (err) => {
       clientError = err;
       teardown();

--- a/test/unit/port-forwarding/device-port-forwarder.spec.ts
+++ b/test/unit/port-forwarding/device-port-forwarder.spec.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import {once} from 'node:events';
+import {type AddressInfo, type Server, type Socket, createConnection, createServer} from 'node:net';
+import {after, before, describe, it} from 'node:test';
+
+import {DevicePortForwarder} from '../../../src/lib/port-forwarding/index.js';
+
+/** Binds a throwaway server on port 0 to find a free local port. */
+async function getFreePort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.listen(0, '127.0.0.1', resolve);
+    server.once('error', reject);
+  });
+  const port = (server.address() as AddressInfo).port;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  return port;
+}
+
+describe('DevicePortForwarder early client disconnect', function () {
+  let upstreamServer: Server;
+  let upstreamPort: number;
+
+  before(async function () {
+    upstreamServer = createServer();
+    await new Promise<void>((resolve, reject) => {
+      upstreamServer.listen(0, '127.0.0.1', resolve);
+      upstreamServer.once('error', reject);
+    });
+    upstreamPort = (upstreamServer.address() as AddressInfo).port;
+  });
+
+  after(async function () {
+    await new Promise<void>((resolve) => upstreamServer.close(() => resolve()));
+  });
+
+  it('should destroy the upstream socket when the client disconnects during upstream connect', async function () {
+    let releaseConnector!: () => void;
+    const connectorGate = new Promise<void>((resolve) => (releaseConnector = resolve));
+    let upstreamSocket!: Socket;
+    const primaryConnector = async (): Promise<Socket> => {
+      upstreamSocket = createConnection({host: '127.0.0.1', port: upstreamPort});
+      await once(upstreamSocket, 'connect');
+      await connectorGate;
+      return upstreamSocket;
+    };
+
+    const localPort = await getFreePort();
+    const forwarder = new DevicePortForwarder(localPort, upstreamPort, {primaryConnector});
+    let upstreamConnectedCount = 0;
+    let clientDisconnectedCount = 0;
+    forwarder.on('upstreamConnected', () => upstreamConnectedCount++);
+    forwarder.on('clientDisconnected', () => clientDisconnectedCount++);
+    await forwarder.start();
+
+    try {
+      const client = createConnection({host: '127.0.0.1', port: localPort});
+      const [localSocket] = (await once(forwarder, 'clientConnected')) as [Socket];
+      client.destroy();
+      await once(localSocket, 'close');
+
+      const disconnected = once(forwarder, 'clientDisconnected');
+      releaseConnector();
+      await disconnected;
+
+      await once(upstreamSocket, 'close');
+      assert.strictEqual(upstreamSocket.destroyed, true);
+      assert.strictEqual(upstreamConnectedCount, 0);
+      assert.strictEqual(clientDisconnectedCount, 1);
+    } finally {
+      await forwarder.stop();
+    }
+  });
+});


### PR DESCRIPTION
Fixes a socket leak in `DevicePortForwarder`. The `close` and `error` listeners were attached to the local socket only after the upstream connection resolved. A client disconnect during that window was missed, the upstream socket stayed open and both sockets leaked until `stop`. An abrupt client reset in the same window also threw an unhandled `error` event.

Now client `close` and `error` are tracked while the upstream connection is being established and the upstream socket is destroyed immediately if the client is already gone. Includes a unit test covering the early disconnect.