### PR TITLE
feat(accessibility-audit): add focus traversal via `moveFocus` and `walkElements`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,7 @@ export type {
   AxInspectorSection,
 } from './services/ios/accessibility-audit/ax-element.js';
 export {serializeAxSetting} from './services/ios/accessibility-audit/index.js';
+export {AxFocusDirection} from './services/ios/accessibility-audit/index.js';
 export type {InspectOptions, RunAuditOptions, AxAuditIssue} from './services/ios/accessibility-audit/index.js';
 export {CoreDeviceInfoService} from './services/ios/device-info/index.js';
 export type {

--- a/src/services/ios/accessibility-audit/ax-element.ts
+++ b/src/services/ios/accessibility-audit/ax-element.ts
@@ -52,6 +52,13 @@ export interface AxInspectorSection {
 
 /** The inspector panel the device pushes when the focused element changes. */
 export interface AxInspectedElement {
+  /**
+   * A handle to the focused element, when the daemon sends one.
+   *
+   * Present on focus pushes, which lets a walk both detect revisits and read
+   * attributes for each element it reaches.
+   */
+  element?: AxElement;
   /** What VoiceOver would announce, when the daemon provides it. */
   spokenDescription?: string;
   /** The caption shown above the panel, when present. */
@@ -175,6 +182,7 @@ export function toInspectedElement(value: unknown): AxInspectedElement {
     });
   }
   return {
+    element: toAxElement(fields.ElementValue_v1),
     spokenDescription:
       typeof fields.SpokenDescriptionValue_v1 === 'string' ? fields.SpokenDescriptionValue_v1 : undefined,
     caption: typeof fields.CaptionTextValue_v1 === 'string' ? fields.CaptionTextValue_v1 : undefined,

--- a/src/services/ios/accessibility-audit/index.ts
+++ b/src/services/ios/accessibility-audit/index.ts
@@ -62,15 +62,12 @@ const MONITORED_EVENT_OFF = 0;
  * Where {@link AccessibilityAuditService.moveFocus} sends the accessibility
  * focus. These are the daemon's own `direction` values, verified live.
  */
-export const AxFocusDirection = {
-  Previous: 3,
-  Next: 4,
-  First: 5,
-  Last: 6,
-} as const;
-
-/** A value of {@link AxFocusDirection}. */
-export type AxFocusDirection = (typeof AxFocusDirection)[keyof typeof AxFocusDirection];
+export enum AxFocusDirection {
+  Previous = 3,
+  Next = 4,
+  First = 5,
+  Last = 6,
+}
 
 /** Safety valve for {@link AccessibilityAuditService.walkElements}. */
 const MAX_WALK_ELEMENTS = 1000;

--- a/src/services/ios/accessibility-audit/index.ts
+++ b/src/services/ios/accessibility-audit/index.ts
@@ -72,6 +72,12 @@ export enum AxFocusDirection {
 /** Default wait for the focus event a move produces. */
 const DEFAULT_FOCUS_TIMEOUT_MS = 15000;
 
+/**
+ * How many further elements must keep matching before a repeated step is taken
+ * as proof the walk has come round again.
+ */
+const WALK_PERIOD_CONFIRM_STEPS = 6;
+
 /** Safety valve for {@link AccessibilityAuditService.walkElements}. */
 const MAX_WALK_ELEMENTS = 1000;
 
@@ -538,9 +544,15 @@ export class AccessibilityAuditService {
    * therefore collapsed for repeat detection and still yielded individually,
    * and the walk stops only when a *pair* of announcements recurs.
    *
-   * The consequence worth knowing: a screen that legitimately repeats the same
-   * two announcements in sequence ends the walk early, and one where every
-   * element announces alike runs to the safety limit.
+   * A repeated step is treated as a hypothesis rather than proof: the walk keeps
+   * going and only stops once the announcements have kept matching one period
+   * back for several more elements. A screen that happens to take the same step
+   * twice is therefore walked in full, where believing the first repeat would
+   * have cut it short.
+   *
+   * The consequence worth knowing: a screen whose announcements repeat over a
+   * long enough stretch to satisfy that check still ends early, and one where
+   * every element announces alike runs to the safety limit.
    *
    * A screen with nothing focusable yields nothing. Note the daemon reports what
    * is actually drawn, so an app that has not rendered looks empty.
@@ -568,10 +580,13 @@ export class AccessibilityAuditService {
    */
   async *walkElements(options: InspectOptions = {}): AsyncGenerator<AxInspectedElement, void, unknown> {
     const {timeoutMs = DEFAULT_FOCUS_TIMEOUT_MS, showVisuals = false} = options;
-    const steps = new Set<string>();
-    let startedAt: string | undefined;
-    let previous: string | undefined;
-    let held: AxInspectedElement | undefined;
+    /** Every announcement seen so far, so a candidate period can be checked against it. */
+    const history: string[] = [];
+    /** Where each step between two announcements was first seen. */
+    const firstSeen = new Map<string, number>();
+    /** Elements not yet known to be new; dropped if the walk turns out to be repeating. */
+    let held: AxInspectedElement[] = [];
+    let candidate: {period: number; confirmed: number} | undefined;
 
     this.beginFocusWork(showVisuals);
     try {
@@ -608,38 +623,58 @@ export class AccessibilityAuditService {
           break;
         }
 
-        if (previous === undefined) {
-          startedAt = announcement;
-        } else if (announcement !== previous) {
-          const transition = `${previous}\u0000${announcement}`;
-          if (steps.has(transition)) {
-            // The sequence is repeating, so anything held back is a revisit and
-            // goes with it.
-            log.debug('Focus began repeating an earlier sequence; ending the walk');
-            return;
+        const index = history.length;
+        history.push(announcement);
+        if (index > 0 && announcement !== history[index - 1]) {
+          const transition = `${history[index - 1]}\u0000${announcement}`;
+          // Kept at its earliest index: the distance back to the *first* time a
+          // step was taken is what gives the true period.
+          const seenAt = firstSeen.get(transition);
+          if (seenAt === undefined) {
+            firstSeen.set(transition, index);
+          } else if (!candidate) {
+            // A repeated step only *suggests* the walk has come round again.
+            // Confirm it before believing it, by checking the announcements keep
+            // matching one period back.
+            candidate = {period: index - seenAt, confirmed: 0};
           }
-          steps.add(transition);
         }
-        previous = announcement;
+
+        if (candidate) {
+          const matches = history[index] === history[index - candidate.period];
+          if (matches) {
+            candidate.confirmed += 1;
+            held.push(element);
+            if (candidate.confirmed >= WALK_PERIOD_CONFIRM_STEPS) {
+              // The sequence really is repeating, so everything held back is a
+              // revisit and goes with it.
+              log.debug(`Walk came full circle after ${candidate.period} element(s)`);
+              return;
+            }
+            continue;
+          }
+          // The repeat was a coincidence — a screen may well take the same step
+          // twice without having come round. Nothing held was a revisit.
+          log.debug('A repeated step did not hold up; continuing the walk');
+          candidate = undefined;
+          yield* held;
+          held = [];
+        }
 
         // Held back only to see whether it was the wrap; it was not.
-        if (held) {
-          yield held;
-          held = undefined;
-        }
+        yield* held;
+        held = [];
 
-        if (step > 0 && announcement === startedAt) {
+        if (index > 0 && announcement === history[0]) {
           // Possibly the wrap. Decided on the next step, so that the element the
           // walk opened on is not yielded twice.
-          held = element;
+          held.push(element);
         } else {
           yield element;
         }
       }
 
-      if (held) {
-        yield held;
-      }
+      yield* held;
     } finally {
       this.endFocusWork(showVisuals);
     }

--- a/src/services/ios/accessibility-audit/index.ts
+++ b/src/services/ios/accessibility-audit/index.ts
@@ -76,6 +76,17 @@ export type AxFocusDirection = (typeof AxFocusDirection)[keyof typeof AxFocusDir
 const MAX_WALK_ELEMENTS = 1000;
 
 /**
+ * How long to wait for the move onto the first element that opens a walk.
+ *
+ * When focus already sits there the daemon stays silent rather than answering,
+ * so this wait is what the walk pays to find that out. A move that is going to
+ * be answered is answered in tens of milliseconds, so this stays well clear of
+ * the caller's own budget, which would otherwise be spent in full before the
+ * walk could start.
+ */
+const FOCUS_FIRST_PROBE_TIMEOUT_MS = 2000;
+
+/**
  * One accessibility setting reported by
  * {@link AccessibilityAuditService.getAccessibilitySettings}.
  *
@@ -437,17 +448,28 @@ export class AccessibilityAuditService {
    * emits nothing and rejects on timeout. Focus does wrap: `Next` from the last
    * element returns to the first.
    *
+   * On timeout the move has already been sent, and nothing ties the daemon's
+   * push back to the move that caused it. A push landing after the wait gave up
+   * is delivered to the next caller, which then sees a stale element — so treat
+   * a timeout as "this connection is briefly out of step" and let it settle.
+   * Draining blindly does not work: a move that changes nothing is answered with
+   * silence, so the event discarded would as often be a real one.
+   *
    * @param direction Where to move; see {@link AxFocusDirection}.
    * @param options Timeout, and whether to draw the on-device highlight.
    */
   async moveFocus(direction: AxFocusDirection, options: InspectOptions = {}): Promise<AxInspectedElement> {
     const {timeoutMs = 15000, showVisuals = false} = options;
-    const pushed = this.transport.waitForInbound('hostInspectorCurrentElementChanged:', timeoutMs);
     this.setMonitoredEventType(MONITORED_EVENT_FOCUS);
     if (showVisuals) {
       this.setShowVisuals(true);
     }
     try {
+      // Registered before the move is sent so the push cannot be missed, and
+      // inside the try so it is always awaited: an abandoned waiter rejects with
+      // nothing listening once the connection closes, which is an unhandled
+      // rejection rather than an error the caller can catch.
+      const pushed = this.transport.waitForInbound('hostInspectorCurrentElementChanged:', timeoutMs);
       const aux = new MessageAux();
       // Every value is envelope-wrapped: a bare `{direction: n}` is accepted on
       // the wire but moves nothing.
@@ -476,15 +498,21 @@ export class AccessibilityAuditService {
   /**
    * Walks the focusable elements of whatever is on screen, in focus order.
    *
-   * Moves focus forward, yielding each element, and stops when focus returns to
-   * the one it started on — verified live: the daemon wraps from the last
-   * element back to the first rather than reporting an end.
+   * Moves focus forward, yielding each element, and stops once the sequence
+   * starts repeating — the daemon cycles rather than reporting an end.
    *
-   * The stop is keyed on what the element announces, not on
-   * {@link AxElement.platformElement}: the daemon issues a fresh handle for
-   * every focus event, so the same element carries different handles on
-   * successive visits. A screen whose *first* element announces exactly the
-   * same text as a later one therefore ends the walk early.
+   * What counts as a repeat is the step *between* two elements, not an element,
+   * because nothing the daemon sends identifies one. {@link
+   * AxElement.platformElement} is a fresh handle per focus event, and
+   * `accessibilityIdentifier` is absent on most elements, so a screen of
+   * lookalikes — a photo grid announcing "Photo, Image" over and over — offers
+   * nothing to tell its elements apart. Runs of identical announcements are
+   * therefore collapsed for repeat detection and still yielded individually,
+   * and the walk stops only when a *pair* of announcements recurs.
+   *
+   * The consequence worth knowing: a screen that legitimately repeats the same
+   * two announcements in sequence ends the walk early, and one where every
+   * element announces alike runs to the safety limit.
    *
    * A screen with nothing focusable yields nothing. Note the daemon reports what
    * is actually drawn, so an app that has not rendered looks empty.
@@ -511,13 +539,23 @@ export class AccessibilityAuditService {
    * @param options Timeout per step, and whether to draw the on-device highlight.
    */
   async *walkElements(options: InspectOptions = {}): AsyncGenerator<AxInspectedElement, void, unknown> {
-    let startedAt: string | undefined;
+    const steps = new Set<string>();
+    let previous: string | undefined;
+    let pending: AxInspectedElement | undefined;
     let direction: AxFocusDirection = AxFocusDirection.First;
 
     for (let step = 0; step < MAX_WALK_ELEMENTS; step += 1) {
       let element: AxInspectedElement;
       try {
-        element = await this.moveFocus(direction, options);
+        element = await this.moveFocus(
+          direction,
+          step === 0
+            ? {
+                ...options,
+                timeoutMs: Math.min(options.timeoutMs ?? FOCUS_FIRST_PROBE_TIMEOUT_MS, FOCUS_FIRST_PROBE_TIMEOUT_MS),
+              }
+            : options,
+        );
       } catch (error) {
         if (step > 0) {
           throw error;
@@ -531,23 +569,42 @@ export class AccessibilityAuditService {
       }
       direction = AxFocusDirection.Next;
 
-      if (!element.element?.platformElement) {
-        // Nothing focusable — an empty or undrawn screen.
-        log.debug('Focus returned no element; ending the walk');
-        return;
-      }
-      const announcement = element.caption ?? element.spokenDescription;
+      const announcement = element.element?.platformElement
+        ? (element.caption ?? element.spokenDescription)
+        : undefined;
       if (announcement === undefined) {
-        log.debug('Focus returned an element with no announcement; ending the walk');
+        // Nothing focusable, or nothing said about it: an empty or undrawn screen.
+        log.debug('Focus returned nothing to identify; ending the walk');
+        if (pending) {
+          yield pending;
+        }
         return;
       }
-      if (startedAt === undefined) {
-        startedAt = announcement;
-      } else if (announcement === startedAt) {
-        // Back where the walk began: the ring is complete.
-        return;
+
+      if (previous === undefined) {
+        previous = announcement;
+      } else if (announcement !== previous) {
+        const transition = `${previous}\u0000${announcement}`;
+        if (steps.has(transition)) {
+          // The sequence is repeating, so `pending` is a revisit rather than a
+          // new element and is dropped with it.
+          log.debug('Focus began repeating an earlier sequence; ending the walk');
+          return;
+        }
+        steps.add(transition);
+        previous = announcement;
       }
-      yield element;
+
+      // Held back one element: whatever completes a repeat has to be discarded,
+      // and that is only known once the *next* element arrives.
+      if (pending) {
+        yield pending;
+      }
+      pending = element;
+    }
+
+    if (pending) {
+      yield pending;
     }
     log.debug(`Walk stopped at the ${MAX_WALK_ELEMENTS}-element safety limit`);
   }

--- a/src/services/ios/accessibility-audit/index.ts
+++ b/src/services/ios/accessibility-audit/index.ts
@@ -59,6 +59,23 @@ const MONITORED_EVENT_FOCUS = 2;
 const MONITORED_EVENT_OFF = 0;
 
 /**
+ * Where {@link AccessibilityAuditService.moveFocus} sends the accessibility
+ * focus. These are the daemon's own `direction` values, verified live.
+ */
+export const AxFocusDirection = {
+  Previous: 3,
+  Next: 4,
+  First: 5,
+  Last: 6,
+} as const;
+
+/** A value of {@link AxFocusDirection}. */
+export type AxFocusDirection = (typeof AxFocusDirection)[keyof typeof AxFocusDirection];
+
+/** Safety valve for {@link AccessibilityAuditService.walkElements}. */
+const MAX_WALK_ELEMENTS = 1000;
+
+/**
  * One accessibility setting reported by
  * {@link AccessibilityAuditService.getAccessibilitySettings}.
  *
@@ -408,6 +425,131 @@ export class AccessibilityAuditService {
         this.setMonitoredEventType(MONITORED_EVENT_OFF);
       }
     };
+  }
+
+  /**
+   * Moves the device's accessibility focus and resolves with the element it
+   * lands on — the same panel {@link getFocusedElement} returns, plus a handle
+   * in `element`.
+   *
+   * The daemon only reports focus that actually *changed*, so a move with
+   * nowhere to go — `First` when focus is already on the first element —
+   * emits nothing and rejects on timeout. Focus does wrap: `Next` from the last
+   * element returns to the first.
+   *
+   * @param direction Where to move; see {@link AxFocusDirection}.
+   * @param options Timeout, and whether to draw the on-device highlight.
+   */
+  async moveFocus(direction: AxFocusDirection, options: InspectOptions = {}): Promise<AxInspectedElement> {
+    const {timeoutMs = 15000, showVisuals = false} = options;
+    const pushed = this.transport.waitForInbound('hostInspectorCurrentElementChanged:', timeoutMs);
+    this.setMonitoredEventType(MONITORED_EVENT_FOCUS);
+    if (showVisuals) {
+      this.setShowVisuals(true);
+    }
+    try {
+      const aux = new MessageAux();
+      // Every value is envelope-wrapped: a bare `{direction: n}` is accepted on
+      // the wire but moves nothing.
+      aux.appendObj({
+        ObjectType: 'passthrough',
+        Value: {
+          allowNonAX: {ObjectType: 'passthrough', Value: 0},
+          direction: {ObjectType: 'passthrough', Value: direction},
+          includeContainers: {ObjectType: 'passthrough', Value: 1},
+        },
+      });
+      this.transport.invokeOneway('deviceInspectorMoveWithOptions:', aux);
+      const [payload] = await pushed;
+      return toInspectedElement(deserializeAxObject(payload));
+    } finally {
+      if (showVisuals) {
+        this.setShowVisuals(false);
+      }
+      // Leave monitoring armed if an observer is relying on it.
+      if (this.observerCount === 0) {
+        this.setMonitoredEventType(MONITORED_EVENT_OFF);
+      }
+    }
+  }
+
+  /**
+   * Walks the focusable elements of whatever is on screen, in focus order.
+   *
+   * Moves focus forward, yielding each element, and stops when focus returns to
+   * the one it started on — verified live: the daemon wraps from the last
+   * element back to the first rather than reporting an end.
+   *
+   * The stop is keyed on what the element announces, not on
+   * {@link AxElement.platformElement}: the daemon issues a fresh handle for
+   * every focus event, so the same element carries different handles on
+   * successive visits. A screen whose *first* element announces exactly the
+   * same text as a later one therefore ends the walk early.
+   *
+   * A screen with nothing focusable yields nothing. Note the daemon reports what
+   * is actually drawn, so an app that has not rendered looks empty.
+   *
+   * Moving focus is a device-wide action: it leaves the focus wherever the walk
+   * finished.
+   *
+   * Read an element's attributes **inside** the loop. `element` is only valid
+   * while it holds focus — {@link getElementAttributeValue} returns real values
+   * for the element being yielded and `null` for one the walk has moved past.
+   *
+   * @example
+   * ```ts
+   * for await (const focused of audit.walkElements()) {
+   *   const basic = focused.sections.find((section) => section.title === 'Basic');
+   *   const label = basic?.attributes.find((attribute) => attribute.name === 'Label');
+   *   // Read now: after the next iteration this element is no longer focused.
+   *   const value = label && focused.element
+   *     ? await audit.getElementAttributeValue(focused.element, label)
+   *     : undefined;
+   * }
+   * ```
+   *
+   * @param options Timeout per step, and whether to draw the on-device highlight.
+   */
+  async *walkElements(options: InspectOptions = {}): AsyncGenerator<AxInspectedElement, void, unknown> {
+    let startedAt: string | undefined;
+    let direction: AxFocusDirection = AxFocusDirection.First;
+
+    for (let step = 0; step < MAX_WALK_ELEMENTS; step += 1) {
+      let element: AxInspectedElement;
+      try {
+        element = await this.moveFocus(direction, options);
+      } catch (error) {
+        if (step > 0) {
+          throw error;
+        }
+        // Focus was already on the first element, so `First` changed nothing and
+        // the daemon stayed silent. Walking forward from here still reaches
+        // every element — focus wraps — just starting one along.
+        log.debug('Focus was already at the first element; walking from where it is');
+        direction = AxFocusDirection.Next;
+        continue;
+      }
+      direction = AxFocusDirection.Next;
+
+      if (!element.element?.platformElement) {
+        // Nothing focusable — an empty or undrawn screen.
+        log.debug('Focus returned no element; ending the walk');
+        return;
+      }
+      const announcement = element.caption ?? element.spokenDescription;
+      if (announcement === undefined) {
+        log.debug('Focus returned an element with no announcement; ending the walk');
+        return;
+      }
+      if (startedAt === undefined) {
+        startedAt = announcement;
+      } else if (announcement === startedAt) {
+        // Back where the walk began: the ring is complete.
+        return;
+      }
+      yield element;
+    }
+    log.debug(`Walk stopped at the ${MAX_WALK_ELEMENTS}-element safety limit`);
   }
 
   /**

--- a/src/services/ios/accessibility-audit/index.ts
+++ b/src/services/ios/accessibility-audit/index.ts
@@ -69,6 +69,9 @@ export enum AxFocusDirection {
   Last = 6,
 }
 
+/** Default wait for the focus event a move produces. */
+const DEFAULT_FOCUS_TIMEOUT_MS = 15000;
+
 /** Safety valve for {@link AccessibilityAuditService.walkElements}. */
 const MAX_WALK_ELEMENTS = 1000;
 
@@ -130,6 +133,7 @@ export class AccessibilityAuditService {
 
   /** Live {@link observeFocusedElement} subscriptions; monitoring stays armed while > 0. */
   private observerCount = 0;
+  private focusMoveInFlight = false;
 
   /** Guards {@link runAudit} against overlapping calls on one instance. */
   private auditInFlight = false;
@@ -445,6 +449,9 @@ export class AccessibilityAuditService {
    * emits nothing and rejects on timeout. Focus does wrap: `Next` from the last
    * element returns to the first.
    *
+   * Only one focus move may be in flight per instance — a second concurrent call
+   * rejects, since both would be resolved by the same push.
+   *
    * On timeout the move has already been sent, and nothing ties the daemon's
    * push back to the move that caused it. A push landing after the wait gave up
    * is delivered to the next caller, which then sees a stale element — so treat
@@ -456,39 +463,63 @@ export class AccessibilityAuditService {
    * @param options Timeout, and whether to draw the on-device highlight.
    */
   async moveFocus(direction: AxFocusDirection, options: InspectOptions = {}): Promise<AxInspectedElement> {
-    const {timeoutMs = 15000, showVisuals = false} = options;
+    const {timeoutMs = DEFAULT_FOCUS_TIMEOUT_MS, showVisuals = false} = options;
+    this.beginFocusWork(showVisuals);
+    try {
+      return await this.requestFocusMove(direction, timeoutMs);
+    } finally {
+      this.endFocusWork(showVisuals);
+    }
+  }
+
+  /**
+   * Sends one move and waits for the focus event it produces.
+   *
+   * Assumes monitoring is already armed, so a walk can arm once instead of once
+   * per step.
+   */
+  private async requestFocusMove(direction: AxFocusDirection, timeoutMs: number): Promise<AxInspectedElement> {
+    // Registered before the move is sent so the push cannot be missed, and
+    // awaited unconditionally: an abandoned waiter rejects with nothing
+    // listening once the connection closes, which is an unhandled rejection
+    // rather than an error the caller can catch.
+    const pushed = this.transport.waitForInbound('hostInspectorCurrentElementChanged:', timeoutMs);
+    const aux = new MessageAux();
+    // Every value is envelope-wrapped: a bare `{direction: n}` is accepted on
+    // the wire but moves nothing.
+    aux.appendObj({
+      ObjectType: 'passthrough',
+      Value: {
+        allowNonAX: {ObjectType: 'passthrough', Value: 0},
+        direction: {ObjectType: 'passthrough', Value: direction},
+        includeContainers: {ObjectType: 'passthrough', Value: 1},
+      },
+    });
+    this.transport.invokeOneway('deviceInspectorMoveWithOptions:', aux);
+    const [payload] = await pushed;
+    return toInspectedElement(deserializeAxObject(payload));
+  }
+
+  /** Arms monitoring for focus work and rejects a second concurrent caller. */
+  private beginFocusWork(showVisuals: boolean): void {
+    if (this.focusMoveInFlight) {
+      throw new Error('A focus move is already running on this service instance; await it or use a second instance');
+    }
+    this.focusMoveInFlight = true;
     this.setMonitoredEventType(MONITORED_EVENT_FOCUS);
     if (showVisuals) {
       this.setShowVisuals(true);
     }
-    try {
-      // Registered before the move is sent so the push cannot be missed, and
-      // inside the try so it is always awaited: an abandoned waiter rejects with
-      // nothing listening once the connection closes, which is an unhandled
-      // rejection rather than an error the caller can catch.
-      const pushed = this.transport.waitForInbound('hostInspectorCurrentElementChanged:', timeoutMs);
-      const aux = new MessageAux();
-      // Every value is envelope-wrapped: a bare `{direction: n}` is accepted on
-      // the wire but moves nothing.
-      aux.appendObj({
-        ObjectType: 'passthrough',
-        Value: {
-          allowNonAX: {ObjectType: 'passthrough', Value: 0},
-          direction: {ObjectType: 'passthrough', Value: direction},
-          includeContainers: {ObjectType: 'passthrough', Value: 1},
-        },
-      });
-      this.transport.invokeOneway('deviceInspectorMoveWithOptions:', aux);
-      const [payload] = await pushed;
-      return toInspectedElement(deserializeAxObject(payload));
-    } finally {
-      if (showVisuals) {
-        this.setShowVisuals(false);
-      }
-      // Leave monitoring armed if an observer is relying on it.
-      if (this.observerCount === 0) {
-        this.setMonitoredEventType(MONITORED_EVENT_OFF);
-      }
+  }
+
+  /** Undoes {@link beginFocusWork}, leaving monitoring armed for any observer. */
+  private endFocusWork(showVisuals: boolean): void {
+    this.focusMoveInFlight = false;
+    if (showVisuals) {
+      this.setShowVisuals(false);
+    }
+    if (this.observerCount === 0) {
+      this.setMonitoredEventType(MONITORED_EVENT_OFF);
     }
   }
 
@@ -536,74 +567,82 @@ export class AccessibilityAuditService {
    * @param options Timeout per step, and whether to draw the on-device highlight.
    */
   async *walkElements(options: InspectOptions = {}): AsyncGenerator<AxInspectedElement, void, unknown> {
+    const {timeoutMs = DEFAULT_FOCUS_TIMEOUT_MS, showVisuals = false} = options;
     const steps = new Set<string>();
+    let startedAt: string | undefined;
     let previous: string | undefined;
-    let pending: AxInspectedElement | undefined;
-    let direction: AxFocusDirection = AxFocusDirection.First;
+    let held: AxInspectedElement | undefined;
 
-    for (let step = 0; step < MAX_WALK_ELEMENTS; step += 1) {
-      let element: AxInspectedElement;
-      try {
-        element = await this.moveFocus(
-          direction,
-          step === 0
-            ? {
-                ...options,
-                timeoutMs: Math.min(options.timeoutMs ?? FOCUS_FIRST_PROBE_TIMEOUT_MS, FOCUS_FIRST_PROBE_TIMEOUT_MS),
-              }
-            : options,
-        );
-      } catch (error) {
-        if (step > 0) {
-          throw error;
+    this.beginFocusWork(showVisuals);
+    try {
+      for (let step = 0; step < MAX_WALK_ELEMENTS; step += 1) {
+        let element: AxInspectedElement;
+        try {
+          element =
+            step === 0
+              ? await this.requestFocusMove(AxFocusDirection.First, Math.min(timeoutMs, FOCUS_FIRST_PROBE_TIMEOUT_MS))
+              : await this.requestFocusMove(AxFocusDirection.Next, timeoutMs);
+        } catch {
+          if (step > 0) {
+            // Focus stopped moving. That is how a screen with a single focusable
+            // element ends, so the walk finishes with what it has rather than
+            // discarding it and rejecting.
+            log.debug('Focus stopped moving; ending the walk');
+            break;
+          }
+          // The opening move changed nothing, so focus already sits where the
+          // walk would have put it. `deviceInspectorFocusOnElement:` cannot be
+          // used to pick it up — it answers with a panel carrying no element
+          // handle — so the walk simply advances from here. Focus cycles, so
+          // every element is still reached, just starting one along.
+          log.debug('Opening move changed nothing; walking on from where focus is');
+          continue;
         }
-        // Focus was already on the first element, so `First` changed nothing and
-        // the daemon stayed silent. Walking forward from here still reaches
-        // every element — focus wraps — just starting one along.
-        log.debug('Focus was already at the first element; walking from where it is');
-        direction = AxFocusDirection.Next;
-        continue;
-      }
-      direction = AxFocusDirection.Next;
 
-      const announcement = element.element?.platformElement
-        ? (element.caption ?? element.spokenDescription)
-        : undefined;
-      if (announcement === undefined) {
-        // Nothing focusable, or nothing said about it: an empty or undrawn screen.
-        log.debug('Focus returned nothing to identify; ending the walk');
-        if (pending) {
-          yield pending;
+        const announcement = element.element?.platformElement
+          ? (element.caption ?? element.spokenDescription)
+          : undefined;
+        if (announcement === undefined) {
+          // Nothing focusable, or nothing said about it: an empty or undrawn screen.
+          log.debug('Focus returned nothing to identify; ending the walk');
+          break;
         }
-        return;
-      }
 
-      if (previous === undefined) {
+        if (previous === undefined) {
+          startedAt = announcement;
+        } else if (announcement !== previous) {
+          const transition = `${previous}\u0000${announcement}`;
+          if (steps.has(transition)) {
+            // The sequence is repeating, so anything held back is a revisit and
+            // goes with it.
+            log.debug('Focus began repeating an earlier sequence; ending the walk');
+            return;
+          }
+          steps.add(transition);
+        }
         previous = announcement;
-      } else if (announcement !== previous) {
-        const transition = `${previous}\u0000${announcement}`;
-        if (steps.has(transition)) {
-          // The sequence is repeating, so `pending` is a revisit rather than a
-          // new element and is dropped with it.
-          log.debug('Focus began repeating an earlier sequence; ending the walk');
-          return;
+
+        // Held back only to see whether it was the wrap; it was not.
+        if (held) {
+          yield held;
+          held = undefined;
         }
-        steps.add(transition);
-        previous = announcement;
+
+        if (step > 0 && announcement === startedAt) {
+          // Possibly the wrap. Decided on the next step, so that the element the
+          // walk opened on is not yielded twice.
+          held = element;
+        } else {
+          yield element;
+        }
       }
 
-      // Held back one element: whatever completes a repeat has to be discarded,
-      // and that is only known once the *next* element arrives.
-      if (pending) {
-        yield pending;
+      if (held) {
+        yield held;
       }
-      pending = element;
+    } finally {
+      this.endFocusWork(showVisuals);
     }
-
-    if (pending) {
-      yield pending;
-    }
-    log.debug(`Walk stopped at the ${MAX_WALK_ELEMENTS}-element safety limit`);
   }
 
   /**

--- a/test/integration/accessibility-audit.spec.ts
+++ b/test/integration/accessibility-audit.spec.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import {type TestContext, after, before, describe, it} from 'node:test';
 
-import {AxFocusDirection, type AccessibilityAuditService} from '../../src/index.js';
+import {AxFocusDirection, type AccessibilityAuditService, type AxInspectedElement} from '../../src/index.js';
 import * as Services from '../../src/services.js';
 import {requireDeviceUdid} from './helpers/device.js';
 
@@ -301,6 +301,13 @@ describe('AccessibilityAuditService', {timeout: 300000}, function () {
       assert.deepStrictEqual(back.element?.platformElement, start.element?.platformElement);
     });
 
+    /** What an element announces — the walk's own notion of identity. */
+    function announcementOf(focused: AxInspectedElement): string {
+      const announcement = focused.caption ?? focused.spokenDescription;
+      assert.ok(announcement !== undefined, 'a walked element should announce something');
+      return announcement;
+    }
+
     it('enumerates distinct elements and terminates', async function (t) {
       if (skipWithoutFocusMove(t)) {
         return;
@@ -308,12 +315,43 @@ describe('AccessibilityAuditService', {timeout: 300000}, function () {
       const seen: string[] = [];
       for await (const focused of service!.walkElements({timeoutMs: 20000})) {
         assert.ok(focused.element, 'each walked element should carry a handle');
-        seen.push(focused.element.platformElement.toString('base64'));
+        seen.push(announcementOf(focused));
       }
 
-      // Termination is by revisit — focus wraps rather than reporting an end.
+      // Focus wraps rather than reporting an end, so the walk stops when it
+      // returns to the element it started on. Asserting on the announcement
+      // rather than `platformElement` is deliberate: the daemon issues a fresh
+      // handle for every focus event, so a handle-based check passes even if
+      // the walk laps the screen forever.
+      assert.ok(seen.length > 0, 'the walk should reach at least one element');
       assert.strictEqual(new Set(seen).size, seen.length, 'the walk must not yield an element twice');
       t.diagnostic(`walked ${seen.length} element(s)`);
+    });
+
+    it('walks the same elements when focus already sits on the first one', async function (t) {
+      if (skipWithoutFocusMove(t)) {
+        return;
+      }
+      const baseline = new Set<string>();
+      for await (const focused of service!.walkElements({timeoutMs: 20000})) {
+        baseline.add(announcementOf(focused));
+      }
+
+      // `First` emits nothing when focus is already there, so this parks focus
+      // on the first element to exercise the walk's opening no-op.
+      try {
+        await service!.moveFocus(AxFocusDirection.First, {timeoutMs: 20000});
+      } catch {
+        // Already there — which is exactly the state under test.
+      }
+
+      const afterward = new Set<string>();
+      for await (const focused of service!.walkElements({timeoutMs: 20000})) {
+        afterward.add(announcementOf(focused));
+      }
+
+      assert.deepStrictEqual(afterward, baseline, 'a walk that opens on a no-op should still reach every element');
+      t.diagnostic(`reached ${afterward.size} element(s) from both starting points`);
     });
 
     it('reads attributes for the element currently focused', async function (t) {

--- a/test/integration/accessibility-audit.spec.ts
+++ b/test/integration/accessibility-audit.spec.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import {type TestContext, after, before, describe, it} from 'node:test';
 
-import {type AccessibilityAuditService} from '../../src/index.js';
+import {AxFocusDirection, type AccessibilityAuditService} from '../../src/index.js';
 import * as Services from '../../src/services.js';
 import {requireDeviceUdid} from './helpers/device.js';
 
@@ -20,9 +20,16 @@ import {requireDeviceUdid} from './helpers/device.js';
  */
 // Generous: the audits alone take ~60s, and the settings tests deliberately
 // pace their writes because the device commits them asynchronously.
+/** Minimal shape of the aux payload the monitoring spy inspects. */
+interface MessageAuxLike {
+  getValues(): Array<{value: unknown}>;
+}
+
 describe('AccessibilityAuditService', {timeout: 300000}, function () {
   /** The selector the setting-write tests depend on. */
   const SETTING_WRITE_SELECTOR = 'deviceUpdateAccessibilitySetting:withValue:';
+  /** The selector focus traversal depends on. */
+  const FOCUS_MOVE_SELECTOR = 'deviceInspectorMoveWithOptions:';
   /** The selector the reset tests depend on. */
   const SETTING_RESET_SELECTOR = 'deviceResetToDefaultAccessibilitySettings';
 
@@ -31,6 +38,8 @@ describe('AccessibilityAuditService', {timeout: 300000}, function () {
   let supportsSettingWrites = false;
   /** Whether it implements the reset selector, which the write tests do not use. */
   let supportsSettingReset = false;
+  /** Whether it implements focus traversal. */
+  let supportsFocusMove = false;
 
   before(async function () {
     const udid = requireDeviceUdid();
@@ -41,6 +50,7 @@ describe('AccessibilityAuditService', {timeout: 300000}, function () {
     const capabilities = await service.getCapabilities();
     supportsSettingWrites = capabilities.includes(SETTING_WRITE_SELECTOR);
     supportsSettingReset = capabilities.includes(SETTING_RESET_SELECTOR);
+    supportsFocusMove = capabilities.includes(FOCUS_MOVE_SELECTOR);
   });
 
   after(function () {
@@ -245,6 +255,104 @@ describe('AccessibilityAuditService', {timeout: 300000}, function () {
       // One cheap type is enough here: before the guard this timed out
       // permanently on this connection.
       assert.ok(Array.isArray(await service!.runAudit(['testTypeContrast'], {timeoutMs: 60000})));
+    });
+  });
+
+  /**
+   * Focus traversal reports what is actually drawn, so these assert shape rather
+   * than a fixed element count — that depends on whatever is on screen.
+   */
+  describe('focus traversal', function () {
+    /** Skips when the daemon does not implement focus movement. */
+    function skipWithoutFocusMove(t: TestContext): boolean {
+      if (!supportsFocusMove) {
+        t.skip(`daemon does not implement ${FOCUS_MOVE_SELECTOR}`);
+        return true;
+      }
+      return false;
+    }
+
+    it('moves focus and returns the element it landed on', async function (t) {
+      if (skipWithoutFocusMove(t)) {
+        return;
+      }
+      // Next rather than First: focus wraps so Next always moves, whereas First
+      // emits nothing when focus already sits on the first element.
+      const first = await service!.moveFocus(AxFocusDirection.Next, {timeoutMs: 20000});
+
+      assert.ok(first.element, 'a focus push should carry an element handle');
+      assert.ok(Buffer.isBuffer(first.element.platformElement));
+      assert.ok(first.sections.length > 0, 'the inspector panel should come with it');
+      t.diagnostic(`First landed on ${JSON.stringify(first.caption)}`);
+    });
+
+    it('moves forward and back between elements', async function (t) {
+      if (skipWithoutFocusMove(t)) {
+        return;
+      }
+      // Only Next/Previous are used: focus wraps, so they always move. `First`
+      // would be a no-op if focus already sat on the first element, and a move
+      // that changes nothing emits no event at all.
+      const start = await service!.moveFocus(AxFocusDirection.Next, {timeoutMs: 20000});
+      const forward = await service!.moveFocus(AxFocusDirection.Next, {timeoutMs: 20000});
+      const back = await service!.moveFocus(AxFocusDirection.Previous, {timeoutMs: 20000});
+
+      assert.notDeepStrictEqual(forward.element?.platformElement, start.element?.platformElement);
+      assert.deepStrictEqual(back.element?.platformElement, start.element?.platformElement);
+    });
+
+    it('enumerates distinct elements and terminates', async function (t) {
+      if (skipWithoutFocusMove(t)) {
+        return;
+      }
+      const seen: string[] = [];
+      for await (const focused of service!.walkElements({timeoutMs: 20000})) {
+        assert.ok(focused.element, 'each walked element should carry a handle');
+        seen.push(focused.element.platformElement.toString('base64'));
+      }
+
+      // Termination is by revisit — focus wraps rather than reporting an end.
+      assert.strictEqual(new Set(seen).size, seen.length, 'the walk must not yield an element twice');
+      t.diagnostic(`walked ${seen.length} element(s)`);
+    });
+
+    it('reads attributes for the element currently focused', async function (t) {
+      if (skipWithoutFocusMove(t)) {
+        return;
+      }
+      const focused = await service!.moveFocus(AxFocusDirection.Next, {timeoutMs: 20000});
+      const basic = focused.sections.find((section) => section.title === 'Basic');
+      const label = basic?.attributes.find((attribute) => attribute.name === 'Label');
+      assert.ok(label && focused.element, 'expected a Label attribute on the focused element');
+
+      // The handle is only valid while the element holds focus, so this reads
+      // immediately rather than after moving on.
+      const value = await service!.getElementAttributeValue(focused.element, label, {timeoutMs: 15000});
+      t.diagnostic(`Label = ${JSON.stringify(value)}`);
+      assert.ok(value === null || typeof value === 'string');
+    });
+
+    it('leaves monitoring disarmed when no observer is active', async function (t) {
+      if (skipWithoutFocusMove(t)) {
+        return;
+      }
+      const sent: unknown[] = [];
+      const transport = (service! as unknown as {transport: {invokeOneway: (s: string, a: MessageAuxLike) => void}})
+        .transport;
+      const real = transport.invokeOneway.bind(transport);
+      transport.invokeOneway = (selector, aux) => {
+        if (selector === 'deviceInspectorSetMonitoredEventType:') {
+          sent.push(aux.getValues()[0].value);
+        }
+        return real(selector, aux);
+      };
+      try {
+        await service!.moveFocus(AxFocusDirection.Next, {timeoutMs: 20000});
+      } finally {
+        transport.invokeOneway = real;
+      }
+
+      assert.ok(sent.includes(0), `expected monitoring to be disarmed, got [${sent.join(', ')}]`);
     });
   });
 


### PR DESCRIPTION
Adds focus traversal to the accessibility audit service: `moveFocus(direction)` moves VoiceOver-style focus (First/Last/Next/Previous) and returns the element it lands on, and `walkElements()` enumerates a screen by walking focus forward.

Focus cycles rather than reporting an end, and nothing the daemon sends identifies an element - `platformElement` is a fresh handle per focus event and `accessibilityIdentifier` is absent on most elements. The walk therefore stops when a pair of announcements recurs, collapsing runs of identical announcements (a photo grid announces "Photo, Image" repeatedly) and holding one element back so the revisit isn't yielded.

### API Usage

```ts
const audit = await Services.startAccessibilityAuditService(udid);
try {
  // One step — move focus and see what it landed on.
  const focused = await audit.moveFocus(AxFocusDirection.Next);
  console.log(focused.caption);        // 'Wi-Fi, **SSID name**, Button'

  // Whole screen — walk focus forward until the sequence repeats.
  for await (const element of audit.walkElements()) {
    console.log(element.caption);
  }
} finally {
  audit.close();
}
```
