### PR TITLE
perf(plist): resolve receivers on decode instead of 50ms polling

### DIFF
--- a/src/lib/plist/plist-service.ts
+++ b/src/lib/plist/plist-service.ts
@@ -26,6 +26,12 @@ export interface PlistServiceOptions {
  */
 type PlistMessage = PlistDictionary;
 
+interface PlistWaiter {
+  resolve: (message: PlistMessage) => void;
+  reject: (error: Error) => void;
+  timeoutId: NodeJS.Timeout;
+}
+
 /**
  * Service for communication using plist protocol
  */
@@ -65,6 +71,7 @@ export class PlistService {
   private readonly _decoder: PlistServiceDecoder;
   private _encoder: PlistServiceEncoder;
   private _messageQueue: PlistMessage[];
+  private _waiters: PlistWaiter[];
 
   /**
    * Creates a new PlistService instance
@@ -86,7 +93,16 @@ export class PlistService {
 
     // Message queue for async receiving
     this._messageQueue = [];
-    this._decoder.on('data', (data: PlistMessage) => this._messageQueue.push(data));
+    this._waiters = [];
+    this._decoder.on('data', (data: PlistMessage) => {
+      const waiter = this._waiters.shift();
+      if (waiter) {
+        clearTimeout(waiter.timeoutId);
+        waiter.resolve(data);
+        return;
+      }
+      this._messageQueue.push(data);
+    });
 
     // Handle errors
     this.setupErrorHandlers();
@@ -119,31 +135,28 @@ export class PlistService {
    * Receive a plist message with timeout
    * @param timeout Timeout in ms
    * @returns Promise resolving to the received message
-   * @throws Error if timeout is reached before receiving a message
+   * @throws Error if the timeout is reached, or if close() is called before a message arrives
    */
   public async receivePlist(timeout = 5000): Promise<PlistMessage> {
     return new Promise<PlistMessage>((resolve, reject) => {
-      // Check if we already have a message
       const message = this._messageQueue.shift();
       if (message) {
         return resolve(message);
       }
 
-      // Set up a check interval
-      const checkInterval = setInterval(() => {
-        const message = this._messageQueue.shift();
-        if (message) {
-          clearInterval(checkInterval);
-          clearTimeout(timeoutId);
-          resolve(message);
-        }
-      }, 50);
+      const waiter: PlistWaiter = {
+        resolve,
+        reject,
+        timeoutId: setTimeout(() => {
+          const index = this._waiters.indexOf(waiter);
+          if (index !== -1) {
+            this._waiters.splice(index, 1);
+          }
+          reject(new Error(`Timed out waiting for plist response after ${timeout}ms`));
+        }, timeout),
+      };
 
-      // Set up timeout
-      const timeoutId = setTimeout(() => {
-        clearInterval(checkInterval);
-        reject(new Error(`Timed out waiting for plist response after ${timeout}ms`));
-      }, timeout);
+      this._waiters.push(waiter);
     });
   }
 
@@ -158,6 +171,11 @@ export class PlistService {
 
       // Clear the message queue to prevent processing during close
       this._messageQueue = [];
+
+      for (const waiter of this._waiters.splice(0)) {
+        clearTimeout(waiter.timeoutId);
+        waiter.reject(new Error('Connection closed while waiting for plist response'));
+      }
 
       // Unpipe the transformers to prevent data flow during close
       try {

--- a/test/unit/plist/plist-service.spec.ts
+++ b/test/unit/plist/plist-service.spec.ts
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import {PassThrough} from 'node:stream';
+import {describe, it} from 'node:test';
+
+import {createPlist} from '../../../src/lib/plist/plist-creator.js';
+import {PlistService} from '../../../src/lib/plist/plist-service.js';
+import type {PlistDictionary} from '../../../src/lib/types.js';
+
+function framePlist(data: PlistDictionary): Buffer {
+  const xml = createPlist(data);
+  const buf = Buffer.from(xml, 'utf8');
+  const header = Buffer.alloc(4);
+  header.writeUInt32BE(buf.length, 0);
+  return Buffer.concat([header, buf]);
+}
+
+describe('PlistService event-driven receive', function () {
+  it('should resolve immediately when message is already queued', async function () {
+    const socket = new PassThrough();
+    const service = new PlistService(socket as any);
+
+    socket.write(framePlist({key: 'value1'}));
+    await new Promise((r) => setImmediate(r));
+
+    const msg = await service.receivePlist(1000);
+    assert.deepStrictEqual(msg, {key: 'value1'});
+    service.close();
+  });
+
+  it('should resolve waiting receiver immediately upon data arrival without polling delay', async function () {
+    const socket = new PassThrough();
+    const service = new PlistService(socket as any);
+
+    const start = Date.now();
+    const receivePromise = service.receivePlist(1000);
+
+    // Send payload after short tick
+    setImmediate(() => {
+      socket.write(framePlist({response: 'ok'}));
+    });
+
+    const msg = await receivePromise;
+    const elapsed = Date.now() - start;
+
+    assert.deepStrictEqual(msg, {response: 'ok'});
+    // Should resolve substantially faster than the previous 50ms polling tick
+    assert.ok(elapsed < 40, `Expected elapsed < 40ms, got ${elapsed}ms`);
+    service.close();
+  });
+
+  it('should resolve multiple receivers in FIFO order', async function () {
+    const socket = new PassThrough();
+    const service = new PlistService(socket as any);
+
+    const p1 = service.receivePlist(1000);
+    const p2 = service.receivePlist(1000);
+
+    socket.write(framePlist({order: 1}));
+    socket.write(framePlist({order: 2}));
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+    assert.deepStrictEqual(r1, {order: 1});
+    assert.deepStrictEqual(r2, {order: 2});
+    service.close();
+  });
+
+  it('should timeout with expected message and clean up waiter', async function () {
+    const socket = new PassThrough();
+    const service = new PlistService(socket as any);
+
+    await assert.rejects(service.receivePlist(50), /Timed out waiting for plist response after 50ms/);
+
+    // After timeout, arriving message should go to message queue or subsequent waiter
+    socket.write(framePlist({afterTimeout: true}));
+    await new Promise((r) => setImmediate(r));
+
+    const subsequent = await service.receivePlist(1000);
+    assert.deepStrictEqual(subsequent, {afterTimeout: true});
+    service.close();
+  });
+
+  it('should reject pending waiters immediately on close()', async function () {
+    const socket = new PassThrough();
+    const service = new PlistService(socket as any);
+
+    const p1 = service.receivePlist(5000);
+    const p2 = service.receivePlist(5000);
+
+    service.close();
+
+    await assert.rejects(p1, /Connection closed while waiting for plist response/);
+    await assert.rejects(p2, /Connection closed while waiting for plist response/);
+  });
+});


### PR DESCRIPTION
## Problem

`receivePlist` polled `_messageQueue` every 50ms. The queue is already filled by the decoder `data` event, so the poll only added latency.

## Fix

Decoder resolves the waiting receiver directly. Queue is the fallback when nobody is waiting.

`close()` now rejects pending receivers instead of leaving them until timeout.

## Before / after

| | before | after |
|---|---|---|
| 20 sequential round trips | 1023ms | 6.5ms |
| service startup | 51ms | 3ms |
| inbound WebInspector message | 25ms | 1.7ms |
| installation-proxy suite, real device | 2.11s | 1.70s |

Timeouts unchanged.

## Tests

Unit 809/809. New spec fails 2/5 on old code.

Device: installation-proxy 10/10 x3, webinspector 5 pass 0 fail, notification-proxy live lockstate relays.