### PR TITLE
fix(remote-xpc): reassemble inbound XPC messages in linear time

### DIFF
--- a/src/lib/remote-xpc/remote-xpc-framed-transport.ts
+++ b/src/lib/remote-xpc/remote-xpc-framed-transport.ts
@@ -7,7 +7,7 @@ import {Http2Constants} from './constants.js';
 import {DataFrame} from './handshake-frames.js';
 import Handshake from './handshake.js';
 import {Http2FrameParser, buildWindowUpdateFrames} from './http2-frame-parser.js';
-import {decodeMessage, probeXpcFraming} from './xpc-protocol.js';
+import {decodeMessage, probeXpcFraming, XPC_WRAPPER_HEADER_SIZE} from './xpc-protocol.js';
 
 const log = getLogger('RemoteXpcFramedTransport');
 
@@ -19,6 +19,13 @@ export interface RemoteXpcFramedTransportConnectOptions {
   handshakeDelayMs?: number;
 }
 
+/** Owned copies of one in-flight XPC message's chunks; `byteLength` is unset until the header is readable. */
+interface PendingXpcMessage {
+  chunks: Buffer[];
+  length: number;
+  byteLength?: number;
+}
+
 /**
  * Shared RemoteXPC transport: owns TCP socket lifecycle, HTTP/2/XPC handshake,
  * DATA frame parsing, window updates, and XPC message reassembly.
@@ -27,7 +34,7 @@ export class RemoteXpcFramedTransport extends EventEmitter {
   private readonly address: [string, number];
   private socket: net.Socket | null = null;
   private frameParser = new Http2FrameParser();
-  private pendingXpcData = new Map<number, Buffer>();
+  private pendingXpcData = new Map<number, PendingXpcMessage>();
   private connected = false;
   private closing = false;
   private desynced = false;
@@ -283,33 +290,63 @@ export class RemoteXpcFramedTransport extends EventEmitter {
   }
 
   /**
-   * Reassembles XPC messages for one HTTP/2 stream; streams buffer separately so
-   * interleaving cannot fabricate a desync. Framed-but-undecodable messages are
-   * skipped, and a retained tail is copied so it cannot pin the parser's buffer.
+   * Accumulates one XPC message per HTTP/2 stream as a chunk list, joined once when
+   * complete. Retained chunks are copied so a stalled stream cannot pin the frame
+   * parser's buffer; the header is probed from at most its first 24 bytes.
    */
   private ingestXpcData(streamId: number, chunk: Buffer): void {
-    if (this.desynced) {
+    if (this.desynced || chunk.length === 0) {
       return;
     }
 
-    const buffered = this.pendingXpcData.get(streamId);
-    let pending = buffered ? Buffer.concat([buffered, chunk]) : chunk;
-    this.pendingXpcData.delete(streamId);
+    const pending = this.pendingXpcData.get(streamId) ?? {chunks: [], length: 0};
+    const length = pending.length + chunk.length;
 
-    while (pending.length > 0) {
-      const framing = probeXpcFraming(pending);
-      if (framing.status === 'incomplete') {
-        this.pendingXpcData.set(streamId, Buffer.from(pending));
-        return;
-      }
+    if (pending.byteLength === undefined) {
+      const head = Buffer.concat([...pending.chunks, chunk], Math.min(length, XPC_WRAPPER_HEADER_SIZE));
+      const framing = probeXpcFraming(head);
       if (framing.status === 'desynced') {
         this.handleDesync(framing.reason);
         return;
       }
+      pending.byteLength = framing.byteLength;
+    }
+    if (pending.byteLength === undefined || length < pending.byteLength) {
+      pending.chunks.push(Buffer.from(chunk));
+      pending.length = length;
+      this.pendingXpcData.set(streamId, pending);
+      return;
+    }
 
-      const message = pending.subarray(0, framing.byteLength);
-      pending = pending.subarray(framing.byteLength);
-      this.decodeAndEmit(message);
+    this.pendingXpcData.delete(streamId);
+    this.drainXpcMessages(
+      streamId,
+      pending.chunks.length === 0 ? chunk : Buffer.concat([...pending.chunks, chunk], length),
+    );
+  }
+
+  /**
+   * Emits every complete message at the front of `buffer`; an incomplete remainder
+   * is re-queued as a copy so it cannot pin the buffer it was sliced from.
+   */
+  private drainXpcMessages(streamId: number, buffer: Buffer): void {
+    let rest = buffer;
+    while (rest.length > 0) {
+      const framing = probeXpcFraming(rest);
+      if (framing.status === 'desynced') {
+        this.handleDesync(framing.reason);
+        return;
+      }
+      if (framing.status === 'incomplete') {
+        this.pendingXpcData.set(streamId, {
+          chunks: [Buffer.from(rest)],
+          length: rest.length,
+          byteLength: framing.byteLength,
+        });
+        return;
+      }
+      this.decodeAndEmit(rest.subarray(0, framing.byteLength));
+      rest = rest.subarray(framing.byteLength);
     }
   }
 

--- a/src/lib/remote-xpc/xpc-protocol.ts
+++ b/src/lib/remote-xpc/xpc-protocol.ts
@@ -38,7 +38,7 @@ export interface DecodedXpcMessage {
 
 /** Framing state of the wrapper at the front of a buffer. `desynced` is unrecoverable. */
 export type XpcFramingProbe =
-  | {status: 'incomplete'}
+  | {status: 'incomplete'; byteLength?: number}
   | {status: 'desynced'; reason: string}
   | {status: 'ok'; byteLength: number};
 
@@ -187,7 +187,7 @@ export function encodeMessage(message: XPCMessage): Buffer {
   return writer.concat();
 }
 
-const XPC_WRAPPER_HEADER_SIZE = 24;
+export const XPC_WRAPPER_HEADER_SIZE = 24;
 /**
  * Upper bound on a declared body length: the initial receive window, which the peer
  * cannot exceed on a stream because WINDOW_UPDATEs go out only for even streams and
@@ -234,7 +234,7 @@ export function probeXpcFraming(buffer: Buffer): XpcFramingProbe {
   }
   const byteLength = XPC_WRAPPER_HEADER_SIZE + Number(bodyLength);
   if (buffer.length < byteLength) {
-    return {status: 'incomplete'};
+    return {status: 'incomplete', byteLength};
   }
   return {status: 'ok', byteLength};
 }

--- a/test/unit/remote-xpc/remote-xpc-framed-transport.spec.ts
+++ b/test/unit/remote-xpc/remote-xpc-framed-transport.spec.ts
@@ -10,6 +10,11 @@ import {MAX_XPC_BODY_SIZE, probeXpcFraming} from '../../../src/lib/remote-xpc/xp
 import type {XPCDictionary} from '../../../src/lib/types.js';
 import {buildMessage, buildUndecodableMessage, toDataFrame} from './xpc-fixtures.js';
 
+interface PendingXpcEntry {
+  chunks: Buffer[];
+  length: number;
+}
+
 interface IngestHarness {
   ingest: (chunk: Buffer) => void;
   ingestOn: (streamId: number, chunk: Buffer) => void;
@@ -17,13 +22,14 @@ interface IngestHarness {
   errors: Error[];
   decodeErrors: Error[];
   pendingLength: () => number;
+  pendingEntries: () => PendingXpcEntry[];
 }
 
 function createIngestHarness(): IngestHarness {
   const transport = new RemoteXpcFramedTransport(['::1', 1]);
   const internals = transport as unknown as {
     ingestXpcData: (streamId: number, chunk: Buffer) => void;
-    pendingXpcData: Map<number, Buffer>;
+    pendingXpcData: Map<number, PendingXpcEntry>;
   };
   const messages: XPCDictionary[] = [];
   const errors: Error[] = [];
@@ -40,6 +46,7 @@ function createIngestHarness(): IngestHarness {
     errors,
     decodeErrors,
     pendingLength: () => [...internals.pendingXpcData.values()].reduce((total, buf) => total + buf.length, 0),
+    pendingEntries: () => [...internals.pendingXpcData.values()],
   };
 }
 
@@ -218,6 +225,47 @@ describe('RemoteXpcFramedTransport', function () {
       assert.strictEqual(harness.pendingLength(), 0);
     });
 
+    it('joins a large message once instead of re-copying the buffered bytes on every frame', function (t) {
+      const harness = createIngestHarness();
+      const payload = buildMessage({blob: 'x'.repeat(1 << 20)});
+      const frameSize = Http2Constants.DEFAULT_PEER_MAX_FRAME_SIZE;
+      const concat = t.mock.method(Buffer, 'concat');
+
+      for (let offset = 0; offset < payload.length; offset += frameSize) {
+        harness.ingest(payload.subarray(offset, offset + frameSize));
+      }
+
+      const copied = concat.mock.calls.reduce((total, call) => total + (call.result?.length ?? 0), 0);
+      assert.strictEqual(harness.messages.length, 1);
+      assert.strictEqual(harness.pendingLength(), 0);
+      assert.ok(
+        copied < payload.length + frameSize,
+        `copied ${copied} bytes to reassemble a ${payload.length} byte message`,
+      );
+    });
+
+    it('does not retain an empty DATA frame', function () {
+      const harness = createIngestHarness();
+
+      harness.ingest(Buffer.alloc(0));
+      harness.ingest(buildMessage({n: 1}).subarray(0, 10));
+      harness.ingest(Buffer.alloc(0));
+
+      assert.strictEqual(harness.pendingEntries().length, 1);
+      assert.strictEqual(harness.pendingEntries()[0].chunks.length, 1);
+    });
+
+    it('copies a retained partial chunk so it cannot pin the buffer it was sliced from', function () {
+      const harness = createIngestHarness();
+      const parent = Buffer.alloc(4096);
+      buildMessage({n: 1}).copy(parent, 0);
+
+      harness.ingest(parent.subarray(0, 10));
+
+      const [retained] = harness.pendingEntries()[0].chunks;
+      assert.notStrictEqual(retained.buffer, parent.buffer);
+    });
+
     it('emits every message when several arrive in one chunk', function () {
       const harness = createIngestHarness();
 
@@ -382,7 +430,10 @@ describe('RemoteXpcFramedTransport', function () {
     });
 
     it('waits for a body declared exactly at the size cap', function () {
-      assert.deepStrictEqual(probeXpcFraming(buildWrapperHeader(MAX_XPC_BODY_SIZE)), {status: 'incomplete'});
+      assert.deepStrictEqual(probeXpcFraming(buildWrapperHeader(MAX_XPC_BODY_SIZE)), {
+        status: 'incomplete',
+        byteLength: 24 + Number(MAX_XPC_BODY_SIZE),
+      });
     });
 
     it('rejects a body declared one byte past the size cap', function () {


### PR DESCRIPTION
Inbound XPC reassembly copied the whole pending buffer twice per 16 KiB DATA frame, so cost grew with the square of the message size.

Changes
- Keep a chunk list and running length per stream, join once when the declared length is reached
- Skip empty DATA frames, copy retained chunks so a stalled stream cannot pin the parser buffer
- probeXpcFraming returns byteLength on incomplete input once the header is readable
- Tests for copy volume, empty frame handling and retained chunk ownership

Loopback through the real socket path, 16 KiB frames, time blocked in reassembly
| message | before | after |
|---|---|---|
| 4 MiB | 19.5 ms | 0.7 ms |
| 8 MiB | 234.8 ms | 1.4 ms |
| 15 MiB | 933.2 ms | 2.9 ms |

Unit suite 842 pass. Device suites app-service, coredevice-device-info and tunnel pass on both builds.
