### PR TITLE
fix(accessibility): decode element rectangles on audit issues

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,8 @@ export type {AxDeviceSetting} from './services/ios/accessibility-audit/index.js'
 export {AxAuditDtxTransport} from './services/ios/accessibility-audit/dtx-transport.js';
 export type {InvokeOptions as AxInvokeOptions} from './services/ios/accessibility-audit/dtx-transport.js';
 export {AX_OBJECT_TYPE, deserializeAxObject} from './services/ios/accessibility-audit/ax-deserialize.js';
-export {AxPoint} from './services/ios/accessibility-audit/ax-values.js';
+export {AxPoint, toAxRect} from './services/ios/accessibility-audit/ax-values.js';
+export type {AxRect} from './services/ios/accessibility-audit/ax-values.js';
 export {
   serializeAxAttribute,
   serializeAxElement,

--- a/src/services/ios/accessibility-audit/ax-values.ts
+++ b/src/services/ios/accessibility-audit/ax-values.ts
@@ -1,3 +1,5 @@
+import {util} from '@appium/support';
+
 import {PlistUID} from '../../../lib/plist/index.js';
 
 /**
@@ -43,4 +45,48 @@ export function archiveAxPoint(point: AxPoint): Record<string, unknown> {
       },
     ],
   };
+}
+
+/** An element's on-screen rectangle, in points. */
+export interface AxRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** `NS.special` value marking an `NSValue` that wraps a `CGRect`. */
+const NS_SPECIAL_RECT = 3;
+
+/** `{{x, y}, {width, height}}` — Foundation's string form for a `CGRect`. */
+const CG_RECT_PATTERN = /^\{\{\s*(-?[\d.]+)\s*,\s*(-?[\d.]+)\s*\}\s*,\s*\{\s*(-?[\d.]+)\s*,\s*(-?[\d.]+)\s*\}\}$/;
+
+/**
+ * Reads an element's rectangle from an audit issue's `ElementRectValue_v1`.
+ *
+ * The daemon sends a `CGRect` as an `NSValue` whose struct is a string, e.g.
+ * `{{16, 186.33}, {18, 18}}`. Returns `undefined` for anything that is not a
+ * rect — including a bare number, which means the archiver reference was never
+ * resolved — rather than guessing at partial coordinates.
+ *
+ * @param value The raw `ElementRectValue_v1` from an audit issue.
+ */
+export function toAxRect(value: unknown): AxRect | undefined {
+  if (!util.isPlainObject(value)) {
+    return undefined;
+  }
+  const fields = value as Record<string, unknown>;
+  if (fields['NS.special'] !== NS_SPECIAL_RECT) {
+    return undefined;
+  }
+  const raw = fields['NS.rectval'];
+  if (typeof raw !== 'string') {
+    return undefined;
+  }
+  const match = CG_RECT_PATTERN.exec(raw.trim());
+  if (!match) {
+    return undefined;
+  }
+  const [x, y, width, height] = match.slice(1, 5).map(Number);
+  return [x, y, width, height].every((n) => Number.isFinite(n)) ? {x, y, width, height} : undefined;
 }

--- a/src/services/ios/dvt/nskeyedarchiver-decoder.ts
+++ b/src/services/ios/dvt/nskeyedarchiver-decoder.ts
@@ -13,6 +13,13 @@ const MAX_DECODE_DEPTH = 1000;
  * - $top: Root object references
  * - $objects: Array of all objects with cross-references
  */
+/**
+ * `NSValue` keys whose value is a UID pointing at the struct's string form.
+ *
+ * `NS.special` discriminates which one is present: 1 point, 2 size, 3 rect.
+ */
+const NSVALUE_STRUCT_KEYS = new Set(['NS.rectval', 'NS.pointval', 'NS.sizeval']);
+
 export class NSKeyedArchiverDecoder {
   private readonly objects: any[];
   private readonly decoded: Map<number, any>;
@@ -149,7 +156,14 @@ export class NSKeyedArchiverDecoder {
         continue; // Skip class metadata
       }
 
-      if (typeof value === 'number') {
+      if (typeof value === 'number' && NSVALUE_STRUCT_KEYS.has(key)) {
+        // An NSValue stores its struct as a string ("{{0, 0}, {18, 18}}") and
+        // points at it by UID. The parser cannot tell a UID from an integer, and
+        // the heuristic below only follows references to objects, so these keys
+        // would keep the raw index. They always reference a string.
+        const referenced = value >= 0 && value < this.objects.length ? this.objects[value] : undefined;
+        result[key] = typeof referenced === 'string' ? referenced : value;
+      } else if (typeof value === 'number') {
         // Could be a reference or primitive
         if (value < this.objects.length && value >= 0) {
           const referenced = this.objects[value];

--- a/test/unit/accessibility-audit/ax-rect.spec.ts
+++ b/test/unit/accessibility-audit/ax-rect.spec.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import {describe, it} from 'node:test';
+
+import {toAxRect} from '../../../src/services/ios/accessibility-audit/ax-values.js';
+
+/**
+ * The daemon sends a `CGRect` as an `NSValue` whose struct is Foundation's
+ * string form, discriminated by `NS.special: 3`.
+ */
+describe('toAxRect', function () {
+  const rect = (rectval: unknown, special: unknown = 3) => ({'NS.rectval': rectval, 'NS.special': special});
+
+  it('parses the Foundation rect string', function () {
+    assert.deepStrictEqual(toAxRect(rect('{{16, 186}, {18, 18}}')), {x: 16, y: 186, width: 18, height: 18});
+  });
+
+  it('keeps fractional coordinates', function () {
+    assert.deepStrictEqual(toAxRect(rect('{{16, 186.33333333333334}, {291.66666666666669, 20.5}}')), {
+      x: 16,
+      y: 186.33333333333334,
+      width: 291.66666666666669,
+      height: 20.5,
+    });
+  });
+
+  it('accepts negative origins', function () {
+    assert.deepStrictEqual(toAxRect(rect('{{-8, -2.5}, {10, 4}}')), {x: -8, y: -2.5, width: 10, height: 4});
+  });
+
+  it('returns undefined for an unresolved archiver reference', function () {
+    // A bare index means the decoder did not dereference the NSValue.
+    assert.strictEqual(toAxRect(rect(42)), undefined);
+  });
+
+  it('returns undefined when NS.special is not a rect', function () {
+    // 1 is a point, 2 a size — neither carries rect coordinates. Note the key is
+    // omitted rather than passed as undefined, which would take the default.
+    assert.strictEqual(toAxRect(rect('{{0, 0}, {1, 1}}', 1)), undefined);
+    assert.strictEqual(toAxRect(rect('{{0, 0}, {1, 1}}', 2)), undefined);
+    assert.strictEqual(toAxRect({'NS.rectval': '{{0, 0}, {1, 1}}'}), undefined);
+  });
+
+  it('returns undefined for malformed or non-object input', function () {
+    assert.strictEqual(toAxRect(rect('{{0, 0}}')), undefined);
+    assert.strictEqual(toAxRect(rect('not a rect')), undefined);
+    assert.strictEqual(toAxRect(null), undefined);
+    assert.strictEqual(toAxRect('{{0, 0}, {1, 1}}'), undefined);
+    assert.strictEqual(toAxRect([1, 2, 3]), undefined);
+  });
+});


### PR DESCRIPTION
Audit issues carry `ElementRectValue_v1`, but it arrived as `{"NS.rectval": 42, "NS.special": 3}` — a bare archiver index — so **0 of 11 findings had usable coordinates**. No other path exposes geometry either: none of the inspector's attributes across Basic, Actions, Element or Hierarchy carries a frame.

