### PR TITLE
fix(dvt): correlate remaining instrument acks with `receiveReply()`

### DIFF
--- a/src/services/ios/dvt/instruments/activity-trace-tap.ts
+++ b/src/services/ios/dvt/instruments/activity-trace-tap.ts
@@ -108,10 +108,10 @@ export class ActivityTraceTap extends BaseInstrument {
       ur: 500,
     };
     const channel = this.requireChannel();
-    await channel.call('setConfig_')(new MessageAux().appendObj(config), true);
-    await channel.receivePlist(); // consume setConfig_ ack
-    await channel.call('start')(undefined, true);
-    await channel.receivePlist(); // consume start ack
+    const configId = await channel.call('setConfig_')(new MessageAux().appendObj(config), true);
+    await channel.receiveReply(configId);
+    const startId = await channel.call('start')(undefined, true);
+    await channel.receiveReply(startId);
     this.started = true;
     this.stopRequested = false;
     log.debug('ActivityTraceTap started');

--- a/src/services/ios/dvt/instruments/application-listing.ts
+++ b/src/services/ios/dvt/instruments/application-listing.ts
@@ -58,9 +58,9 @@ export class ApplicationListing extends BaseInstrument {
 
     const args = new MessageAux().appendObj(null).appendObj(null);
 
-    await channel.call('installedApplicationsMatching_registerUpdateToken_')(args);
+    const messageId = await channel.call('installedApplicationsMatching_registerUpdateToken_')(args);
 
-    const result = await channel.receivePlist();
+    const result = await channel.receiveReply(messageId);
 
     if (!result) {
       log.warn('Received null/undefined response from installedApplicationsMatching');

--- a/src/services/ios/dvt/instruments/condition-inducer.ts
+++ b/src/services/ios/dvt/instruments/condition-inducer.ts
@@ -20,8 +20,8 @@ export class ConditionInducer extends BaseInstrument {
     await this.initialize();
     const channel = this.requireChannel();
 
-    await channel.call('availableConditionInducers')();
-    const result = await channel.receivePlist();
+    const messageId = await channel.call('availableConditionInducers')();
+    const result = await channel.receiveReply(messageId);
 
     // Handle different response formats
     if (!result) {
@@ -61,10 +61,10 @@ export class ConditionInducer extends BaseInstrument {
 
         const args = new MessageAux().appendObj(group.identifier).appendObj(profile.identifier);
 
-        await channel.call('enableConditionWithIdentifier_profileIdentifier_')(args);
+        const messageId = await channel.call('enableConditionWithIdentifier_profileIdentifier_')(args);
 
         // Wait for response which may be a raised NSError
-        await channel.receivePlist();
+        await channel.receiveReply(messageId);
 
         log.info(`Successfully enabled condition profile: ${profileIdentifier}`);
         return;
@@ -88,8 +88,8 @@ export class ConditionInducer extends BaseInstrument {
     await this.initialize();
     const channel = this.requireChannel();
 
-    await channel.call('disableActiveCondition')();
-    const response = await channel.receivePlist();
+    const messageId = await channel.call('disableActiveCondition')();
+    const response = await channel.receiveReply(messageId);
 
     // Response can be:
     // - true (successfully disabled condition)

--- a/src/services/ios/dvt/instruments/device-info.ts
+++ b/src/services/ios/dvt/instruments/device-info.ts
@@ -249,7 +249,7 @@ export class DeviceInfo extends BaseInstrument {
     const call = channel.call(selectorName);
     const args = arg !== undefined ? new MessageAux().appendObj(arg) : undefined;
 
-    await call(args);
-    return channel.receivePlist();
+    const messageId = await call(args);
+    return channel.receiveReply(messageId);
   }
 }

--- a/src/services/ios/dvt/instruments/energy-monitor.ts
+++ b/src/services/ios/dvt/instruments/energy-monitor.ts
@@ -140,8 +140,8 @@ export class EnergyMonitor extends BaseInstrument {
 
   private async sampleOnce(pids: number[], signal?: AbortSignal): Promise<EnergyMonitorSample> {
     const channel = this.requireChannel();
-    await channel.call('sampleAttributes_forPIDs_')(new MessageAux().appendObj({}).appendObj(pids));
-    return await channel.receivePlist(signal);
+    const messageId = await channel.call('sampleAttributes_forPIDs_')(new MessageAux().appendObj({}).appendObj(pids));
+    return await channel.receiveReply(messageId, signal);
   }
 
   private isAbortError(err: unknown): boolean {

--- a/src/services/ios/dvt/instruments/graphics.ts
+++ b/src/services/ios/dvt/instruments/graphics.ts
@@ -12,8 +12,8 @@ export class Graphics extends BaseInstrument {
     const channel = this.requireChannel();
 
     const args = new MessageAux().appendObj(0.0);
-    await channel.call('startSamplingAtTimeInterval_')(args);
-    await channel.receivePlist();
+    const messageId = await channel.call('startSamplingAtTimeInterval_')(args);
+    await channel.receiveReply(messageId);
   }
 
   async stop(): Promise<void> {

--- a/src/services/ios/dvt/instruments/location-simulation.ts
+++ b/src/services/ios/dvt/instruments/location-simulation.ts
@@ -28,8 +28,8 @@ export class LocationSimulation extends BaseInstrument {
 
     const args = new MessageAux().appendObj(coordinates.latitude).appendObj(coordinates.longitude);
 
-    await channel.call('simulateLocationWithLatitude_longitude_')(args);
-    await channel.receivePlist();
+    const messageId = await channel.call('simulateLocationWithLatitude_longitude_')(args);
+    await channel.receiveReply(messageId);
 
     log.info(`Location set to: ${coordinates.latitude}, ${coordinates.longitude}`);
   }

--- a/src/services/ios/dvt/instruments/screenshot.ts
+++ b/src/services/ios/dvt/instruments/screenshot.ts
@@ -14,8 +14,8 @@ export class Screenshot extends BaseInstrument {
     await this.initialize();
     const channel = this.requireChannel();
 
-    await channel.call('takeScreenshot')();
-    const result = await channel.receivePlist();
+    const messageId = await channel.call('takeScreenshot')();
+    const result = await channel.receiveReply(messageId);
 
     if (!result) {
       throw new Error('Failed to capture screenshot: received null response');

--- a/test/unit/dvt/dvt-receive.spec.ts
+++ b/test/unit/dvt/dvt-receive.spec.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import {Duplex, PassThrough} from 'node:stream';
 import {describe, it} from 'node:test';
 
-import {ChannelFragmenter} from '../../../src/services/ios/dvt/channel-fragmenter.js';
+import {ChannelFragmenter, isReplyTo} from '../../../src/services/ios/dvt/channel-fragmenter.js';
 import {DTX_CONSTANTS} from '../../../src/services/ios/dvt/dtx-message.js';
 import {DVTSecureSocketProxyService} from '../../../src/services/ios/dvt/index.js';
 
@@ -31,6 +31,10 @@ class TestableDVTService extends DVTSecureSocketProxyService {
 
   public receiveReply(channel: number, identifier: number): Promise<[unknown, unknown[]]> {
     return this.recvReplyPlist(channel, identifier);
+  }
+
+  public receiveReplyRaw(channel: number, identifier: number): Promise<[Buffer | null, unknown[]]> {
+    return this.recvMessage(channel, undefined, isReplyTo(identifier));
   }
 }
 
@@ -105,6 +109,28 @@ describe('DVTSecureSocketProxyService receive path', function () {
 
     const [streamData] = await streamPromise;
     assert.strictEqual(streamData?.length, 12, 'stream reader should get the callback, not the reply');
+  });
+
+  it('should route out-of-order replies to their own callers', async function () {
+    const service = new TestableDVTService('test-udid');
+    const socket = new PassThrough();
+    service.attachSocket(socket, [1]);
+
+    // Two requests in flight on one channel; the device answers the second first.
+    const first = service.receiveReplyRaw(1, 10);
+    const second = service.receiveReplyRaw(1, 11);
+    await tick();
+
+    socket.write(buildCorrelatedMessage(64, 1, 11, 1));
+    socket.write(buildCorrelatedMessage(32, 1, 10, 1));
+    await tick();
+    await tick();
+
+    // A FIFO queue would hand the id-11 reply to the id-10 caller.
+    const [firstData] = await first;
+    const [secondData] = await second;
+    assert.strictEqual(firstData?.length, 32, 'id 10 must get its own 32-byte reply');
+    assert.strictEqual(secondData?.length, 64, 'id 11 must get its own 64-byte reply');
   });
 
   it('should not hand a reply to a mismatched identifier', async function () {


### PR DESCRIPTION
Follow-up to #315, which added identifier-based reply correlation but only migrated `ProcessControl`. The remaining instruments still read their acks through unfiltered `receivePlist()`, which takes whichever message arrives first, so a callback, or another in-flight request's reply, can be picked up instead.

Migrates the 10 request/reply sites now that `Channel.call()` returns the message identifier:

- `condition-inducer` (3), `activity-trace-tap` (2), `graphics`, `screenshot`, `application-listing`, `energy-monitor`, `location-simulation` and `device-info`
 
Stream readers keep using unfiltered reads and must not be migrated: `graphics.messages()`, `sysmontap`, `network-monitor`, `notifications`, `process-control.outputEvents()`.

These channels aren't broken today and nothing streams on them concurrently, so this is closing a latent bug, not a live one.