### PR TITLE
fix(deps): require appium-ios-tuntap ^2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@appium/strongbox": "^1.1.2",
     "@appium/support": "^7.2.2",
     "@xmldom/xmldom": "^0.x",
-    "appium-ios-tuntap": "^1.0.0",
+    "appium-ios-tuntap": "^2.0.0",
     "async-lock": "^1.4.1",
     "axios": "^1.15.1",
     "commander": "^14.0.1",


### PR DESCRIPTION
tuntap 2.0.0 removed the unused JS polling API. remotexpc uses only the tunnel APIs, so no code changes are needed.