### PR TITLE
fix(accessibility): reject unknown audit types before they reach the device

### DIFF
--- a/src/services/ios/accessibility-audit/index.ts
+++ b/src/services/ios/accessibility-audit/index.ts
@@ -117,6 +117,14 @@ export class AccessibilityAuditService {
    */
   private settingTypes: Map<string, number | undefined> | undefined;
 
+  /**
+   * Supported audit types, read once per connection.
+   *
+   * Like the setting catalogue this is fixed for the device, so validating a
+   * name costs one round trip per connection rather than one per audit.
+   */
+  private auditTypeNames: Set<string> | undefined;
+
   private constructor(private readonly transport: AxAuditDtxTransport) {}
 
   /**
@@ -264,6 +272,7 @@ export class AccessibilityAuditService {
       : undefined;
 
     try {
+      await this.assertKnownAuditTypes(auditTypes, options);
       if (options.targetPid !== undefined) {
         // Narrows the audit to one process; omitted, the daemon uses the
         // foreground app.
@@ -284,6 +293,27 @@ export class AccessibilityAuditService {
       this.auditInFlight = false;
       stopIssues();
       stopLog?.();
+    }
+  }
+
+  /**
+   * Rejects audit types the device does not implement.
+   *
+   * An unrecognised name makes the daemon return neither issues nor a
+   * completion, and that connection can never run another audit — so the name
+   * must never reach the device.
+   */
+  private async assertKnownAuditTypes(auditTypes: string[], options?: InvokeOptions): Promise<void> {
+    if (auditTypes.length === 0) {
+      return;
+    }
+    this.auditTypeNames ??= new Set(await this.getSupportedAuditTypes(options));
+    const unknown = auditTypes.filter((auditType) => !this.auditTypeNames?.has(auditType));
+    if (unknown.length > 0) {
+      throw new Error(
+        `Unknown audit type(s) ${unknown.map((auditType) => JSON.stringify(auditType)).join(', ')}; ` +
+          `the device supports: ${[...(this.auditTypeNames ?? [])].join(', ')}`,
+      );
     }
   }
 

--- a/src/services/ios/accessibility-audit/index.ts
+++ b/src/services/ios/accessibility-audit/index.ts
@@ -272,7 +272,7 @@ export class AccessibilityAuditService {
       : undefined;
 
     try {
-      await this.assertKnownAuditTypes(auditTypes, options);
+      await this.assertKnownAuditTypes(auditTypes);
       if (options.targetPid !== undefined) {
         // Narrows the audit to one process; omitted, the daemon uses the
         // foreground app.
@@ -303,16 +303,28 @@ export class AccessibilityAuditService {
    * completion, and that connection can never run another audit — so the name
    * must never reach the device.
    */
-  private async assertKnownAuditTypes(auditTypes: string[], options?: InvokeOptions): Promise<void> {
+  private async assertKnownAuditTypes(auditTypes: string[]): Promise<void> {
     if (auditTypes.length === 0) {
       return;
     }
-    this.auditTypeNames ??= new Set(await this.getSupportedAuditTypes(options));
-    const unknown = auditTypes.filter((auditType) => !this.auditTypeNames?.has(auditType));
+    // Deliberately not the caller's `timeoutMs`: that budget is for the audit
+    // itself, and reusing it here would let a long audit spend it twice.
+    const known = this.auditTypeNames ?? new Set(await this.getSupportedAuditTypes());
+    if (known.size === 0) {
+      // Nothing to validate against. Caching an empty catalogue would reject
+      // every type from here on — including after the daemon recovered — which
+      // is worse than the wedge this guards against, so let the call through.
+      log.debug('Device reported no supported audit types; skipping validation');
+      return;
+    }
+    this.auditTypeNames = known;
+
+    const unknown = auditTypes.filter((auditType) => !known.has(auditType));
     if (unknown.length > 0) {
       throw new Error(
-        `Unknown audit type(s) ${unknown.map((auditType) => JSON.stringify(auditType)).join(', ')}; ` +
-          `the device supports: ${[...(this.auditTypeNames ?? [])].join(', ')}`,
+        `Unknown ${util.pluralize('audit type', unknown.length)} ` +
+          `${unknown.map((auditType) => JSON.stringify(auditType)).join(', ')}; ` +
+          `the device supports: ${[...known].join(', ')}`,
       );
     }
   }

--- a/test/integration/accessibility-audit.spec.ts
+++ b/test/integration/accessibility-audit.spec.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import {after, before, describe, it} from 'node:test';
+import {type TestContext, after, before, describe, it} from 'node:test';
 
 import {type AccessibilityAuditService} from '../../src/index.js';
 import * as Services from '../../src/services.js';
@@ -21,11 +21,20 @@ import {requireDeviceUdid} from './helpers/device.js';
 // Generous: the audits alone take ~60s, and the settings tests deliberately
 // pace their writes because the device commits them asynchronously.
 describe('AccessibilityAuditService', {timeout: 300000}, function () {
+  /** The selector the setting-write tests depend on. */
+  const SETTING_WRITE_SELECTOR = 'deviceUpdateAccessibilitySetting:withValue:';
+
   let service: AccessibilityAuditService | null = null;
+  /** Whether this device's daemon implements setting writes at all. */
+  let supportsSettingWrites = false;
 
   before(async function () {
     const udid = requireDeviceUdid();
     service = await Services.startAccessibilityAuditService(udid);
+    // Gate on what the daemon advertises rather than on an OS version: it
+    // publishes the selectors it implements, which is both more precise and
+    // stable across releases.
+    supportsSettingWrites = (await service.getCapabilities()).includes(SETTING_WRITE_SELECTOR);
   });
 
   after(function () {
@@ -174,7 +183,59 @@ describe('AccessibilityAuditService', {timeout: 300000}, function () {
    * rather than session-scoped, so running it against a configured device
    * would discard real settings.
    */
+  /**
+   * An audit type the device does not implement makes the daemon return neither
+   * issues nor a completion, and that connection can never run another audit —
+   * so the name must be refused before it reaches the wire. Matching is exact:
+   * case, surrounding whitespace and a bare prefix all wedge it.
+   */
+  describe('audit type validation', function () {
+    const POISON: Array<[string, string[]]> = [
+      ['an invented name', ['bogusAuditTypeThatDoesNotExist']],
+      ['the wrong case', ['TESTTYPECONTRAST']],
+      ['an empty string', ['']],
+      ['a bare prefix', ['testType']],
+      ['surrounding whitespace', [' testTypeContrast ']],
+    ];
+
+    for (const [label, auditTypes] of POISON) {
+      it(`rejects ${label} without contacting the device`, async function () {
+        await assert.rejects(() => service!.runAudit(auditTypes, {timeoutMs: 20000}), /Unknown audit type/);
+      });
+    }
+
+    it('rejects a valid type mixed with an unknown one', async function () {
+      const types = await service!.getSupportedAuditTypes();
+
+      await assert.rejects(() => service!.runAudit([types[0], 'bogusType'], {timeoutMs: 20000}), /Unknown audit type/);
+    });
+
+    it('still accepts an empty list, which the device reads as every type', async function () {
+      // Rejecting this would be a regression: the daemon audits everything.
+      assert.ok(Array.isArray(await service!.runAudit([], {timeoutMs: 60000})));
+    });
+
+    it('leaves the connection usable after a rejected audit', async function (t) {
+      const types = await service!.getSupportedAuditTypes();
+      await assert.rejects(() => service!.runAudit(['nopeNotAType'], {timeoutMs: 20000}), /Unknown audit type/);
+
+      // Before the guard this call timed out permanently on this connection.
+      const issues = await service!.runAudit(types, {timeoutMs: 60000});
+      assert.ok(Array.isArray(issues));
+      t.diagnostic(`audit after a rejected one returned ${issues.length} issue(s)`);
+    });
+  });
+
   describe('accessibility settings', function () {
+    /** Skips when the daemon does not implement setting writes. */
+    function skipWithoutSettingWrites(t: TestContext): boolean {
+      if (!supportsSettingWrites) {
+        t.skip(`daemon does not implement ${SETTING_WRITE_SELECTOR}`);
+        return true;
+      }
+      return false;
+    }
+
     /** Polls until `identifier` reads `expected`, since a write settles asynchronously. */
     async function waitForSetting(identifier: string, expected: unknown, timeoutMs = 8000): Promise<unknown> {
       const deadline = performance.now() + timeoutMs;
@@ -196,6 +257,9 @@ describe('AccessibilityAuditService', {timeout: 300000}, function () {
     }
 
     it('quantises a slider value to the device tick marks', async function (t) {
+      if (skipWithoutSettingWrites(t)) {
+        return;
+      }
       const settings = await service!.getAccessibilitySettings();
       const slider = settings.find((setting) => setting.identifier === 'DYNAMIC_TYPE');
       assert.ok(slider, 'DYNAMIC_TYPE should be present');
@@ -217,20 +281,29 @@ describe('AccessibilityAuditService', {timeout: 300000}, function () {
       }
     });
 
-    it('rejects an unknown setting identifier instead of silently doing nothing', async function () {
+    it('rejects an unknown setting identifier instead of silently doing nothing', async function (t) {
+      if (skipWithoutSettingWrites(t)) {
+        return;
+      }
       await assert.rejects(
         () => service!.setAccessibilitySetting('NOT_A_REAL_SETTING', true),
         /Unknown accessibility setting/,
       );
     });
 
-    it('rejects a value of the wrong kind for the setting', async function () {
+    it('rejects a value of the wrong kind for the setting', async function (t) {
+      if (skipWithoutSettingWrites(t)) {
+        return;
+      }
       // DYNAMIC_TYPE is a slider, GRAYSCALE a toggle.
       await assert.rejects(() => service!.setAccessibilitySetting('DYNAMIC_TYPE', true), /slider/);
       await assert.rejects(() => service!.setAccessibilitySetting('GRAYSCALE', 0.5 as unknown as boolean), /toggle/);
     });
 
-    it('rejects an out-of-range slider value without touching the device', async function () {
+    it('rejects an out-of-range slider value without touching the device', async function (t) {
+      if (skipWithoutSettingWrites(t)) {
+        return;
+      }
       const before = await currentValue('DYNAMIC_TYPE');
 
       await assert.rejects(() => service!.setAccessibilitySetting('DYNAMIC_TYPE', -1), /between 0 and 1/);
@@ -269,6 +342,9 @@ describe('AccessibilityAuditService', {timeout: 300000}, function () {
 
       /** Reports why a test is being skipped, or null when it may run. */
       async function skipReason(): Promise<string | null> {
+        if (!supportsSettingWrites) {
+          return `daemon does not implement ${SETTING_WRITE_SELECTOR}`;
+        }
         if (!RESET_ALLOWED) {
           return 'set ALLOW_ACCESSIBILITY_SETTINGS_RESET=1 to run — this permanently resets the accessibility settings on the device';
         }

--- a/test/integration/accessibility-audit.spec.ts
+++ b/test/integration/accessibility-audit.spec.ts
@@ -23,10 +23,14 @@ import {requireDeviceUdid} from './helpers/device.js';
 describe('AccessibilityAuditService', {timeout: 300000}, function () {
   /** The selector the setting-write tests depend on. */
   const SETTING_WRITE_SELECTOR = 'deviceUpdateAccessibilitySetting:withValue:';
+  /** The selector the reset tests depend on. */
+  const SETTING_RESET_SELECTOR = 'deviceResetToDefaultAccessibilitySettings';
 
   let service: AccessibilityAuditService | null = null;
   /** Whether this device's daemon implements setting writes at all. */
   let supportsSettingWrites = false;
+  /** Whether it implements the reset selector, which the write tests do not use. */
+  let supportsSettingReset = false;
 
   before(async function () {
     const udid = requireDeviceUdid();
@@ -34,7 +38,9 @@ describe('AccessibilityAuditService', {timeout: 300000}, function () {
     // Gate on what the daemon advertises rather than on an OS version: it
     // publishes the selectors it implements, which is both more precise and
     // stable across releases.
-    supportsSettingWrites = (await service.getCapabilities()).includes(SETTING_WRITE_SELECTOR);
+    const capabilities = await service.getCapabilities();
+    supportsSettingWrites = capabilities.includes(SETTING_WRITE_SELECTOR);
+    supportsSettingReset = capabilities.includes(SETTING_RESET_SELECTOR);
   });
 
   after(function () {
@@ -199,7 +205,7 @@ describe('AccessibilityAuditService', {timeout: 300000}, function () {
     ];
 
     for (const [label, auditTypes] of POISON) {
-      it(`rejects ${label} without contacting the device`, async function () {
+      it(`rejects ${label} without starting an audit`, async function () {
         await assert.rejects(() => service!.runAudit(auditTypes, {timeoutMs: 20000}), /Unknown audit type/);
       });
     }
@@ -210,19 +216,32 @@ describe('AccessibilityAuditService', {timeout: 300000}, function () {
       await assert.rejects(() => service!.runAudit([types[0], 'bogusType'], {timeoutMs: 20000}), /Unknown audit type/);
     });
 
-    it('still accepts an empty list, which the device reads as every type', async function () {
-      // Rejecting this would be a regression: the daemon audits everything.
-      assert.ok(Array.isArray(await service!.runAudit([], {timeoutMs: 60000})));
+    it('does not validate against an empty catalogue', async function () {
+      // A device reporting no types must not make every type unknown — and the
+      // empty list must not be cached, or the service stays broken afterwards.
+      const types = await service!.getSupportedAuditTypes();
+      const real = service!.getSupportedAuditTypes.bind(service!);
+      const instance = service! as unknown as {auditTypeNames?: Set<string>; getSupportedAuditTypes: unknown};
+      instance.getSupportedAuditTypes = async () => [];
+      instance.auditTypeNames = undefined;
+      try {
+        assert.ok(Array.isArray(await service!.runAudit([types[0]], {timeoutMs: 60000})));
+        assert.strictEqual(instance.auditTypeNames, undefined, 'an empty catalogue must not be cached');
+      } finally {
+        instance.getSupportedAuditTypes = real;
+        instance.auditTypeNames = undefined;
+      }
+
+      // Still works once the device reports its types again.
+      assert.ok(Array.isArray(await service!.runAudit([types[0]], {timeoutMs: 60000})));
     });
 
-    it('leaves the connection usable after a rejected audit', async function (t) {
-      const types = await service!.getSupportedAuditTypes();
+    it('leaves the connection usable after a rejected audit', async function () {
       await assert.rejects(() => service!.runAudit(['nopeNotAType'], {timeoutMs: 20000}), /Unknown audit type/);
 
-      // Before the guard this call timed out permanently on this connection.
-      const issues = await service!.runAudit(types, {timeoutMs: 60000});
-      assert.ok(Array.isArray(issues));
-      t.diagnostic(`audit after a rejected one returned ${issues.length} issue(s)`);
+      // One cheap type is enough here: before the guard this timed out
+      // permanently on this connection.
+      assert.ok(Array.isArray(await service!.runAudit(['testTypeContrast'], {timeoutMs: 60000})));
     });
   });
 
@@ -281,29 +300,20 @@ describe('AccessibilityAuditService', {timeout: 300000}, function () {
       }
     });
 
-    it('rejects an unknown setting identifier instead of silently doing nothing', async function (t) {
-      if (skipWithoutSettingWrites(t)) {
-        return;
-      }
+    it('rejects an unknown setting identifier instead of silently doing nothing', async function () {
       await assert.rejects(
         () => service!.setAccessibilitySetting('NOT_A_REAL_SETTING', true),
         /Unknown accessibility setting/,
       );
     });
 
-    it('rejects a value of the wrong kind for the setting', async function (t) {
-      if (skipWithoutSettingWrites(t)) {
-        return;
-      }
+    it('rejects a value of the wrong kind for the setting', async function () {
       // DYNAMIC_TYPE is a slider, GRAYSCALE a toggle.
       await assert.rejects(() => service!.setAccessibilitySetting('DYNAMIC_TYPE', true), /slider/);
       await assert.rejects(() => service!.setAccessibilitySetting('GRAYSCALE', 0.5 as unknown as boolean), /toggle/);
     });
 
-    it('rejects an out-of-range slider value without touching the device', async function (t) {
-      if (skipWithoutSettingWrites(t)) {
-        return;
-      }
+    it('rejects an out-of-range slider value without touching the device', async function () {
       const before = await currentValue('DYNAMIC_TYPE');
 
       await assert.rejects(() => service!.setAccessibilitySetting('DYNAMIC_TYPE', -1), /between 0 and 1/);
@@ -342,8 +352,8 @@ describe('AccessibilityAuditService', {timeout: 300000}, function () {
 
       /** Reports why a test is being skipped, or null when it may run. */
       async function skipReason(): Promise<string | null> {
-        if (!supportsSettingWrites) {
-          return `daemon does not implement ${SETTING_WRITE_SELECTOR}`;
+        if (!supportsSettingReset) {
+          return `daemon does not implement ${SETTING_RESET_SELECTOR}`;
         }
         if (!RESET_ALLOWED) {
           return 'set ALLOW_ACCESSIBILITY_SETTINGS_RESET=1 to run — this permanently resets the accessibility settings on the device';
@@ -370,6 +380,11 @@ describe('AccessibilityAuditService', {timeout: 300000}, function () {
       });
 
       it('clears a session override held by this service', async function (t) {
+        // The only reset test that also writes a setting.
+        if (!supportsSettingWrites) {
+          t.skip(`daemon does not implement ${SETTING_WRITE_SELECTOR}`);
+          return;
+        }
         const skip = await skipReason();
         if (skip) {
           t.skip(skip);

--- a/test/integration/accessibility-audit.spec.ts
+++ b/test/integration/accessibility-audit.spec.ts
@@ -221,8 +221,11 @@ describe('AccessibilityAuditService', {timeout: 300000}, function () {
       // empty list must not be cached, or the service stays broken afterwards.
       const types = await service!.getSupportedAuditTypes();
       const real = service!.getSupportedAuditTypes.bind(service!);
-      const instance = service! as unknown as {auditTypeNames?: Set<string>; getSupportedAuditTypes: unknown};
-      instance.getSupportedAuditTypes = async () => [];
+      const instance = service! as unknown as {
+        auditTypeNames?: Set<string>;
+        getSupportedAuditTypes: () => Promise<string[]>;
+      };
+      instance.getSupportedAuditTypes = async (): Promise<string[]> => [];
       instance.auditTypeNames = undefined;
       try {
         assert.ok(Array.isArray(await service!.runAudit([types[0]], {timeoutMs: 60000})));


### PR DESCRIPTION
An audit type the daemon doesn't implement makes it return neither issues nor a completion, and that connection can never run another audit, the service looks alive (`getApiVersion` still works) while every `runAudit` times out.

`runAudit` now validates against `getSupportedAuditTypes()` and throws locally, caching the list per connection. Matching is exact: wrong case, surrounding whitespace and a bare `testType` prefix all wedge the daemon too. An empty list still passes through, the device reads it as "every type".