### PR TITLE
fix(remote-xpc): propagate XPC decode errors instead of stalling

### DIFF
--- a/src/lib/remote-xpc/remote-xpc-framed-transport.ts
+++ b/src/lib/remote-xpc/remote-xpc-framed-transport.ts
@@ -237,7 +237,9 @@ export class RemoteXpcFramedTransport extends EventEmitter {
   private handleDesync(reason: string): void {
     this.desynced = true;
     this.connected = false;
-    void this.close();
+    this.close().catch((error: unknown) => {
+      log.debug(`Failed to close a desynced RemoteXPC transport: ${error}`);
+    });
     this.emit('error', new Error(reason));
   }
 

--- a/src/lib/remote-xpc/remote-xpc-framed-transport.ts
+++ b/src/lib/remote-xpc/remote-xpc-framed-transport.ts
@@ -2,10 +2,11 @@ import {EventEmitter} from 'node:events';
 import net from 'node:net';
 
 import {getLogger} from '../logger.js';
+import type {XPCDictionary} from '../types.js';
 import {DataFrame} from './handshake-frames.js';
 import Handshake from './handshake.js';
 import {Http2FrameParser, buildWindowUpdateFrames} from './http2-frame-parser.js';
-import {decodeMessage} from './xpc-protocol.js';
+import {decodeMessage, probeXpcFraming} from './xpc-protocol.js';
 
 const log = getLogger('RemoteXpcFramedTransport');
 
@@ -25,9 +26,10 @@ export class RemoteXpcFramedTransport extends EventEmitter {
   private readonly address: [string, number];
   private socket: net.Socket | null = null;
   private frameParser = new Http2FrameParser();
-  private pendingXpcData = Buffer.alloc(0);
+  private pendingXpcData = new Map<number, Buffer>();
   private connected = false;
   private closing = false;
+  private desynced = false;
 
   constructor(address: [string, number]) {
     super();
@@ -129,12 +131,24 @@ export class RemoteXpcFramedTransport extends EventEmitter {
     });
   }
 
+  /**
+   * Handlers ignore a socket that has since been replaced by a reconnect; a closing
+   * socket outlives `close()`, and its late events would otherwise hit the new one.
+   */
   private registerSocketHandlers(socket: net.Socket): void {
+    const superseded = (): boolean => this.socket !== null && this.socket !== socket;
+
     socket.on('data', (data: Buffer | string) => {
+      if (superseded()) {
+        return;
+      }
       const chunk = Buffer.isBuffer(data) ? data : Buffer.from(data, 'hex');
       this.handleData(chunk);
     });
     socket.on('error', (error: Error) => {
+      if (superseded()) {
+        return;
+      }
       const wasConnected = this.connected;
       this.connected = false;
       if (this.closing || !wasConnected) {
@@ -145,6 +159,9 @@ export class RemoteXpcFramedTransport extends EventEmitter {
       this.emit('error', error);
     });
     socket.on('close', () => {
+      if (superseded()) {
+        return;
+      }
       this.connected = false;
       this.emit('close');
     });
@@ -168,29 +185,77 @@ export class RemoteXpcFramedTransport extends EventEmitter {
         continue;
       }
 
+      const socket = this.socket;
+      if (this.desynced || !socket) {
+        return;
+      }
+
       const {streamId, data, bodyLen} = frame.frame;
       for (const windowUpdate of buildWindowUpdateFrames(streamId, bodyLen)) {
-        this.socket.write(windowUpdate);
+        socket.write(windowUpdate);
       }
-      this.ingestXpcData(data);
+      this.ingestXpcData(streamId, data);
     }
   }
 
-  private ingestXpcData(chunk: Buffer): void {
-    let pending = Buffer.concat([this.pendingXpcData, chunk]);
-    this.pendingXpcData = Buffer.alloc(0);
+  /**
+   * Reassembles XPC messages for one HTTP/2 stream; streams buffer separately so
+   * interleaving cannot fabricate a desync. Framed-but-undecodable messages are
+   * skipped, and a retained tail is copied so it cannot pin the parser's buffer.
+   */
+  private ingestXpcData(streamId: number, chunk: Buffer): void {
+    if (this.desynced) {
+      return;
+    }
+
+    const buffered = this.pendingXpcData.get(streamId);
+    let pending = buffered ? Buffer.concat([buffered, chunk]) : chunk;
+    this.pendingXpcData.delete(streamId);
 
     while (pending.length > 0) {
-      try {
-        const {message, bytesConsumed} = decodeMessage(pending);
-        pending = pending.subarray(bytesConsumed);
-        if (message.body) {
-          this.emit('message', message.body);
-        }
-      } catch {
-        this.pendingXpcData = pending;
+      const framing = probeXpcFraming(pending);
+      if (framing.status === 'incomplete') {
+        this.pendingXpcData.set(streamId, Buffer.from(pending));
         return;
       }
+      if (framing.status === 'desynced') {
+        this.handleDesync(framing.reason);
+        return;
+      }
+
+      const message = pending.subarray(0, framing.byteLength);
+      pending = pending.subarray(framing.byteLength);
+      this.decodeAndEmit(message);
+    }
+  }
+
+  /**
+   * Latches the whole connection closed: framing alignment is lost and the peer's
+   * remaining bytes cannot be trusted on any stream. Teardown starts before the
+   * emit so a listener that reconnects synchronously keeps its new socket.
+   */
+  private handleDesync(reason: string): void {
+    this.desynced = true;
+    this.connected = false;
+    void this.close();
+    this.emit('error', new Error(reason));
+  }
+
+  /**
+   * A message that will not decode is reported on `'decodeError'`, never `'error'`:
+   * it is not fatal, the messages behind it still arrive, and an unheard `'error'`
+   * would be thrown by Node.
+   */
+  private decodeAndEmit(message: Buffer): void {
+    let body: XPCDictionary | null | undefined;
+    try {
+      body = decodeMessage(message).message.body;
+    } catch (error) {
+      this.emit('decodeError', error instanceof Error ? error : new Error(String(error)));
+      return;
+    }
+    if (body) {
+      this.emit('message', body);
     }
   }
 
@@ -241,6 +306,7 @@ export class RemoteXpcFramedTransport extends EventEmitter {
 
   private resetParsers(): void {
     this.frameParser = new Http2FrameParser();
-    this.pendingXpcData = Buffer.alloc(0);
+    this.pendingXpcData.clear();
+    this.desynced = false;
   }
 }

--- a/src/lib/remote-xpc/rsd-service-catalog-client.ts
+++ b/src/lib/remote-xpc/rsd-service-catalog-client.ts
@@ -177,10 +177,10 @@ class RsdServiceCatalogClient {
   }
 
   /**
-   * The `'error'` listener is permanent, not `once`: Node throws an `'error'` that
-   * has no listener, and one can still arrive after connect() has settled.
-   * `'decodeError'` is a single unreadable message, not a dead connection, so it
-   * must not fail the attempt — the catalog may be in the very next message.
+   * The `'error'` listener is permanent: Node throws an `'error'` that has no
+   * listener, and one can still arrive after connect() has settled. `'decodeError'`
+   * is a single unreadable message, not a dead connection, so it must not fail the
+   * attempt; it logs only the first to stay off the hot path.
    */
   private registerTransportHandlers(session: ConnectSession, transport: RemoteXpcFramedTransport): void {
     transport.on('error', (error: Error) => {
@@ -191,7 +191,7 @@ class RsdServiceCatalogClient {
       session.settleFailure(error);
     });
 
-    transport.on('decodeError', (error: Error) => {
+    transport.once('decodeError', (error: Error) => {
       log.debug(`Skipped an undecodable RSD message: ${error.message}`);
     });
 

--- a/src/lib/remote-xpc/rsd-service-catalog-client.ts
+++ b/src/lib/remote-xpc/rsd-service-catalog-client.ts
@@ -176,13 +176,23 @@ class RsdServiceCatalogClient {
     };
   }
 
+  /**
+   * The `'error'` listener is permanent, not `once`: Node throws an `'error'` that
+   * has no listener, and one can still arrive after connect() has settled.
+   * `'decodeError'` is a single unreadable message, not a dead connection, so it
+   * must not fail the attempt — the catalog may be in the very next message.
+   */
   private registerTransportHandlers(session: ConnectSession, transport: RemoteXpcFramedTransport): void {
-    transport.once('error', (error: Error) => {
+    transport.on('error', (error: Error) => {
       if (!this._isClosing) {
         log.error(`Connection error: ${error}`);
       }
       this._isConnected = false;
       session.settleFailure(error);
+    });
+
+    transport.on('decodeError', (error: Error) => {
+      log.debug(`Skipped an undecodable RSD message: ${error.message}`);
     });
 
     transport.on('message', (body) => this.processIncomingMessage(session, body));

--- a/src/lib/remote-xpc/service-catalog.ts
+++ b/src/lib/remote-xpc/service-catalog.ts
@@ -1,5 +1,5 @@
 import type {XPCDictionary} from '../types.js';
-import {decodeMessage} from './xpc-protocol.js';
+import {decodeMessage, probeXpcFraming} from './xpc-protocol.js';
 
 export interface Service {
   serviceName: string;
@@ -16,35 +16,51 @@ export interface ServicesResponse {
  */
 export class ServiceCatalogCollector {
   private previousFrameData: Buffer = Buffer.alloc(0);
+  private desynced = false;
 
   /**
-   * Feed one DATA frame payload. Returns the catalog when a complete XPC
-   * message containing `Services` has been decoded.
+   * Feed one DATA frame payload. Returns the catalog once a complete XPC message
+   * carrying `Services` decodes. Framed-but-undecodable messages are skipped.
+   * @throws once the stream desyncs, and on every later call — no payload can resynchronise it
    */
   ingestDataPayload(chunk: Buffer): ServicesResponse | null {
+    if (this.desynced) {
+      throw new Error('XPC stream is desynced');
+    }
+
     let pending = Buffer.concat([this.previousFrameData, chunk]);
     this.previousFrameData = Buffer.alloc(0);
 
     while (pending.length > 0) {
-      try {
-        const {message, bytesConsumed} = decodeMessage(pending);
-        pending = pending.subarray(bytesConsumed);
-
-        if (message.body === null || message.body === undefined) {
-          continue;
-        }
-
-        const catalog = servicesFromXpcBody(message.body);
-        if (catalog) {
-          this.previousFrameData = pending;
-          return catalog;
-        }
-      } catch {
+      const framing = probeXpcFraming(pending);
+      if (framing.status === 'incomplete') {
         this.previousFrameData = pending;
         return null;
       }
+      if (framing.status === 'desynced') {
+        this.desynced = true;
+        throw new Error(framing.reason);
+      }
+
+      const message = pending.subarray(0, framing.byteLength);
+      pending = pending.subarray(framing.byteLength);
+
+      const catalog = extractCatalog(message);
+      if (catalog) {
+        this.previousFrameData = pending;
+        return catalog;
+      }
     }
 
+    return null;
+  }
+}
+
+/** Catalog carried by one complete XPC message; null if it carries none or will not decode. */
+function extractCatalog(message: Buffer): ServicesResponse | null {
+  try {
+    return servicesFromXpcBody(decodeMessage(message).message.body);
+  } catch {
     return null;
   }
 }

--- a/src/lib/remote-xpc/xpc-protocol.ts
+++ b/src/lib/remote-xpc/xpc-protocol.ts
@@ -1,4 +1,5 @@
 import type {XPCArray, XPCDictionary, XPCValue} from '../types.js';
+import {Http2Constants} from './constants.js';
 import {XPCUUID} from './xpc-uuid.js';
 
 // Constants for XPC protocol.
@@ -34,6 +35,12 @@ export interface DecodedXpcMessage {
   /** Bytes consumed from `buffer` (may be less than `buffer.length`). */
   bytesConsumed: number;
 }
+
+/** Framing state of the wrapper at the front of a buffer. `desynced` is unrecoverable. */
+export type XpcFramingProbe =
+  | {status: 'incomplete'}
+  | {status: 'desynced'; reason: string}
+  | {status: 'ok'; byteLength: number};
 
 // A simple binary writer that collects Buffer chunks.
 class Writer {
@@ -181,6 +188,12 @@ export function encodeMessage(message: XPCMessage): Buffer {
 }
 
 const XPC_WRAPPER_HEADER_SIZE = 24;
+/**
+ * Upper bound on a declared body length: the initial receive window, which the peer
+ * cannot exceed on a stream because WINDOW_UPDATEs go out only for even streams and
+ * RemoteXPC uses odd ones. Anything larger is corrupt framing, not a partial read.
+ */
+export const MAX_XPC_BODY_SIZE = BigInt(Http2Constants.DEFAULT_SETTINGS_INITIAL_WINDOW_SIZE);
 
 /**
  * Returns the total byte length of one length-prefixed XPC wrapper in `buffer`.
@@ -200,6 +213,30 @@ export function getXpcMessageByteLength(buffer: Buffer): number {
     throw new Error('Incomplete XPC wrapper');
   }
   return total;
+}
+
+/**
+ * Non-throwing framing check: separates "wait for more bytes" from "stream unusable".
+ * An oversized declared length is desync, not a partial read — treating it as
+ * incomplete would buffer the rest of the stream forever.
+ */
+export function probeXpcFraming(buffer: Buffer): XpcFramingProbe {
+  if (buffer.length < XPC_WRAPPER_HEADER_SIZE) {
+    return {status: 'incomplete'};
+  }
+  const magic = buffer.readUInt32LE(0);
+  if (magic !== WRAPPER_MAGIC) {
+    return {status: 'desynced', reason: `Invalid XPC wrapper magic: 0x${magic.toString(16)}`};
+  }
+  const bodyLength = buffer.readBigUInt64LE(8);
+  if (bodyLength > MAX_XPC_BODY_SIZE) {
+    return {status: 'desynced', reason: `XPC body length ${bodyLength} exceeds ${MAX_XPC_BODY_SIZE}`};
+  }
+  const byteLength = XPC_WRAPPER_HEADER_SIZE + Number(bodyLength);
+  if (buffer.length < byteLength) {
+    return {status: 'incomplete'};
+  }
+  return {status: 'ok', byteLength};
 }
 
 /**

--- a/src/services/ios/core-device/core-device-service.ts
+++ b/src/services/ios/core-device/core-device-service.ts
@@ -9,6 +9,9 @@ import {BaseService} from '../base-service.js';
 
 const log = getLogger('CoreDeviceService');
 
+/** Transports already carrying the permanent failure loggers. */
+const loggedTransports = new WeakSet<RemoteXpcFramedTransport>();
+
 const CONNECT_TIMEOUT_MS = 10_000;
 const DEFAULT_INVOKE_TIMEOUT_MS = 30_000;
 
@@ -132,6 +135,7 @@ export abstract class CoreDeviceService extends BaseService {
 
   protected async createTransport(): Promise<RemoteXpcFramedTransport> {
     const transport = new RemoteXpcFramedTransport(await this.resolveServiceAddress(this.serviceName));
+    attachTransportLogging(transport);
     await transport.connect({timeoutMs: CONNECT_TIMEOUT_MS});
     return transport;
   }
@@ -167,17 +171,15 @@ export abstract class CoreDeviceService extends BaseService {
   }
 
   /**
-   * Creates a transport and attaches a permanent `'error'` listener. The
-   * framed transport is an EventEmitter; an `'error'` emitted with no listener
-   * is thrown by Node and crashes the process. `invoke()` registers a per-call
-   * listener, but fire-and-forget `send()` does not — so this guarantees a
-   * listener always exists for the transport's lifetime.
+   * Creates a transport that already carries a permanent `'error'` listener.
+   * Attaching it after connect() would leave the handshake window uncovered:
+   * frames arriving there can emit `'error'`, and Node throws one that has no
+   * listener. Attaching is idempotent, so an override of createTransport() that
+   * already attached is not double-wired.
    */
   private async newTransport(): Promise<RemoteXpcFramedTransport> {
     const transport = await this.createTransport();
-    transport.on('error', (error: Error) => {
-      log.debug(`CoreDevice transport error: ${error.message}`);
-    });
+    attachTransportLogging(transport);
     this.nextMessageId = 1;
     return transport;
   }
@@ -286,6 +288,7 @@ export abstract class CoreDeviceService extends BaseService {
   ): Promise<XPCDictionary> {
     return new Promise<XPCDictionary>((resolve, reject) => {
       let settled = false;
+      let lastDecodeError: Error | undefined;
 
       const cleanup = (): void => {
         if (settled) {
@@ -294,6 +297,7 @@ export abstract class CoreDeviceService extends BaseService {
         settled = true;
         clearTimeout(timer);
         transport.off('message', onMessage);
+        transport.off('decodeError', onDecodeError);
         transport.off('error', onError);
         transport.off('close', onClose);
       };
@@ -305,6 +309,10 @@ export abstract class CoreDeviceService extends BaseService {
         }
         cleanup();
         resolve(body);
+      };
+
+      const onDecodeError = (error: Error): void => {
+        lastDecodeError = error;
       };
 
       const onError = (error: Error): void => {
@@ -319,18 +327,39 @@ export abstract class CoreDeviceService extends BaseService {
 
       const timer = setTimeout(() => {
         cleanup();
+        const cause = lastDecodeError ? `; last message was undecodable: ${lastDecodeError.message}` : '';
         reject(
           new CoreDeviceError(
-            `CoreDevice invocation '${featureIdentifier ?? '<none>'}' timed out after ${timeoutMs}ms`,
+            `CoreDevice invocation '${featureIdentifier ?? '<none>'}' timed out after ${timeoutMs}ms${cause}`,
           ),
         );
       }, timeoutMs);
 
       transport.on('message', onMessage);
+      transport.on('decodeError', onDecodeError);
       transport.once('error', onError);
       transport.once('close', onClose);
     });
   }
+}
+
+/**
+ * Attaches the permanent failure listeners once per transport. An `'error'` with
+ * no listener is thrown by Node and crashes the process, and fire-and-forget
+ * `send()` registers no per-call listener of its own.
+ */
+function attachTransportLogging(transport: RemoteXpcFramedTransport): void {
+  if (loggedTransports.has(transport)) {
+    return;
+  }
+  loggedTransports.add(transport);
+
+  transport.on('error', (error: Error) => {
+    log.debug(`CoreDevice transport error: ${error.message}`);
+  });
+  transport.on('decodeError', (error: Error) => {
+    log.debug(`CoreDevice skipped an undecodable message: ${error.message}`);
+  });
 }
 
 /**

--- a/src/services/ios/core-device/core-device-service.ts
+++ b/src/services/ios/core-device/core-device-service.ts
@@ -357,7 +357,7 @@ function attachTransportLogging(transport: RemoteXpcFramedTransport): void {
   transport.on('error', (error: Error) => {
     log.debug(`CoreDevice transport error: ${error.message}`);
   });
-  transport.on('decodeError', (error: Error) => {
+  transport.once('decodeError', (error: Error) => {
     log.debug(`CoreDevice skipped an undecodable message: ${error.message}`);
   });
 }

--- a/test/unit/remote-xpc/remote-xpc-framed-transport.spec.ts
+++ b/test/unit/remote-xpc/remote-xpc-framed-transport.spec.ts
@@ -2,7 +2,51 @@ import assert from 'node:assert/strict';
 import * as net from 'node:net';
 import {describe, it} from 'node:test';
 
+import {Http2Constants} from '../../../src/lib/remote-xpc/constants.js';
 import {RemoteXpcFramedTransport} from '../../../src/lib/remote-xpc/remote-xpc-framed-transport.js';
+import {MAX_XPC_BODY_SIZE, probeXpcFraming} from '../../../src/lib/remote-xpc/xpc-protocol.js';
+import type {XPCDictionary} from '../../../src/lib/types.js';
+import {buildMessage, buildUndecodableMessage, toDataFrame} from './xpc-fixtures.js';
+
+interface IngestHarness {
+  ingest: (chunk: Buffer) => void;
+  ingestOn: (streamId: number, chunk: Buffer) => void;
+  messages: XPCDictionary[];
+  errors: Error[];
+  decodeErrors: Error[];
+  pendingLength: () => number;
+}
+
+function createIngestHarness(): IngestHarness {
+  const transport = new RemoteXpcFramedTransport(['::1', 1]);
+  const internals = transport as unknown as {
+    ingestXpcData: (streamId: number, chunk: Buffer) => void;
+    pendingXpcData: Map<number, Buffer>;
+  };
+  const messages: XPCDictionary[] = [];
+  const errors: Error[] = [];
+  const decodeErrors: Error[] = [];
+
+  transport.on('message', (body: XPCDictionary) => messages.push(body));
+  transport.on('error', (error: Error) => errors.push(error));
+  transport.on('decodeError', (error: Error) => decodeErrors.push(error));
+
+  return {
+    ingest: (chunk: Buffer) => internals.ingestXpcData(Http2Constants.ROOT_CHANNEL, chunk),
+    ingestOn: (streamId: number, chunk: Buffer) => internals.ingestXpcData(streamId, chunk),
+    messages,
+    errors,
+    decodeErrors,
+    pendingLength: () => [...internals.pendingXpcData.values()].reduce((total, buf) => total + buf.length, 0),
+  };
+}
+
+/** A 24-byte wrapper header declaring `bodyLength`, with no body bytes behind it. */
+function buildWrapperHeader(bodyLength: bigint): Buffer {
+  const header = Buffer.from(buildMessage({n: 1}).subarray(0, 24));
+  header.writeBigUInt64LE(bodyLength, 8);
+  return header;
+}
 
 function listenOnLoopback(server: net.Server): Promise<number> {
   return new Promise<number>((resolve, reject) => {
@@ -15,6 +59,42 @@ function listenOnLoopback(server: net.Server): Promise<number> {
 
 function closeServer(server: net.Server): Promise<void> {
   return new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+/** Longer than the transport's socket close/end timeouts, so teardown has finished. */
+const SOCKET_TEARDOWN_MS = 700;
+
+function settle(ms = 100): Promise<void> {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Runs `run` against a transport connected to a bare loopback server, with an
+ * 'error' sink attached. Accepted sockets are destroyed on teardown, otherwise
+ * server.close() never calls back and the test hangs.
+ */
+async function withConnectedTransport(
+  run: (transport: RemoteXpcFramedTransport, ingest: (chunk: Buffer) => void) => Promise<void>,
+): Promise<void> {
+  const accepted: net.Socket[] = [];
+  const server = net.createServer((socket) => accepted.push(socket));
+  const port = await listenOnLoopback(server);
+  const transport = new RemoteXpcFramedTransport(['::1', port]);
+  const ingest = (
+    transport as unknown as {ingestXpcData: (streamId: number, chunk: Buffer) => void}
+  ).ingestXpcData.bind(transport, Http2Constants.ROOT_CHANNEL);
+
+  try {
+    await transport.connect({timeoutMs: 2000});
+    transport.on('error', (): void => undefined);
+    await run(transport, ingest);
+  } finally {
+    await transport.close();
+    for (const socket of accepted) {
+      socket.destroy();
+    }
+    await closeServer(server);
+  }
 }
 
 describe('RemoteXpcFramedTransport', function () {
@@ -53,5 +133,208 @@ describe('RemoteXpcFramedTransport', function () {
       acceptedSocket?.destroy();
       await closeServer(server);
     }
+  });
+
+  describe('XPC message reassembly', function () {
+    it('buffers a message split across chunks and emits it once complete', function () {
+      const harness = createIngestHarness();
+      const payload = buildMessage({hello: 'world'});
+      const splitAt = Math.floor(payload.length / 2);
+
+      harness.ingest(payload.subarray(0, splitAt));
+      assert.strictEqual(harness.messages.length, 0);
+      assert.strictEqual(harness.pendingLength(), splitAt);
+
+      harness.ingest(payload.subarray(splitAt));
+      assert.deepStrictEqual(harness.messages, [{hello: 'world'}]);
+      assert.strictEqual(harness.decodeErrors.length, 0);
+      assert.strictEqual(harness.errors.length, 0);
+      assert.strictEqual(harness.pendingLength(), 0);
+    });
+
+    it('emits every message when several arrive in one chunk', function () {
+      const harness = createIngestHarness();
+
+      harness.ingest(Buffer.concat([buildMessage({n: 1}, 1), buildMessage({n: 2}, 2), buildMessage({n: 3}, 3)]));
+
+      assert.deepStrictEqual(harness.messages, [{n: 1}, {n: 2}, {n: 3}]);
+      assert.strictEqual(harness.decodeErrors.length, 0);
+      assert.strictEqual(harness.errors.length, 0);
+      assert.strictEqual(harness.pendingLength(), 0);
+    });
+
+    it('reports an undecodable message and still delivers the ones behind it', function () {
+      const harness = createIngestHarness();
+      const undecodable = buildUndecodableMessage();
+
+      harness.ingest(Buffer.concat([undecodable, buildMessage({n: 1}, 2), buildMessage({n: 2}, 3)]));
+
+      assert.deepStrictEqual(harness.messages, [{n: 1}, {n: 2}]);
+      assert.strictEqual(harness.decodeErrors.length, 1);
+      assert.match(harness.decodeErrors[0].message, /Unsupported xpc type/);
+      assert.strictEqual(harness.errors.length, 0, 'an undecodable message is not a connection failure');
+      assert.strictEqual(harness.pendingLength(), 0);
+    });
+
+    it('does not stall once an undecodable message has been reported', function () {
+      const harness = createIngestHarness();
+
+      harness.ingest(buildUndecodableMessage());
+      harness.ingest(buildMessage({n: 1}, 2));
+
+      assert.deepStrictEqual(harness.messages, [{n: 1}]);
+      assert.strictEqual(harness.decodeErrors.length, 1);
+      assert.strictEqual(harness.errors.length, 0);
+      assert.strictEqual(harness.pendingLength(), 0);
+    });
+
+    it('reassembles each stream separately when frames interleave', function () {
+      const harness = createIngestHarness();
+      const reply = buildMessage({from: 'reply-channel'}, 2);
+      const splitAt = Math.floor(reply.length / 2);
+
+      harness.ingestOn(Http2Constants.REPLY_CHANNEL, reply.subarray(0, splitAt));
+      harness.ingestOn(Http2Constants.ROOT_CHANNEL, buildMessage({from: 'root-channel'}, 1));
+      harness.ingestOn(Http2Constants.REPLY_CHANNEL, reply.subarray(splitAt));
+
+      assert.deepStrictEqual(harness.messages, [{from: 'root-channel'}, {from: 'reply-channel'}]);
+      assert.strictEqual(harness.errors.length, 0, 'interleaved streams must not read as a desync');
+      assert.strictEqual(harness.pendingLength(), 0);
+    });
+
+    it('survives an undecodable message when nothing is listening', function () {
+      const bare = new RemoteXpcFramedTransport(['::1', 1]);
+      const ingest = (bare as unknown as {ingestXpcData: (streamId: number, chunk: Buffer) => void}).ingestXpcData.bind(
+        bare,
+        Http2Constants.ROOT_CHANNEL,
+      );
+
+      assert.strictEqual(bare.listenerCount('decodeError'), 0);
+      assert.doesNotThrow(() => ingest(buildUndecodableMessage()));
+    });
+
+    it('emits an error and stops buffering when the stream is desynced', function () {
+      const harness = createIngestHarness();
+      const garbage = Buffer.alloc(32, 0xab);
+
+      harness.ingest(Buffer.concat([garbage, buildMessage({n: 1})]));
+
+      assert.strictEqual(harness.messages.length, 0);
+      assert.strictEqual(harness.errors.length, 1);
+      assert.match(harness.errors[0].message, /Invalid XPC wrapper magic/);
+      assert.strictEqual(harness.pendingLength(), 0);
+    });
+
+    it('reports a desync once, not on every later chunk', function () {
+      const harness = createIngestHarness();
+
+      harness.ingest(Buffer.alloc(32, 0xab));
+      harness.ingest(buildMessage({n: 1}));
+
+      assert.strictEqual(harness.errors.length, 1);
+      assert.strictEqual(harness.messages.length, 0);
+    });
+
+    it('marks itself disconnected and emits close after a desync', async function () {
+      await withConnectedTransport(async (transport, ingest) => {
+        assert.strictEqual(transport.isConnected, true);
+
+        const closed = new Promise<void>((resolve) => transport.once('close', () => resolve()));
+        ingest(Buffer.alloc(32, 0xab));
+
+        await closed;
+        assert.strictEqual(transport.isConnected, false);
+      });
+    });
+
+    it('does not leave an unhandled rejection behind when a desync closes the socket', async function () {
+      const rejections: unknown[] = [];
+      const onRejection = (reason: unknown): void => {
+        rejections.push(reason);
+      };
+      process.on('unhandledRejection', onRejection);
+
+      try {
+        await withConnectedTransport(async (_transport, ingest) => {
+          ingest(Buffer.alloc(32, 0xab));
+          await settle();
+
+          assert.deepStrictEqual(rejections, []);
+        });
+      } finally {
+        process.off('unhandledRejection', onRejection);
+      }
+    });
+
+    it('accepts messages again after reconnecting past a desync', async function () {
+      await withConnectedTransport(async (transport, ingest) => {
+        ingest(Buffer.alloc(32, 0xab));
+        await settle();
+
+        await transport.connect({timeoutMs: 2000});
+        const messages: XPCDictionary[] = [];
+        transport.on('message', (body: XPCDictionary) => messages.push(body));
+        ingest(buildMessage({n: 1}));
+
+        assert.deepStrictEqual(messages, [{n: 1}], 'the desync latch must not survive a reconnect');
+      });
+    });
+
+    it('tolerates an explicit close after a desync already closed the socket', async function () {
+      await withConnectedTransport(async (transport, ingest) => {
+        ingest(Buffer.alloc(32, 0xab));
+        await settle();
+
+        await transport.close();
+        await transport.close();
+      });
+    });
+
+    it('does not dereference a socket the desync already closed', async function () {
+      await withConnectedTransport(async (transport) => {
+        const handleData = (transport as unknown as {handleData: (chunk: Buffer) => void}).handleData.bind(transport);
+        const chunk = Buffer.concat([toDataFrame(Buffer.alloc(32, 0xab), 2), toDataFrame(buildMessage({n: 1}), 2)]);
+
+        assert.doesNotThrow(() => handleData(chunk), 'a desync mid-loop must not crash the data handler');
+      });
+    });
+
+    it('ignores a superseded socket closing after a reconnect', async function () {
+      await withConnectedTransport(async (transport, ingest) => {
+        ingest(Buffer.alloc(32, 0xab));
+
+        await transport.connect({timeoutMs: 2000});
+        let closes = 0;
+        transport.on('close', () => {
+          closes += 1;
+        });
+        await settle(SOCKET_TEARDOWN_MS);
+
+        assert.strictEqual(closes, 0, 'the old socket must not emit close on the live connection');
+        assert.strictEqual(transport.isConnected, true);
+      });
+    });
+
+    it('waits for a body declared exactly at the size cap', function () {
+      assert.deepStrictEqual(probeXpcFraming(buildWrapperHeader(MAX_XPC_BODY_SIZE)), {status: 'incomplete'});
+    });
+
+    it('rejects a body declared one byte past the size cap', function () {
+      const probe = probeXpcFraming(buildWrapperHeader(MAX_XPC_BODY_SIZE + BigInt(1)));
+
+      assert.strictEqual(probe.status, 'desynced');
+    });
+
+    it('treats an oversized declared body length as a desync instead of buffering it', function () {
+      const harness = createIngestHarness();
+      const bogus = Buffer.from(buildMessage({n: 1}));
+      bogus.writeBigUInt64LE(BigInt('0xffffffffffff0000'), 8);
+
+      harness.ingest(bogus);
+
+      assert.strictEqual(harness.errors.length, 1);
+      assert.match(harness.errors[0].message, /exceeds/);
+      assert.strictEqual(harness.pendingLength(), 0, 'a corrupt length must not be buffered forever');
+    });
   });
 });

--- a/test/unit/remote-xpc/rsd-service-catalog-client.spec.ts
+++ b/test/unit/remote-xpc/rsd-service-catalog-client.spec.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import * as net from 'node:net';
+import {describe, it} from 'node:test';
+
+import {RsdServiceCatalogClient} from '../../../src/lib/remote-xpc/rsd-service-catalog-client.js';
+import {buildCatalogMessage, buildUndecodableMessage, toDataFrame} from './xpc-fixtures.js';
+
+/** Exceeds the client's internal handshake delay so teardown cannot race it. */
+const HANDSHAKE_DRAIN_MS = 200;
+
+/**
+ * Serves `writes` to the first client that connects, one socket write each, and
+ * hands a client pointed at it to `run`. Drains before teardown because connect()
+ * settles on the catalog while the handshake writes are still in flight.
+ */
+async function withScriptedRsd(
+  writes: Buffer[],
+  run: (client: RsdServiceCatalogClient) => Promise<void>,
+): Promise<void> {
+  const accepted: net.Socket[] = [];
+  const server = net.createServer((socket) => {
+    accepted.push(socket);
+    for (const write of writes) {
+      socket.write(write);
+    }
+  });
+  const port = await new Promise<number>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '::1', () => resolve((server.address() as net.AddressInfo).port));
+  });
+
+  const client = new RsdServiceCatalogClient(['::1', port]);
+  try {
+    await run(client);
+  } finally {
+    await new Promise<void>((resolve) => setTimeout(resolve, HANDSHAKE_DRAIN_MS));
+    await client.close().catch((): void => undefined);
+    for (const socket of accepted) {
+      socket.destroy();
+    }
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+describe('RsdServiceCatalogClient', function () {
+  it('returns the catalog that follows an undecodable message in the same frame', async function () {
+    const frame = toDataFrame(Buffer.concat([buildUndecodableMessage(1), buildCatalogMessage()]));
+
+    await withScriptedRsd([frame], async (client): Promise<void> => {
+      const response = await client.connect({timeoutMs: 5000});
+
+      assert.strictEqual(response.services.length, 1);
+      assert.strictEqual(response.services[0].serviceName, 'com.apple.afc.shim.remote');
+    });
+  });
+
+  it('returns the catalog when it arrives in a later frame than the undecodable message', async function () {
+    const writes = [
+      toDataFrame(buildUndecodableMessage(1)),
+      toDataFrame(buildCatalogMessage('com.apple.mobile.diagnostics_relay.shim.remote', '59999')),
+    ];
+
+    await withScriptedRsd(writes, async (client): Promise<void> => {
+      const response = await client.connect({timeoutMs: 5000});
+
+      assert.strictEqual(response.services[0].port, '59999');
+    });
+  });
+
+  it('fails the connect attempt when the stream desyncs', async function () {
+    await withScriptedRsd([toDataFrame(Buffer.alloc(64, 0xab))], async (client): Promise<void> => {
+      await assert.rejects(client.connect({timeoutMs: 5000}), /Invalid XPC wrapper magic/);
+    });
+  });
+});

--- a/test/unit/remote-xpc/service-catalog.spec.ts
+++ b/test/unit/remote-xpc/service-catalog.spec.ts
@@ -5,6 +5,7 @@ import {DataFrame} from '../../../src/lib/remote-xpc/handshake-frames.js';
 import {Http2FrameParser, buildWindowUpdateFrames} from '../../../src/lib/remote-xpc/http2-frame-parser.js';
 import {ServiceCatalogCollector, servicesFromXpcBody} from '../../../src/lib/remote-xpc/service-catalog.js';
 import {encodeMessage} from '../../../src/lib/remote-xpc/xpc-protocol.js';
+import {buildUndecodableMessage} from './xpc-fixtures.js';
 
 function buildCatalogXpcPayload(serviceCount: number): Buffer {
   const services: Record<string, {Port: string}> = {};
@@ -93,6 +94,33 @@ describe('RSD service catalog discovery', function () {
         collector.ingestDataPayload(Buffer.concat([prelude.subarray(prelude.length - 4), catalog])),
         null,
       );
+    });
+
+    it('skips an undecodable message and still returns the catalog behind it', function () {
+      const collector = new ServiceCatalogCollector();
+
+      const result = collector.ingestDataPayload(
+        Buffer.concat([buildUndecodableMessage(1), buildCatalogXpcPayload(2)]),
+      );
+
+      assert.notStrictEqual(result, null);
+      assert.ok(result!.services.length >= 2);
+    });
+
+    it('throws once the stream desyncs rather than reporting "not yet"', function () {
+      const collector = new ServiceCatalogCollector();
+
+      assert.throws(
+        () => collector.ingestDataPayload(Buffer.concat([Buffer.alloc(32, 0xab), buildCatalogXpcPayload(1)])),
+        /Invalid XPC wrapper magic/,
+      );
+    });
+
+    it('keeps throwing once desynced rather than resuming mid-message', function () {
+      const collector = new ServiceCatalogCollector();
+
+      assert.throws(() => collector.ingestDataPayload(Buffer.alloc(32, 0xab)), /Invalid XPC wrapper magic/);
+      assert.throws(() => collector.ingestDataPayload(buildCatalogXpcPayload(1)), /desynced/);
     });
 
     it('returns the complete catalog across many TCP-sized chunks', function () {

--- a/test/unit/remote-xpc/xpc-fixtures.ts
+++ b/test/unit/remote-xpc/xpc-fixtures.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+
+import {DataFrame} from '../../../src/lib/remote-xpc/handshake-frames.js';
+import {encodeMessage} from '../../../src/lib/remote-xpc/xpc-protocol.js';
+import type {XPCDictionary} from '../../../src/lib/types.js';
+
+const STRING_TYPE_TAG = 0x00009000;
+const FILE_TRANSFER_TYPE_TAG = 0x0001a000;
+
+export function buildMessage(body: XPCDictionary, id = 1): Buffer {
+  return encodeMessage({flags: 0x00000001, id: BigInt(id), body});
+}
+
+/** Retags the encoded string value as the unimplemented fileTransfer type, keeping framing intact. */
+export function withUnsupportedValueType(payload: Buffer): Buffer {
+  const retagged = Buffer.from(payload);
+  const tag = Buffer.alloc(4);
+  tag.writeUInt32LE(STRING_TYPE_TAG);
+  const offset = retagged.indexOf(tag);
+  assert.ok(offset > 0, 'expected an encoded string type tag to retag');
+  retagged.writeUInt32LE(FILE_TRANSFER_TYPE_TAG, offset);
+  return retagged;
+}
+
+/** A framed message the decoder cannot read: correct wrapper, unsupported value type. */
+export function buildUndecodableMessage(id = 1): Buffer {
+  return withUnsupportedValueType(buildMessage({payload: 'unsupported'}, id));
+}
+
+export function buildCatalogMessage(serviceName = 'com.apple.afc.shim.remote', port = '52280'): Buffer {
+  return buildMessage({MessageType: 'Handshake', Services: {[serviceName]: {Port: port}}});
+}
+
+export function toDataFrame(payload: Buffer, streamId = 1): Buffer {
+  return new DataFrame(streamId, payload, []).serialize();
+}

--- a/test/unit/services/core-device-service.spec.ts
+++ b/test/unit/services/core-device-service.spec.ts
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict';
+import * as net from 'node:net';
+import {describe, it} from 'node:test';
+
+import {Http2Constants} from '../../../src/lib/remote-xpc/constants.js';
+import {RemoteXpcFramedTransport} from '../../../src/lib/remote-xpc/remote-xpc-framed-transport.js';
+import type {XPCDictionary, XPCValue} from '../../../src/lib/types.js';
+import {CoreDeviceService} from '../../../src/services/ios/core-device/core-device-service.js';
+import {buildMessage, buildUndecodableMessage} from '../remote-xpc/xpc-fixtures.js';
+
+const FEATURE = 'com.apple.coredevice.feature.test';
+
+function buildReply(output: XPCValue = {ok: true}): Buffer {
+  return buildMessage({'CoreDevice.output': output} as XPCDictionary, 2);
+}
+
+/**
+ * Feeds a scripted byte stream back through the transport's own reassembly path
+ * whenever the service sends a request, standing in for the device's reply.
+ */
+class ScriptedCoreDeviceService extends CoreDeviceService {
+  constructor(private readonly reply: Buffer) {
+    super('test-udid', 'com.apple.coredevice.test');
+  }
+
+  async invokeFeature(timeoutMs: number): Promise<XPCValue> {
+    return this.invoke(FEATURE, {}, {timeoutMs});
+  }
+
+  protected async createTransport(): Promise<RemoteXpcFramedTransport> {
+    const transport = new RemoteXpcFramedTransport(['::1', 1]);
+    const ingest = (
+      transport as unknown as {ingestXpcData: (streamId: number, chunk: Buffer) => void}
+    ).ingestXpcData.bind(transport, Http2Constants.ROOT_CHANNEL);
+    transport.sendDataFrame = (): void => {
+      setImmediate(() => ingest(this.reply));
+    };
+    return transport;
+  }
+}
+
+/** Points the real createTransport() at a socket that completes the write-only handshake. */
+class LoopbackCoreDeviceService extends CoreDeviceService {
+  constructor(private readonly port: number) {
+    super('test-udid', 'com.apple.coredevice.test');
+  }
+
+  async openTransport(): Promise<RemoteXpcFramedTransport> {
+    return this.createTransport();
+  }
+
+  protected async resolveServiceAddress(): Promise<[string, number]> {
+    return ['::1', this.port];
+  }
+}
+
+describe('CoreDeviceService transport wiring', function () {
+  it('attaches failure listeners to the transport it creates', async function () {
+    const accepted: net.Socket[] = [];
+    const server = net.createServer((socket) => accepted.push(socket));
+    const port = await new Promise<number>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '::1', () => resolve((server.address() as net.AddressInfo).port));
+    });
+
+    const service = new LoopbackCoreDeviceService(port);
+    let transport: RemoteXpcFramedTransport | undefined;
+    try {
+      transport = await service.openTransport();
+
+      assert.ok(transport.listenerCount('error') > 0, "an unlistened 'error' crashes the process");
+      assert.ok(transport.listenerCount('decodeError') > 0);
+    } finally {
+      await transport?.close();
+      for (const socket of accepted) {
+        socket.destroy();
+      }
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it('resolves the invocation when an undecodable message precedes the reply', async function () {
+    const service = new ScriptedCoreDeviceService(Buffer.concat([buildUndecodableMessage(1), buildReply()]));
+
+    try {
+      assert.deepStrictEqual(await service.invokeFeature(2000), {ok: true});
+    } finally {
+      await service.close();
+    }
+  });
+
+  it('names the undecodable message as the cause when the reply never decodes', async function () {
+    const service = new ScriptedCoreDeviceService(buildUndecodableMessage(1));
+
+    try {
+      await assert.rejects(
+        service.invokeFeature(300),
+        /timed out after 300ms; last message was undecodable: Unsupported xpc type/,
+      );
+    } finally {
+      await service.close();
+    }
+  });
+
+  it('reports a plain timeout when no message arrived at all', async function () {
+    const service = new ScriptedCoreDeviceService(Buffer.alloc(0));
+
+    try {
+      await assert.rejects(service.invokeFeature(300), /timed out after 300ms$/);
+    } finally {
+      await service.close();
+    }
+  });
+});


### PR DESCRIPTION
### Problem

A single undecodable XPC message stalled the connection. `ingestXpcData` caught
every decode failure and buffered the bytes as if the message were incomplete, so
the parser waited forever for bytes that were already there and every later message
on that stream was lost. All streams shared one buffer, so interleaved frames could
also corrupt each other.

Decode failures were also reported on `'error'`. Node throws an `'error'` with no
listener, and `RsdServiceCatalogClient` used `once('error')`, so a later error
crashed the process. `CoreDeviceService` attached its listener after `connect()`,
leaving the handshake window uncovered.

### Fix

- Add `probeXpcFraming`, a non throwing framing check that separates "wait for more
  bytes" from "stream is unusable". A body length above the initial receive window
  is treated as desync, not a partial read.
- Buffer pending bytes per HTTP/2 stream.
- Emit `'decodeError'` for one unreadable message and keep the connection alive.
  Reserve `'error'` for desync, which latches the transport closed.
- Ignore socket events from a socket already replaced by a reconnect.
- Attach the permanent listeners before `connect()`, idempotently.
- Surface the last decode error in the CoreDevice invoke timeout message.

### Tests

New unit coverage for the framed transport, the RSD catalog client, the service
catalog collector and CoreDeviceService. 836 unit tests pass.
