### PR TITLE
feat(companion-proxy): add CompanionProxyService for paired Apple Watch access

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -399,37 +399,46 @@ export interface CompanionProxyService extends BaseService {
   /**
    * List the UDIDs of the watches paired with this phone
    * @returns Paired watch UDIDs; empty when none are paired
+   * @throws {CompanionProxyError} On any other daemon `Error` reply
    */
   list(): Promise<string[]>;
   /**
-   * Stream watch pair/unpair/attach/detach events
+   * Stream watch pair/unpair/attach/detach events on a dedicated connection that is
+   * closed when the consumer stops iterating, on error, or on `close()`
    * @param timeout Milliseconds to wait for each event
+   * @throws {CompanionProxyError} On a daemon `Error` reply or a frame that is not a companion event
+   * @throws {Error} When no event arrives within `timeout` or the connection is closed
    */
   listen(timeout?: number): AsyncGenerator<CompanionDeviceEvent>;
   /**
    * Read one registry value for a paired watch
    * @param companionUdid Watch UDID
    * @param key Registry key, e.g. `DeviceName`
+   * @throws {CompanionProxyError} On a daemon `Error` reply or a reply without `RetrievedValueDictionary`
    */
   getValue(companionUdid: string, key: string): Promise<PlistValue>;
   /**
    * Forward a watch TCP port through the phone
-   * @param gizmoPort TCP port on the watch
+   * @param watchPort TCP port on the watch
    * @returns Ephemeral phone port proxying to the watch port
+   * @throws {TypeError} When `watchPort` is not an integer in 1..65535
+   * @throws {CompanionProxyError} On a daemon `Error` reply or a reply without `CompanionProxyServicePort`
    */
-  startForwardingServicePort(gizmoPort: number, options?: StartForwardingOptions): Promise<number>;
+  startForwardingServicePort(watchPort: number, options?: StartForwardingOptions): Promise<number>;
   /**
    * Stop forwarding a watch TCP port
-   * @param gizmoPort TCP port on the watch
+   * @param watchPort TCP port on the watch
+   * @throws {TypeError} When `watchPort` is not an integer in 1..65535
+   * @throws {CompanionProxyError} On a daemon `Error` reply or a reply that is not a success
    */
-  stopForwardingServicePort(gizmoPort: number): Promise<void>;
+  stopForwardingServicePort(watchPort: number): Promise<void>;
   /**
    * Open a raw TCP socket to a phone port returned by startForwardingServicePort
    * @param companionPort Phone port
    */
   connectToForwardedPort(companionPort: number): Promise<Socket>;
   /**
-   * Close the persistent listen connection
+   * Close every open listen() stream
    */
   close(): void;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,10 +2,12 @@
  * Common type definitions for the appium-ios-remotexpc library
  */
 import {type EventEmitter} from 'node:events';
+import type {Socket} from 'node:net';
 
 import type {ServiceConnection} from '../service-connection.js';
 import type AfcService from '../services/ios/afc/index.js';
 import type {BaseService, Service} from '../services/ios/base-service.js';
+import type {CompanionDeviceEvent, StartForwardingOptions} from '../services/ios/companion-proxy/index.js';
 import type {iOSApplication} from '../services/ios/dvt/instruments/application-listing.js';
 import type {LocationCoordinates} from '../services/ios/dvt/instruments/location-simulation.js';
 import type {NotificationMessage} from '../services/ios/dvt/instruments/notifications.js';
@@ -386,6 +388,48 @@ export interface NotificationProxyService extends BaseService {
   expectNotification(timeout?: number): Promise<PlistMessage>;
   /**
    * Close the notification proxy service connection
+   */
+  close(): void;
+}
+
+/**
+ * Represents the instance side of CompanionProxyService (paired Apple Watch access via the phone)
+ */
+export interface CompanionProxyService extends BaseService {
+  /**
+   * List the UDIDs of the watches paired with this phone
+   * @returns Paired watch UDIDs; empty when none are paired
+   */
+  list(): Promise<string[]>;
+  /**
+   * Stream watch pair/unpair/attach/detach events
+   * @param timeout Milliseconds to wait for each event
+   */
+  listen(timeout?: number): AsyncGenerator<CompanionDeviceEvent>;
+  /**
+   * Read one registry value for a paired watch
+   * @param companionUdid Watch UDID
+   * @param key Registry key, e.g. `DeviceName`
+   */
+  getValue(companionUdid: string, key: string): Promise<PlistValue>;
+  /**
+   * Forward a watch TCP port through the phone
+   * @param gizmoPort TCP port on the watch
+   * @returns Ephemeral phone port proxying to the watch port
+   */
+  startForwardingServicePort(gizmoPort: number, options?: StartForwardingOptions): Promise<number>;
+  /**
+   * Stop forwarding a watch TCP port
+   * @param gizmoPort TCP port on the watch
+   */
+  stopForwardingServicePort(gizmoPort: number): Promise<void>;
+  /**
+   * Open a raw TCP socket to a phone port returned by startForwardingServicePort
+   * @param companionPort Phone port
+   */
+  connectToForwardedPort(companionPort: number): Promise<Socket>;
+  /**
+   * Close the persistent listen connection
    */
   close(): void;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -404,12 +404,14 @@ export interface CompanionProxyService extends BaseService {
   list(): Promise<string[]>;
   /**
    * Stream watch pair/unpair/attach/detach events on a dedicated connection that is
-   * closed when the consumer stops iterating, on error, or on `close()`
+   * closed when the consumer stops iterating, on error, on abort, or on `close()`
    * @param timeout Milliseconds to wait for each event
+   * @param signal Aborting it stops this stream only, settling a pending iteration with the abort reason
    * @throws {CompanionProxyError} On a daemon `Error` reply or a frame that is not a companion event
    * @throws {Error} When no event arrives within `timeout` or the connection is closed
+   * @throws {DOMException} The `AbortError` (or `signal.reason`) once `signal` aborts
    */
-  listen(timeout?: number): AsyncGenerator<CompanionDeviceEvent>;
+  listen(timeout?: number, signal?: AbortSignal): AsyncGenerator<CompanionDeviceEvent>;
   /**
    * Read one registry value for a paired watch
    * @param companionUdid Watch UDID

--- a/src/services/ios/companion-proxy/errors.ts
+++ b/src/services/ios/companion-proxy/errors.ts
@@ -1,0 +1,12 @@
+/**
+ * Raised when companion_proxy rejects a command; `code` carries the daemon's raw `Error` string.
+ */
+export class CompanionProxyError extends Error {
+  readonly code?: string;
+
+  constructor(message: string, code?: string) {
+    super(message);
+    this.name = 'CompanionProxyError';
+    this.code = code;
+  }
+}

--- a/src/services/ios/companion-proxy/index.ts
+++ b/src/services/ios/companion-proxy/index.ts
@@ -104,36 +104,33 @@ export class CompanionProxyService extends BaseService implements CompanionProxy
     if (response.Error === 'NoPairedWatches') {
       return [];
     }
-    this.throwOnError(response, 'GetDeviceRegistry');
-    const udids = response.PairedDevicesArray;
+    const udids = this.throwOnError(response, 'GetDeviceRegistry').PairedDevicesArray;
     return Array.isArray(udids) ? udids.map(String) : [];
   }
 
   /**
    * Stream watch pair/unpair/attach/detach events on a dedicated connection that is closed
-   * when the consumer stops iterating, on error, or on `close()`.
+   * when the consumer stops iterating, on error, on `close()`, or when the daemon hangs up.
    * The daemon cancels the stream on any further input, so nothing else is ever sent on it.
    * @param timeout Milliseconds to wait for each event
    * @throws {CompanionProxyError} On a daemon `Error` reply or a frame that is not a companion event
-   * @throws {Error} When no event arrives within `timeout` or the connection is closed
+   * @throws {Error} When no event arrives within `timeout` or the connection is closed by either side
    */
   async *listen(timeout: number = DEFAULT_EVENT_TIMEOUT_MS): AsyncGenerator<CompanionDeviceEvent> {
     const conn = await this.connectToCompanionProxyService();
     this._listenConns.add(conn);
+    conn.getSocket().once('close', () => this.releaseListenConnection(conn));
     try {
       conn.sendPlist({Command: 'StartListeningForDevices'});
       while (true) {
-        const frame = await conn.receive(timeout);
-        this.throwOnError(frame, 'StartListeningForDevices');
+        const frame = this.throwOnError(await conn.receive(timeout), 'StartListeningForDevices');
         if (!isCompanionDeviceEvent(frame)) {
           throw new CompanionProxyError(`Unexpected companion event frame: ${JSON.stringify(frame)}`);
         }
         yield frame;
       }
     } finally {
-      if (this._listenConns.delete(conn)) {
-        this.closeListenConnection(conn);
-      }
+      this.releaseListenConnection(conn);
     }
   }
 
@@ -144,8 +141,10 @@ export class CompanionProxyService extends BaseService implements CompanionProxy
    * @throws {CompanionProxyError} On a daemon `Error` reply or a reply without `RetrievedValueDictionary`
    */
   async getValue(companionUdid: string, key: string): Promise<PlistValue> {
-    const response = await this.sendCommand(this.buildGetValueRequest(companionUdid, key));
-    this.throwOnError(response, 'GetValueFromRegistry');
+    const response = this.throwOnError(
+      await this.sendCommand(this.buildGetValueRequest(companionUdid, key)),
+      'GetValueFromRegistry',
+    );
     const values = response.RetrievedValueDictionary;
     if (!isPlistDictionary(values)) {
       throw new CompanionProxyError(`Unexpected GetValueFromRegistry reply: ${JSON.stringify(response)}`);
@@ -162,8 +161,10 @@ export class CompanionProxyService extends BaseService implements CompanionProxy
    * @throws {CompanionProxyError} On a daemon `Error` reply or a reply without `CompanionProxyServicePort`
    */
   async startForwardingServicePort(watchPort: number, options?: StartForwardingOptions): Promise<number> {
-    const response = await this.sendCommand(this.buildStartForwardingRequest(watchPort, options));
-    this.throwOnError(response, 'StartForwardingServicePort');
+    const response = this.throwOnError(
+      await this.sendCommand(this.buildStartForwardingRequest(watchPort, options)),
+      'StartForwardingServicePort',
+    );
     const port = response.CompanionProxyServicePort;
     if (typeof port !== 'number') {
       throw new CompanionProxyError(`Unexpected StartForwardingServicePort reply: ${JSON.stringify(response)}`);
@@ -179,8 +180,10 @@ export class CompanionProxyService extends BaseService implements CompanionProxy
    * @throws {CompanionProxyError} On a daemon `Error` reply or a reply that is not a success
    */
   async stopForwardingServicePort(watchPort: number): Promise<void> {
-    const response = await this.sendCommand(this.buildStopForwardingRequest(watchPort));
-    this.throwOnError(response, 'StopForwardingServicePort');
+    const response = this.throwOnError(
+      await this.sendCommand(this.buildStopForwardingRequest(watchPort)),
+      'StopForwardingServicePort',
+    );
     if (response.Command !== 'ComandSuccess' && response.Command !== 'CommandSuccess') {
       throw new CompanionProxyError(`Unexpected StopForwardingServicePort reply: ${JSON.stringify(response)}`);
     }
@@ -214,8 +217,7 @@ export class CompanionProxyService extends BaseService implements CompanionProxy
       createConnectionTimeout: this.timeout,
     });
     try {
-      const greeting = await conn.receive(this.timeout);
-      this.throwOnError(greeting, 'StartService');
+      const greeting = this.throwOnError(await conn.receive(this.timeout), 'StartService');
       if (greeting?.Request !== 'StartService') {
         throw new CompanionProxyError(`Expected StartService greeting, got: ${JSON.stringify(greeting)}`);
       }
@@ -246,9 +248,22 @@ export class CompanionProxyService extends BaseService implements CompanionProxy
     }
   }
 
-  private throwOnError(response: PlistDictionary, command: string): void {
+  /**
+   * Close a `listen()` connection exactly once; rejects its pending receive so the generator exits
+   */
+  private releaseListenConnection(conn: ServiceConnection): void {
+    if (this._listenConns.delete(conn)) {
+      this.closeListenConnection(conn);
+    }
+  }
+
+  /**
+   * Throw on a daemon `Error` reply, otherwise pass the response through
+   * @throws {CompanionProxyError} Carrying the daemon `Error` code
+   */
+  private throwOnError<T extends PlistDictionary>(response: T, command: string): T {
     if (!response?.Error) {
-      return;
+      return response;
     }
     const code = String(response.Error);
     const description = response.ErrorDescription ? ` - ${String(response.ErrorDescription)}` : '';

--- a/src/services/ios/companion-proxy/index.ts
+++ b/src/services/ios/companion-proxy/index.ts
@@ -67,10 +67,15 @@ function isCompanionDeviceEvent(frame: PlistDictionary): frame is CompanionDevic
   return typeof frame?.Command === 'string' && typeof frame.GizmoUDIDKey === 'string';
 }
 
-function assertGizmoPort(port: number): void {
+/**
+ * Validate a watch TCP port and pass it through
+ * @throws {TypeError} When `port` is not an integer in 1..65535
+ */
+function assertWatchPort(port: number): number {
   if (!Number.isInteger(port) || port < 1 || port > MAX_PORT) {
-    throw new TypeError(`gizmoPort must be an integer in 1..${MAX_PORT}, got ${port}`);
+    throw new TypeError(`watchPort must be an integer in 1..${MAX_PORT}, got ${port}`);
   }
+  return port;
 }
 
 /**
@@ -79,10 +84,10 @@ function assertGizmoPort(port: number): void {
  * - Read per-watch registry values
  * - Forward a watch TCP port through the phone and connect to it
  */
-class CompanionProxyService extends BaseService implements CompanionProxyServiceInterface {
+export class CompanionProxyService extends BaseService implements CompanionProxyServiceInterface {
   static readonly RSD_SERVICE_NAME = 'com.apple.companion_proxy.shim.remote';
   private readonly timeout: number;
-  private _listenConn: ServiceConnection | null = null;
+  private readonly _listenConns = new Set<ServiceConnection>();
 
   constructor(udid: string, timeout: number = DEFAULT_TIMEOUT_MS) {
     super(udid);
@@ -92,6 +97,7 @@ class CompanionProxyService extends BaseService implements CompanionProxyService
   /**
    * List the UDIDs of the watches paired with this phone
    * @returns Paired watch UDIDs; empty when the daemon reports `NoPairedWatches`
+   * @throws {CompanionProxyError} On any other daemon `Error` reply
    */
   async list(): Promise<string[]> {
     const response = await this.sendCommand({Command: 'GetDeviceRegistry'});
@@ -104,23 +110,30 @@ class CompanionProxyService extends BaseService implements CompanionProxyService
   }
 
   /**
-   * Stream watch pair/unpair/attach/detach events on a dedicated persistent connection.
+   * Stream watch pair/unpair/attach/detach events on a dedicated connection that is closed
+   * when the consumer stops iterating, on error, or on `close()`.
    * The daemon cancels the stream on any further input, so nothing else is ever sent on it.
    * @param timeout Milliseconds to wait for each event
+   * @throws {CompanionProxyError} On a daemon `Error` reply or a frame that is not a companion event
+   * @throws {Error} When no event arrives within `timeout` or the connection is closed
    */
   async *listen(timeout: number = DEFAULT_EVENT_TIMEOUT_MS): AsyncGenerator<CompanionDeviceEvent> {
-    if (!this._listenConn) {
-      this._listenConn = await this.connectToCompanionProxyService();
-      this._listenConn.sendPlist({Command: 'StartListeningForDevices'});
-    }
-    const conn = this._listenConn;
-    while (true) {
-      const frame = await conn.receive(timeout);
-      this.throwOnError(frame, 'StartListeningForDevices');
-      if (!isCompanionDeviceEvent(frame)) {
-        throw new CompanionProxyError(`Unexpected companion event frame: ${JSON.stringify(frame)}`);
+    const conn = await this.connectToCompanionProxyService();
+    this._listenConns.add(conn);
+    try {
+      conn.sendPlist({Command: 'StartListeningForDevices'});
+      while (true) {
+        const frame = await conn.receive(timeout);
+        this.throwOnError(frame, 'StartListeningForDevices');
+        if (!isCompanionDeviceEvent(frame)) {
+          throw new CompanionProxyError(`Unexpected companion event frame: ${JSON.stringify(frame)}`);
+        }
+        yield frame;
       }
-      yield frame;
+    } finally {
+      if (this._listenConns.delete(conn)) {
+        this.closeListenConnection(conn);
+      }
     }
   }
 
@@ -128,6 +141,7 @@ class CompanionProxyService extends BaseService implements CompanionProxyService
    * Read one registry value for a paired watch
    * @param companionUdid Watch UDID from `list()`
    * @param key Registry key, e.g. `DeviceName`, `ProductVersion`, `BatteryCurrentCapacity`
+   * @throws {CompanionProxyError} On a daemon `Error` reply or a reply without `RetrievedValueDictionary`
    */
   async getValue(companionUdid: string, key: string): Promise<PlistValue> {
     const response = await this.sendCommand(this.buildGetValueRequest(companionUdid, key));
@@ -142,11 +156,13 @@ class CompanionProxyService extends BaseService implements CompanionProxyService
   /**
    * Ask the phone to forward a watch TCP port; the listener survives until
    * `stopForwardingServicePort()`. Reach it with `connectToForwardedPort()`.
-   * @param gizmoPort TCP port on the watch
-   * @returns Ephemeral port on the phone proxying to `gizmoPort`
+   * @param watchPort TCP port on the watch
+   * @returns Ephemeral port on the phone proxying to `watchPort`
+   * @throws {TypeError} When `watchPort` is not an integer in 1..65535
+   * @throws {CompanionProxyError} On a daemon `Error` reply or a reply without `CompanionProxyServicePort`
    */
-  async startForwardingServicePort(gizmoPort: number, options?: StartForwardingOptions): Promise<number> {
-    const response = await this.sendCommand(this.buildStartForwardingRequest(gizmoPort, options));
+  async startForwardingServicePort(watchPort: number, options?: StartForwardingOptions): Promise<number> {
+    const response = await this.sendCommand(this.buildStartForwardingRequest(watchPort, options));
     this.throwOnError(response, 'StartForwardingServicePort');
     const port = response.CompanionProxyServicePort;
     if (typeof port !== 'number') {
@@ -158,10 +174,12 @@ class CompanionProxyService extends BaseService implements CompanionProxyService
   /**
    * Stop forwarding a watch port started with `startForwardingServicePort()`.
    * Accepts Apple's misspelled `ComandSuccess` reply as well as `CommandSuccess`.
-   * @param gizmoPort TCP port on the watch (not the phone port returned earlier)
+   * @param watchPort TCP port on the watch (not the phone port returned earlier)
+   * @throws {TypeError} When `watchPort` is not an integer in 1..65535
+   * @throws {CompanionProxyError} On a daemon `Error` reply or a reply that is not a success
    */
-  async stopForwardingServicePort(gizmoPort: number): Promise<void> {
-    const response = await this.sendCommand(this.buildStopForwardingRequest(gizmoPort));
+  async stopForwardingServicePort(watchPort: number): Promise<void> {
+    const response = await this.sendCommand(this.buildStopForwardingRequest(watchPort));
     this.throwOnError(response, 'StopForwardingServicePort');
     if (response.Command !== 'ComandSuccess' && response.Command !== 'CommandSuccess') {
       throw new CompanionProxyError(`Unexpected StopForwardingServicePort reply: ${JSON.stringify(response)}`);
@@ -178,16 +196,13 @@ class CompanionProxyService extends BaseService implements CompanionProxyService
   }
 
   /**
-   * Close the persistent `listen()` connection, if any
+   * Close every open `listen()` stream; their pending receives reject and the generators exit
    */
   close(): void {
-    try {
-      this._listenConn?.close();
-    } catch (error) {
-      log.error('Error closing companion proxy connection:', error);
-    } finally {
-      this._listenConn = null;
+    for (const conn of this._listenConns) {
+      this.closeListenConnection(conn);
     }
+    this._listenConns.clear();
   }
 
   /**
@@ -223,6 +238,14 @@ class CompanionProxyService extends BaseService implements CompanionProxyService
     }
   }
 
+  private closeListenConnection(conn: ServiceConnection): void {
+    try {
+      conn.close();
+    } catch (error) {
+      log.error('Error closing companion proxy connection:', error);
+    }
+  }
+
   private throwOnError(response: PlistDictionary, command: string): void {
     if (!response?.Error) {
       return;
@@ -241,13 +264,12 @@ class CompanionProxyService extends BaseService implements CompanionProxyService
   }
 
   private buildStartForwardingRequest(
-    gizmoPort: number,
+    watchPort: number,
     {serviceName, isServiceLowPriority = false, preferWifi = false, ...options}: StartForwardingOptions = {},
   ): StartForwardingServicePortRequest {
-    assertGizmoPort(gizmoPort);
     return {
       Command: 'StartForwardingServicePort',
-      GizmoRemotePortNumber: gizmoPort,
+      GizmoRemotePortNumber: assertWatchPort(watchPort),
       IsServiceLowPriority: isServiceLowPriority,
       PreferWifi: preferWifi,
       ...(serviceName === undefined ? {} : {ForwardedServiceName: serviceName}),
@@ -255,13 +277,10 @@ class CompanionProxyService extends BaseService implements CompanionProxyService
     };
   }
 
-  private buildStopForwardingRequest(gizmoPort: number): StopForwardingServicePortRequest {
-    assertGizmoPort(gizmoPort);
+  private buildStopForwardingRequest(watchPort: number): StopForwardingServicePortRequest {
     return {
       Command: 'StopForwardingServicePort',
-      GizmoRemotePortNumber: gizmoPort,
+      GizmoRemotePortNumber: assertWatchPort(watchPort),
     };
   }
 }
-
-export {CompanionProxyService};

--- a/src/services/ios/companion-proxy/index.ts
+++ b/src/services/ios/companion-proxy/index.ts
@@ -1,0 +1,267 @@
+import type {Socket} from 'node:net';
+
+import {util} from '@appium/support';
+
+import {getLogger} from '../../../lib/logger.js';
+import {connectViaTunnel} from '../../../lib/port-forwarding/connectors.js';
+import type {
+  CompanionProxyService as CompanionProxyServiceInterface,
+  PlistDictionary,
+  PlistValue,
+} from '../../../lib/types.js';
+import type {ServiceConnection} from '../../../service-connection.js';
+import {BaseService} from '../base-service.js';
+import {CompanionProxyError} from './errors.js';
+
+const log = getLogger('CompanionProxyService');
+
+const DEFAULT_TIMEOUT_MS = 10000;
+const DEFAULT_EVENT_TIMEOUT_MS = 120000;
+const MAX_PORT = 65535;
+
+export type CompanionDeviceEventCommand = 'GizmoPaired' | 'GizmoUnpaired' | 'GizmoAttach' | 'GizmoDetach';
+
+/**
+ * Event frame streamed by `StartListeningForDevices`.
+ */
+export interface CompanionDeviceEvent extends PlistDictionary {
+  Command: CompanionDeviceEventCommand;
+  GizmoUDIDKey: string;
+  /** Present on `GizmoAttach` for watchOS >= 2 */
+  CompanionLockdownProxyPort?: number;
+}
+
+/**
+ * Options for `StartForwardingServicePort`; any extra keys are merged verbatim into the request.
+ */
+export interface StartForwardingOptions extends PlistDictionary {
+  serviceName?: string;
+  isServiceLowPriority?: boolean;
+  preferWifi?: boolean;
+}
+
+interface GetValueFromRegistryRequest extends PlistDictionary {
+  Command: 'GetValueFromRegistry';
+  GetValueGizmoUDIDKey: string;
+  GetValueKeyKey: string;
+}
+
+interface StartForwardingServicePortRequest extends PlistDictionary {
+  Command: 'StartForwardingServicePort';
+  GizmoRemotePortNumber: number;
+  IsServiceLowPriority: boolean;
+  PreferWifi: boolean;
+  ForwardedServiceName?: string;
+}
+
+interface StopForwardingServicePortRequest extends PlistDictionary {
+  Command: 'StopForwardingServicePort';
+  GizmoRemotePortNumber: number;
+}
+
+function isPlistDictionary(value: PlistValue): value is PlistDictionary {
+  return util.isPlainObject(value);
+}
+
+function isCompanionDeviceEvent(frame: PlistDictionary): frame is CompanionDeviceEvent {
+  return typeof frame?.Command === 'string' && typeof frame.GizmoUDIDKey === 'string';
+}
+
+function assertGizmoPort(port: number): void {
+  if (!Number.isInteger(port) || port < 1 || port > MAX_PORT) {
+    throw new TypeError(`gizmoPort must be an integer in 1..${MAX_PORT}, got ${port}`);
+  }
+}
+
+/**
+ * CompanionProxyService provides an API to:
+ * - List paired Apple Watches and stream pair/attach events
+ * - Read per-watch registry values
+ * - Forward a watch TCP port through the phone and connect to it
+ */
+class CompanionProxyService extends BaseService implements CompanionProxyServiceInterface {
+  static readonly RSD_SERVICE_NAME = 'com.apple.companion_proxy.shim.remote';
+  private readonly timeout: number;
+  private _listenConn: ServiceConnection | null = null;
+
+  constructor(udid: string, timeout: number = DEFAULT_TIMEOUT_MS) {
+    super(udid);
+    this.timeout = timeout;
+  }
+
+  /**
+   * List the UDIDs of the watches paired with this phone
+   * @returns Paired watch UDIDs; empty when the daemon reports `NoPairedWatches`
+   */
+  async list(): Promise<string[]> {
+    const response = await this.sendCommand({Command: 'GetDeviceRegistry'});
+    if (response.Error === 'NoPairedWatches') {
+      return [];
+    }
+    this.throwOnError(response, 'GetDeviceRegistry');
+    const udids = response.PairedDevicesArray;
+    return Array.isArray(udids) ? udids.map(String) : [];
+  }
+
+  /**
+   * Stream watch pair/unpair/attach/detach events on a dedicated persistent connection.
+   * The daemon cancels the stream on any further input, so nothing else is ever sent on it.
+   * @param timeout Milliseconds to wait for each event
+   */
+  async *listen(timeout: number = DEFAULT_EVENT_TIMEOUT_MS): AsyncGenerator<CompanionDeviceEvent> {
+    if (!this._listenConn) {
+      this._listenConn = await this.connectToCompanionProxyService();
+      this._listenConn.sendPlist({Command: 'StartListeningForDevices'});
+    }
+    const conn = this._listenConn;
+    while (true) {
+      const frame = await conn.receive(timeout);
+      this.throwOnError(frame, 'StartListeningForDevices');
+      if (!isCompanionDeviceEvent(frame)) {
+        throw new CompanionProxyError(`Unexpected companion event frame: ${JSON.stringify(frame)}`);
+      }
+      yield frame;
+    }
+  }
+
+  /**
+   * Read one registry value for a paired watch
+   * @param companionUdid Watch UDID from `list()`
+   * @param key Registry key, e.g. `DeviceName`, `ProductVersion`, `BatteryCurrentCapacity`
+   */
+  async getValue(companionUdid: string, key: string): Promise<PlistValue> {
+    const response = await this.sendCommand(this.buildGetValueRequest(companionUdid, key));
+    this.throwOnError(response, 'GetValueFromRegistry');
+    const values = response.RetrievedValueDictionary;
+    if (!isPlistDictionary(values)) {
+      throw new CompanionProxyError(`Unexpected GetValueFromRegistry reply: ${JSON.stringify(response)}`);
+    }
+    return values[key];
+  }
+
+  /**
+   * Ask the phone to forward a watch TCP port; the listener survives until
+   * `stopForwardingServicePort()`. Reach it with `connectToForwardedPort()`.
+   * @param gizmoPort TCP port on the watch
+   * @returns Ephemeral port on the phone proxying to `gizmoPort`
+   */
+  async startForwardingServicePort(gizmoPort: number, options?: StartForwardingOptions): Promise<number> {
+    const response = await this.sendCommand(this.buildStartForwardingRequest(gizmoPort, options));
+    this.throwOnError(response, 'StartForwardingServicePort');
+    const port = response.CompanionProxyServicePort;
+    if (typeof port !== 'number') {
+      throw new CompanionProxyError(`Unexpected StartForwardingServicePort reply: ${JSON.stringify(response)}`);
+    }
+    return port;
+  }
+
+  /**
+   * Stop forwarding a watch port started with `startForwardingServicePort()`.
+   * Accepts Apple's misspelled `ComandSuccess` reply as well as `CommandSuccess`.
+   * @param gizmoPort TCP port on the watch (not the phone port returned earlier)
+   */
+  async stopForwardingServicePort(gizmoPort: number): Promise<void> {
+    const response = await this.sendCommand(this.buildStopForwardingRequest(gizmoPort));
+    this.throwOnError(response, 'StopForwardingServicePort');
+    if (response.Command !== 'ComandSuccess' && response.Command !== 'CommandSuccess') {
+      throw new CompanionProxyError(`Unexpected StopForwardingServicePort reply: ${JSON.stringify(response)}`);
+    }
+  }
+
+  /**
+   * Open a raw TCP socket to a phone port returned by `startForwardingServicePort()`.
+   * No RSD check-in happens on this socket.
+   * @param companionPort Phone port
+   */
+  async connectToForwardedPort(companionPort: number): Promise<Socket> {
+    return await connectViaTunnel(this.udid, companionPort);
+  }
+
+  /**
+   * Close the persistent `listen()` connection, if any
+   */
+  close(): void {
+    try {
+      this._listenConn?.close();
+    } catch (error) {
+      log.error('Error closing companion proxy connection:', error);
+    } finally {
+      this._listenConn = null;
+    }
+  }
+
+  /**
+   * Open a fresh checked-in connection and drain the shim's `StartService` greeting.
+   * A greeting carrying `Error` (e.g. `ServiceProhibited`) is surfaced instead of hanging later.
+   */
+  private async connectToCompanionProxyService(): Promise<ServiceConnection> {
+    const conn = await this.startLockdownService(CompanionProxyService.RSD_SERVICE_NAME, {
+      createConnectionTimeout: this.timeout,
+    });
+    try {
+      const greeting = await conn.receive(this.timeout);
+      this.throwOnError(greeting, 'StartService');
+      if (greeting?.Request !== 'StartService') {
+        throw new CompanionProxyError(`Expected StartService greeting, got: ${JSON.stringify(greeting)}`);
+      }
+      return conn;
+    } catch (error) {
+      conn.close();
+      throw error;
+    }
+  }
+
+  /**
+   * Send one command on a fresh connection; the daemon closes after every reply
+   */
+  private async sendCommand(request: PlistDictionary): Promise<PlistDictionary> {
+    const conn = await this.connectToCompanionProxyService();
+    try {
+      return await conn.sendPlistRequest(request, this.timeout);
+    } finally {
+      conn.close();
+    }
+  }
+
+  private throwOnError(response: PlistDictionary, command: string): void {
+    if (!response?.Error) {
+      return;
+    }
+    const code = String(response.Error);
+    const description = response.ErrorDescription ? ` - ${String(response.ErrorDescription)}` : '';
+    throw new CompanionProxyError(`${command} failed: ${code}${description}`, code);
+  }
+
+  private buildGetValueRequest(companionUdid: string, key: string): GetValueFromRegistryRequest {
+    return {
+      Command: 'GetValueFromRegistry',
+      GetValueGizmoUDIDKey: companionUdid,
+      GetValueKeyKey: key,
+    };
+  }
+
+  private buildStartForwardingRequest(
+    gizmoPort: number,
+    {serviceName, isServiceLowPriority = false, preferWifi = false, ...options}: StartForwardingOptions = {},
+  ): StartForwardingServicePortRequest {
+    assertGizmoPort(gizmoPort);
+    return {
+      Command: 'StartForwardingServicePort',
+      GizmoRemotePortNumber: gizmoPort,
+      IsServiceLowPriority: isServiceLowPriority,
+      PreferWifi: preferWifi,
+      ...(serviceName === undefined ? {} : {ForwardedServiceName: serviceName}),
+      ...options,
+    };
+  }
+
+  private buildStopForwardingRequest(gizmoPort: number): StopForwardingServicePortRequest {
+    assertGizmoPort(gizmoPort);
+    return {
+      Command: 'StopForwardingServicePort',
+      GizmoRemotePortNumber: gizmoPort,
+    };
+  }
+}
+
+export {CompanionProxyService};

--- a/src/services/ios/companion-proxy/index.ts
+++ b/src/services/ios/companion-proxy/index.ts
@@ -110,17 +110,25 @@ export class CompanionProxyService extends BaseService implements CompanionProxy
 
   /**
    * Stream watch pair/unpair/attach/detach events on a dedicated connection that is closed
-   * when the consumer stops iterating, on error, on `close()`, or when the daemon hangs up.
+   * when the consumer stops iterating, on error, on abort, on `close()`, or when the daemon hangs up.
    * The daemon cancels the stream on any further input, so nothing else is ever sent on it.
    * @param timeout Milliseconds to wait for each event
+   * @param signal Aborting it stops this stream only, settling a pending iteration with the abort reason
    * @throws {CompanionProxyError} On a daemon `Error` reply or a frame that is not a companion event
    * @throws {Error} When no event arrives within `timeout` or the connection is closed by either side
+   * @throws {DOMException} The `AbortError` (or `signal.reason`) once `signal` aborts
    */
-  async *listen(timeout: number = DEFAULT_EVENT_TIMEOUT_MS): AsyncGenerator<CompanionDeviceEvent> {
+  async *listen(
+    timeout: number = DEFAULT_EVENT_TIMEOUT_MS,
+    signal?: AbortSignal,
+  ): AsyncGenerator<CompanionDeviceEvent> {
     const conn = await this.connectToCompanionProxyService();
     this._listenConns.add(conn);
-    conn.getSocket().once('close', () => this.releaseListenConnection(conn));
+    const release = (): void => this.releaseListenConnection(conn);
+    conn.getSocket().once('close', release);
+    signal?.addEventListener('abort', release, {once: true});
     try {
+      signal?.throwIfAborted();
       conn.sendPlist({Command: 'StartListeningForDevices'});
       while (true) {
         const frame = this.throwOnError(await conn.receive(timeout), 'StartListeningForDevices');
@@ -128,9 +136,13 @@ export class CompanionProxyService extends BaseService implements CompanionProxy
           throw new CompanionProxyError(`Unexpected companion event frame: ${JSON.stringify(frame)}`);
         }
         yield frame;
+        signal?.throwIfAborted();
       }
+    } catch (error) {
+      throw signal?.aborted ? signal.reason : error;
     } finally {
-      this.releaseListenConnection(conn);
+      signal?.removeEventListener('abort', release);
+      release();
     }
   }
 

--- a/test/unit/companion-proxy/companion-proxy-service.spec.ts
+++ b/test/unit/companion-proxy/companion-proxy-service.spec.ts
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict';
+import {EventEmitter} from 'node:events';
 import type {Socket} from 'node:net';
 import {type TestContext, describe, it} from 'node:test';
+import {setImmediate as nextTick} from 'node:timers/promises';
 
 import type {PlistDictionary} from '../../../src/lib/types.js';
 import {CompanionProxyError} from '../../../src/services/ios/companion-proxy/errors.js';
@@ -17,15 +19,20 @@ const attach: CompanionDeviceEvent = {
   CompanionLockdownProxyPort: 62078,
 };
 const detach: CompanionDeviceEvent = {Command: 'GizmoDetach', GizmoUDIDKey: WATCH_UDID};
+/** Inbound marker: `receive()` stays pending until `close()` rejects it, like the real PlistService */
+const PENDING = Symbol('pending');
 
 interface FakeConnection {
   sentRequests: PlistDictionary[];
   sentMessages: PlistDictionary[];
   timeouts: Array<number | undefined>;
   closeCount: number;
+  socket: EventEmitter;
+  pendingRejects: Array<(error: Error) => void>;
   sendPlistRequest(request: PlistDictionary, timeout?: number): Promise<PlistDictionary>;
   sendPlist(message: PlistDictionary): void;
   receive(timeout?: number): Promise<PlistDictionary>;
+  getSocket(): EventEmitter;
   close(): void;
 }
 
@@ -33,13 +40,15 @@ interface FakeConnection {
  * Fake ServiceConnection whose inbound frames are served in order to both
  * `receive()` and `sendPlistRequest()` (which the real class implements as send + receive).
  */
-function createFakeConnection(inbound: Array<PlistDictionary | Error>): FakeConnection {
+function createFakeConnection(inbound: Array<PlistDictionary | Error | typeof PENDING>): FakeConnection {
   const frames = [...inbound];
   const conn: FakeConnection = {
     sentRequests: [],
     sentMessages: [],
     timeouts: [],
     closeCount: 0,
+    socket: new EventEmitter(),
+    pendingRejects: [],
     async sendPlistRequest(request, timeout) {
       conn.sentRequests.push(request);
       return await conn.receive(timeout);
@@ -53,13 +62,22 @@ function createFakeConnection(inbound: Array<PlistDictionary | Error>): FakeConn
       if (frame === undefined) {
         throw new Error('fake connection has no more inbound frames');
       }
+      if (frame === PENDING) {
+        return await new Promise<PlistDictionary>((_, reject) => conn.pendingRejects.push(reject));
+      }
       if (frame instanceof Error) {
         throw frame;
       }
       return frame;
     },
+    getSocket() {
+      return conn.socket;
+    },
     close() {
       conn.closeCount++;
+      for (const reject of conn.pendingRejects.splice(0)) {
+        reject(new Error('Connection closed while waiting for plist response'));
+      }
     },
   };
   return conn;
@@ -444,6 +462,20 @@ describe('CompanionProxyService', function () {
       assert.deepStrictEqual(startedServices, [RSD_SERVICE_NAME, RSD_SERVICE_NAME]);
       assert.deepStrictEqual(first.sentMessages, [{Command: 'StartListeningForDevices'}]);
       assert.deepStrictEqual(second.sentMessages, [{Command: 'StartListeningForDevices'}]);
+    });
+
+    it('exits when the daemon closes the socket instead of waiting out the event timeout', async function (t) {
+      const conn = createFakeConnection([GREETING, PENDING]);
+      const {service} = await createService(t, [conn]);
+
+      const consumed = take(service.listen(), 1);
+      while (conn.pendingRejects.length === 0) {
+        await nextTick();
+      }
+      conn.socket.emit('close');
+
+      await assert.rejects(consumed, /Connection closed/);
+      assert.strictEqual(conn.closeCount, 1);
     });
 
     it('does not share a connection between concurrent listeners', async function (t) {

--- a/test/unit/companion-proxy/companion-proxy-service.spec.ts
+++ b/test/unit/companion-proxy/companion-proxy-service.spec.ts
@@ -11,6 +11,12 @@ const UDID = 'phone-udid';
 const WATCH_UDID = 'watch-udid';
 const RSD_SERVICE_NAME = 'com.apple.companion_proxy.shim.remote';
 const GREETING: PlistDictionary = {Request: 'StartService', Service: RSD_SERVICE_NAME, Port: 49152};
+const attach: CompanionDeviceEvent = {
+  Command: 'GizmoAttach',
+  GizmoUDIDKey: WATCH_UDID,
+  CompanionLockdownProxyPort: 62078,
+};
+const detach: CompanionDeviceEvent = {Command: 'GizmoDetach', GizmoUDIDKey: WATCH_UDID};
 
 interface FakeConnection {
   sentRequests: PlistDictionary[];
@@ -182,7 +188,7 @@ describe('CompanionProxyService', function () {
       });
     });
 
-    it('rejects a gizmoPort outside 1..65535 or non-integer', function () {
+    it('rejects a watchPort outside 1..65535 or non-integer', function () {
       for (const port of [0, 65536, 1.5, -1, Number.NaN]) {
         assert.throws(() => builders.buildStartForwardingRequest(port), TypeError, `start ${port}`);
         assert.throws(() => builders.buildStopForwardingRequest(port), TypeError, `stop ${port}`);
@@ -349,7 +355,7 @@ describe('CompanionProxyService', function () {
       await assert.rejects(service.startForwardingServicePort(62078), CompanionProxyError);
     });
 
-    it('rejects an invalid gizmoPort before opening a connection', async function (t) {
+    it('rejects an invalid watchPort before opening a connection', async function (t) {
       const {service, startedServices} = await createService(t, []);
 
       await assert.rejects(service.startForwardingServicePort(0), TypeError);
@@ -389,14 +395,7 @@ describe('CompanionProxyService', function () {
   });
 
   describe('listen', function () {
-    const attach: CompanionDeviceEvent = {
-      Command: 'GizmoAttach',
-      GizmoUDIDKey: WATCH_UDID,
-      CompanionLockdownProxyPort: 62078,
-    };
-    const detach: CompanionDeviceEvent = {Command: 'GizmoDetach', GizmoUDIDKey: WATCH_UDID};
-
-    it('fires StartListeningForDevices once without awaiting a reply and yields typed events in order', async function (t) {
+    it('fires StartListeningForDevices once, yields typed events in order, and closes when the consumer stops', async function (t) {
       const conn = createFakeConnection([GREETING, attach, detach]);
       const {service} = await createService(t, [conn], 1234);
 
@@ -406,7 +405,7 @@ describe('CompanionProxyService', function () {
       assert.deepStrictEqual(conn.sentMessages, [{Command: 'StartListeningForDevices'}]);
       assert.deepStrictEqual(conn.sentRequests, []);
       assert.deepStrictEqual(conn.timeouts, [1234, 777, 777]);
-      assert.strictEqual(conn.closeCount, 0);
+      assert.strictEqual(conn.closeCount, 1);
     });
 
     it('throws with the daemon code when the stream answers NoSocket', async function (t) {
@@ -423,41 +422,41 @@ describe('CompanionProxyService', function () {
       await assert.rejects(take(service.listen(), 1), CompanionProxyError);
     });
 
-    it('propagates receive errors to the consumer', async function (t) {
+    it('propagates receive errors to the consumer and closes the connection', async function (t) {
       const conn = createFakeConnection([GREETING, new Error('socket lost')]);
       const {service} = await createService(t, [conn]);
 
       await assert.rejects(take(service.listen(), 1), /socket lost/);
+
+      assert.strictEqual(conn.closeCount, 1);
     });
 
-    it('reuses the persistent connection until close(), then reconnects', async function (t) {
-      const first = createFakeConnection([GREETING, attach, detach]);
-      const second = createFakeConnection([GREETING, attach]);
+    it('opens a dedicated connection per listen() call and closes it when iteration ends', async function (t) {
+      const first = createFakeConnection([GREETING, attach]);
+      const second = createFakeConnection([GREETING, detach]);
       const {service, startedServices} = await createService(t, [first, second]);
 
       assert.deepStrictEqual(await take(service.listen(), 1), [attach]);
-      assert.deepStrictEqual(await take(service.listen(), 1), [detach]);
-      assert.deepStrictEqual(startedServices, [RSD_SERVICE_NAME]);
-      assert.deepStrictEqual(first.sentMessages, [{Command: 'StartListeningForDevices'}]);
-
-      service.close();
       assert.strictEqual(first.closeCount, 1);
+      assert.deepStrictEqual(await take(service.listen(), 1), [detach]);
+      assert.strictEqual(second.closeCount, 1);
 
-      assert.deepStrictEqual(await take(service.listen(), 1), [attach]);
       assert.deepStrictEqual(startedServices, [RSD_SERVICE_NAME, RSD_SERVICE_NAME]);
+      assert.deepStrictEqual(first.sentMessages, [{Command: 'StartListeningForDevices'}]);
       assert.deepStrictEqual(second.sentMessages, [{Command: 'StartListeningForDevices'}]);
     });
 
-    it('keeps the listen connection open across per-command calls', async function (t) {
-      const listenConn = createFakeConnection([GREETING, attach]);
-      const commandConn = createFakeConnection([GREETING, {PairedDevicesArray: [WATCH_UDID]}]);
-      const {service} = await createService(t, [listenConn, commandConn]);
+    it('does not share a connection between concurrent listeners', async function (t) {
+      const first = createFakeConnection([GREETING, attach]);
+      const second = createFakeConnection([GREETING, detach]);
+      const {service, startedServices} = await createService(t, [first, second]);
 
-      await take(service.listen(), 1);
-      await service.list();
+      const events = await Promise.all([take(service.listen(), 1), take(service.listen(), 1)]);
 
-      assert.strictEqual(listenConn.closeCount, 0);
-      assert.strictEqual(commandConn.closeCount, 1);
+      assert.deepStrictEqual(events, [[attach], [detach]]);
+      assert.deepStrictEqual(startedServices, [RSD_SERVICE_NAME, RSD_SERVICE_NAME]);
+      assert.strictEqual(first.closeCount, 1);
+      assert.strictEqual(second.closeCount, 1);
     });
   });
 
@@ -481,15 +480,36 @@ describe('CompanionProxyService', function () {
       assert.deepStrictEqual(startedServices, []);
     });
 
+    it('closes every active listen() connection exactly once', async function (t) {
+      const first = createFakeConnection([GREETING, attach, detach]);
+      const second = createFakeConnection([GREETING, attach, detach]);
+      const {service} = await createService(t, [first, second]);
+      const firstEvents = service.listen();
+      const secondEvents = service.listen();
+      await firstEvents.next();
+      await secondEvents.next();
+
+      service.close();
+
+      assert.strictEqual(first.closeCount, 1);
+      assert.strictEqual(second.closeCount, 1);
+      await firstEvents.return(undefined);
+      await secondEvents.return(undefined);
+      assert.strictEqual(first.closeCount, 1);
+      assert.strictEqual(second.closeCount, 1);
+    });
+
     it('swallows errors thrown by the underlying connection close', async function (t) {
       const conn = createFakeConnection([GREETING, {Command: 'GizmoPaired', GizmoUDIDKey: WATCH_UDID}]);
       conn.close = () => {
         throw new Error('already closed');
       };
       const {service} = await createService(t, [conn]);
-      await take(service.listen(), 1);
+      const events = service.listen();
+      await events.next();
 
       service.close();
+      await events.return(undefined);
     });
   });
 });

--- a/test/unit/companion-proxy/companion-proxy-service.spec.ts
+++ b/test/unit/companion-proxy/companion-proxy-service.spec.ts
@@ -1,0 +1,495 @@
+import assert from 'node:assert/strict';
+import type {Socket} from 'node:net';
+import {type TestContext, describe, it} from 'node:test';
+
+import type {PlistDictionary} from '../../../src/lib/types.js';
+import {CompanionProxyError} from '../../../src/services/ios/companion-proxy/errors.js';
+import {type CompanionDeviceEvent, CompanionProxyService} from '../../../src/services/ios/companion-proxy/index.js';
+import {mockImport} from '../../helpers/mock-module.js';
+
+const UDID = 'phone-udid';
+const WATCH_UDID = 'watch-udid';
+const RSD_SERVICE_NAME = 'com.apple.companion_proxy.shim.remote';
+const GREETING: PlistDictionary = {Request: 'StartService', Service: RSD_SERVICE_NAME, Port: 49152};
+
+interface FakeConnection {
+  sentRequests: PlistDictionary[];
+  sentMessages: PlistDictionary[];
+  timeouts: Array<number | undefined>;
+  closeCount: number;
+  sendPlistRequest(request: PlistDictionary, timeout?: number): Promise<PlistDictionary>;
+  sendPlist(message: PlistDictionary): void;
+  receive(timeout?: number): Promise<PlistDictionary>;
+  close(): void;
+}
+
+/**
+ * Fake ServiceConnection whose inbound frames are served in order to both
+ * `receive()` and `sendPlistRequest()` (which the real class implements as send + receive).
+ */
+function createFakeConnection(inbound: Array<PlistDictionary | Error>): FakeConnection {
+  const frames = [...inbound];
+  const conn: FakeConnection = {
+    sentRequests: [],
+    sentMessages: [],
+    timeouts: [],
+    closeCount: 0,
+    async sendPlistRequest(request, timeout) {
+      conn.sentRequests.push(request);
+      return await conn.receive(timeout);
+    },
+    sendPlist(message) {
+      conn.sentMessages.push(message);
+    },
+    async receive(timeout) {
+      conn.timeouts.push(timeout);
+      const frame = frames.shift();
+      if (frame === undefined) {
+        throw new Error('fake connection has no more inbound frames');
+      }
+      if (frame instanceof Error) {
+        throw frame;
+      }
+      return frame;
+    },
+    close() {
+      conn.closeCount++;
+    },
+  };
+  return conn;
+}
+
+interface Harness {
+  service: CompanionProxyService;
+  startedServices: string[];
+  connectViaTunnelCalls: Array<[string, number]>;
+  tunnelSocket: Socket;
+}
+
+/**
+ * Imports the service with BaseService replaced so each `startLockdownService` call hands
+ * out the next fake connection, and connectViaTunnel replaced with a recording stub.
+ */
+async function createService(t: TestContext, connections: FakeConnection[], timeout?: number): Promise<Harness> {
+  const pending = [...connections];
+  const startedServices: string[] = [];
+  const connectViaTunnelCalls: Array<[string, number]> = [];
+  const tunnelSocket = {} as Socket;
+
+  const {CompanionProxyService: MockedService} = await mockImport<{
+    CompanionProxyService: typeof CompanionProxyService;
+  }>(t, '../../../src/services/ios/companion-proxy/index.js', import.meta.url, {
+    '../../../src/services/ios/base-service.js': {
+      BaseService: class {
+        constructor(readonly udid: string) {}
+        async startLockdownService(serviceName: string): Promise<FakeConnection> {
+          startedServices.push(serviceName);
+          const conn = pending.shift();
+          if (!conn) {
+            throw new Error('no fake connection left for startLockdownService');
+          }
+          return conn;
+        }
+      },
+    },
+    '../../../src/lib/port-forwarding/connectors.js': {
+      connectViaTunnel: async (udid: string, port: number): Promise<Socket> => {
+        connectViaTunnelCalls.push([udid, port]);
+        return tunnelSocket;
+      },
+    },
+  });
+
+  return {
+    service: new MockedService(UDID, timeout),
+    startedServices,
+    connectViaTunnelCalls,
+    tunnelSocket,
+  };
+}
+
+async function take<T>(generator: AsyncGenerator<T>, count: number): Promise<T[]> {
+  const items: T[] = [];
+  for await (const item of generator) {
+    items.push(item);
+    if (items.length === count) {
+      break;
+    }
+  }
+  return items;
+}
+
+async function rejectsWithCode(promise: Promise<unknown>, code: string): Promise<void> {
+  await assert.rejects(promise, (error: unknown) => {
+    assert.ok(error instanceof CompanionProxyError, `expected CompanionProxyError, got ${String(error)}`);
+    assert.strictEqual(error.name, 'CompanionProxyError');
+    assert.strictEqual(error.code, code);
+    return true;
+  });
+}
+
+describe('CompanionProxyService', function () {
+  describe('request builders', function () {
+    const service = new CompanionProxyService(UDID);
+    const builders = service as unknown as {
+      buildGetValueRequest(udid: string, key: string): PlistDictionary;
+      buildStartForwardingRequest(port: number, options?: PlistDictionary): PlistDictionary;
+      buildStopForwardingRequest(port: number): PlistDictionary;
+    };
+
+    it('exposes the RSD shim service name', function () {
+      assert.strictEqual(CompanionProxyService.RSD_SERVICE_NAME, RSD_SERVICE_NAME);
+    });
+
+    it('builds GetValueFromRegistry with the exact wire keys', function () {
+      assert.deepStrictEqual(builders.buildGetValueRequest(WATCH_UDID, 'DeviceName'), {
+        Command: 'GetValueFromRegistry',
+        GetValueGizmoUDIDKey: WATCH_UDID,
+        GetValueKeyKey: 'DeviceName',
+      });
+    });
+
+    it('builds StartForwardingServicePort with defaults and no ForwardedServiceName', function () {
+      assert.deepStrictEqual(builders.buildStartForwardingRequest(62078), {
+        Command: 'StartForwardingServicePort',
+        GizmoRemotePortNumber: 62078,
+        IsServiceLowPriority: false,
+        PreferWifi: false,
+      });
+    });
+
+    it('builds StartForwardingServicePort with every option and merges extra keys', function () {
+      const request = builders.buildStartForwardingRequest(8080, {
+        serviceName: 'com.example.service',
+        isServiceLowPriority: true,
+        preferWifi: true,
+        ExtraKey: 'extra',
+      });
+      assert.deepStrictEqual(request, {
+        Command: 'StartForwardingServicePort',
+        GizmoRemotePortNumber: 8080,
+        IsServiceLowPriority: true,
+        PreferWifi: true,
+        ForwardedServiceName: 'com.example.service',
+        ExtraKey: 'extra',
+      });
+    });
+
+    it('builds StopForwardingServicePort with the watch port', function () {
+      assert.deepStrictEqual(builders.buildStopForwardingRequest(62078), {
+        Command: 'StopForwardingServicePort',
+        GizmoRemotePortNumber: 62078,
+      });
+    });
+
+    it('rejects a gizmoPort outside 1..65535 or non-integer', function () {
+      for (const port of [0, 65536, 1.5, -1, Number.NaN]) {
+        assert.throws(() => builders.buildStartForwardingRequest(port), TypeError, `start ${port}`);
+        assert.throws(() => builders.buildStopForwardingRequest(port), TypeError, `stop ${port}`);
+      }
+    });
+  });
+
+  describe('connection lifecycle', function () {
+    it('checks in, drains the greeting, sends the command with the configured timeout, then closes', async function (t) {
+      const conn = createFakeConnection([GREETING, {PairedDevicesArray: [WATCH_UDID]}]);
+      const {service, startedServices} = await createService(t, [conn], 1234);
+
+      await service.list();
+
+      assert.deepStrictEqual(startedServices, [RSD_SERVICE_NAME]);
+      assert.deepStrictEqual(conn.sentRequests, [{Command: 'GetDeviceRegistry'}]);
+      assert.deepStrictEqual(conn.sentMessages, []);
+      assert.deepStrictEqual(conn.timeouts, [1234, 1234]);
+      assert.strictEqual(conn.closeCount, 1);
+    });
+
+    it('opens a fresh connection for every command', async function (t) {
+      const first = createFakeConnection([GREETING, {PairedDevicesArray: [WATCH_UDID]}]);
+      const second = createFakeConnection([GREETING, {RetrievedValueDictionary: {DeviceName: 'Watch'}}]);
+      const {service, startedServices} = await createService(t, [first, second]);
+
+      await service.list();
+      await service.getValue(WATCH_UDID, 'DeviceName');
+
+      assert.deepStrictEqual(startedServices, [RSD_SERVICE_NAME, RSD_SERVICE_NAME]);
+      assert.strictEqual(first.closeCount, 1);
+      assert.strictEqual(second.closeCount, 1);
+    });
+
+    it('surfaces an Error-bearing greeting (USB-only refusal) and closes without sending', async function (t) {
+      const conn = createFakeConnection([{Request: 'StartService', Error: 'ServiceProhibited'}]);
+      const {service} = await createService(t, [conn]);
+
+      await rejectsWithCode(service.list(), 'ServiceProhibited');
+
+      assert.deepStrictEqual(conn.sentRequests, []);
+      assert.strictEqual(conn.closeCount, 1);
+    });
+
+    it('rejects a greeting that is not StartService and closes the connection', async function (t) {
+      const conn = createFakeConnection([{Request: 'Something'}]);
+      const {service} = await createService(t, [conn]);
+
+      await assert.rejects(service.list(), CompanionProxyError);
+
+      assert.strictEqual(conn.closeCount, 1);
+    });
+
+    it('closes the connection when the command reply times out', async function (t) {
+      const conn = createFakeConnection([GREETING, new Error('Timed out waiting for plist response')]);
+      const {service} = await createService(t, [conn]);
+
+      await assert.rejects(service.list(), /Timed out/);
+
+      assert.strictEqual(conn.closeCount, 1);
+    });
+  });
+
+  describe('list', function () {
+    it('returns PairedDevicesArray', async function (t) {
+      const conn = createFakeConnection([GREETING, {PairedDevicesArray: [WATCH_UDID, 'second-watch']}]);
+      const {service} = await createService(t, [conn]);
+
+      assert.deepStrictEqual(await service.list(), [WATCH_UDID, 'second-watch']);
+    });
+
+    it('returns [] on NoPairedWatches', async function (t) {
+      const conn = createFakeConnection([GREETING, {Error: 'NoPairedWatches'}]);
+      const {service} = await createService(t, [conn]);
+
+      assert.deepStrictEqual(await service.list(), []);
+    });
+
+    it('returns [] when PairedDevicesArray is missing', async function (t) {
+      const conn = createFakeConnection([GREETING, {}]);
+      const {service} = await createService(t, [conn]);
+
+      assert.deepStrictEqual(await service.list(), []);
+    });
+
+    it('throws CompanionProxyError with the daemon code on any other Error', async function (t) {
+      const conn = createFakeConnection([GREETING, {Error: 'UnexpectedReply'}]);
+      const {service} = await createService(t, [conn]);
+
+      await rejectsWithCode(service.list(), 'UnexpectedReply');
+    });
+
+    it('appends ErrorDescription to the message when the daemon sends one', async function (t) {
+      const conn = createFakeConnection([GREETING, {Error: 'ErrorReply', ErrorDescription: 'watch unreachable'}]);
+      const {service} = await createService(t, [conn]);
+
+      await assert.rejects(service.list(), {
+        name: 'CompanionProxyError',
+        message: 'GetDeviceRegistry failed: ErrorReply - watch unreachable',
+      });
+    });
+  });
+
+  describe('getValue', function () {
+    it('sends GetValueFromRegistry and unwraps RetrievedValueDictionary[key]', async function (t) {
+      const conn = createFakeConnection([GREETING, {RetrievedValueDictionary: {BatteryCurrentCapacity: 87}}]);
+      const {service} = await createService(t, [conn]);
+
+      assert.strictEqual(await service.getValue(WATCH_UDID, 'BatteryCurrentCapacity'), 87);
+      assert.deepStrictEqual(conn.sentRequests, [
+        {
+          Command: 'GetValueFromRegistry',
+          GetValueGizmoUDIDKey: WATCH_UDID,
+          GetValueKeyKey: 'BatteryCurrentCapacity',
+        },
+      ]);
+    });
+
+    it('throws with the daemon code on NoMatchingWatch', async function (t) {
+      const conn = createFakeConnection([GREETING, {Error: 'NoMatchingWatch'}]);
+      const {service} = await createService(t, [conn]);
+
+      await rejectsWithCode(service.getValue('unknown', 'DeviceName'), 'NoMatchingWatch');
+    });
+
+    it('throws when the reply has no RetrievedValueDictionary', async function (t) {
+      const conn = createFakeConnection([GREETING, {Command: 'Whatever'}]);
+      const {service} = await createService(t, [conn]);
+
+      await assert.rejects(service.getValue(WATCH_UDID, 'DeviceName'), CompanionProxyError);
+    });
+  });
+
+  describe('startForwardingServicePort', function () {
+    it('sends the request and returns CompanionProxyServicePort', async function (t) {
+      const conn = createFakeConnection([
+        GREETING,
+        {Command: 'CompanionServiceSetup', CompanionProxyServicePort: 51234},
+      ]);
+      const {service} = await createService(t, [conn]);
+
+      assert.strictEqual(await service.startForwardingServicePort(62078, {preferWifi: true}), 51234);
+      assert.deepStrictEqual(conn.sentRequests, [
+        {
+          Command: 'StartForwardingServicePort',
+          GizmoRemotePortNumber: 62078,
+          IsServiceLowPriority: false,
+          PreferWifi: true,
+        },
+      ]);
+    });
+
+    it('throws with the daemon code on ServiceProxySetup', async function (t) {
+      const conn = createFakeConnection([GREETING, {Error: 'ServiceProxySetup'}]);
+      const {service} = await createService(t, [conn]);
+
+      await rejectsWithCode(service.startForwardingServicePort(62078), 'ServiceProxySetup');
+    });
+
+    it('throws when the reply carries no port', async function (t) {
+      const conn = createFakeConnection([GREETING, {Command: 'CompanionServiceSetup'}]);
+      const {service} = await createService(t, [conn]);
+
+      await assert.rejects(service.startForwardingServicePort(62078), CompanionProxyError);
+    });
+
+    it('rejects an invalid gizmoPort before opening a connection', async function (t) {
+      const {service, startedServices} = await createService(t, []);
+
+      await assert.rejects(service.startForwardingServicePort(0), TypeError);
+
+      assert.deepStrictEqual(startedServices, []);
+    });
+  });
+
+  describe('stopForwardingServicePort', function () {
+    for (const reply of ['ComandSuccess', 'CommandSuccess']) {
+      it(`accepts ${reply}`, async function (t) {
+        const conn = createFakeConnection([GREETING, {Command: reply}]);
+        const {service} = await createService(t, [conn]);
+
+        await service.stopForwardingServicePort(62078);
+
+        assert.deepStrictEqual(conn.sentRequests, [
+          {Command: 'StopForwardingServicePort', GizmoRemotePortNumber: 62078},
+        ]);
+        assert.strictEqual(conn.closeCount, 1);
+      });
+    }
+
+    it('throws with the daemon code on MalformedCommand', async function (t) {
+      const conn = createFakeConnection([GREETING, {Error: 'MalformedCommand'}]);
+      const {service} = await createService(t, [conn]);
+
+      await rejectsWithCode(service.stopForwardingServicePort(62078), 'MalformedCommand');
+    });
+
+    it('throws on an unexpected reply', async function (t) {
+      const conn = createFakeConnection([GREETING, {Command: 'Nope'}]);
+      const {service} = await createService(t, [conn]);
+
+      await assert.rejects(service.stopForwardingServicePort(62078), CompanionProxyError);
+    });
+  });
+
+  describe('listen', function () {
+    const attach: CompanionDeviceEvent = {
+      Command: 'GizmoAttach',
+      GizmoUDIDKey: WATCH_UDID,
+      CompanionLockdownProxyPort: 62078,
+    };
+    const detach: CompanionDeviceEvent = {Command: 'GizmoDetach', GizmoUDIDKey: WATCH_UDID};
+
+    it('fires StartListeningForDevices once without awaiting a reply and yields typed events in order', async function (t) {
+      const conn = createFakeConnection([GREETING, attach, detach]);
+      const {service} = await createService(t, [conn], 1234);
+
+      const events = await take(service.listen(777), 2);
+
+      assert.deepStrictEqual(events, [attach, detach]);
+      assert.deepStrictEqual(conn.sentMessages, [{Command: 'StartListeningForDevices'}]);
+      assert.deepStrictEqual(conn.sentRequests, []);
+      assert.deepStrictEqual(conn.timeouts, [1234, 777, 777]);
+      assert.strictEqual(conn.closeCount, 0);
+    });
+
+    it('throws with the daemon code when the stream answers NoSocket', async function (t) {
+      const conn = createFakeConnection([GREETING, {Error: 'NoSocket'}]);
+      const {service} = await createService(t, [conn]);
+
+      await rejectsWithCode(take(service.listen(), 1), 'NoSocket');
+    });
+
+    it('throws on a frame that is not a companion event', async function (t) {
+      const conn = createFakeConnection([GREETING, {Command: 'GizmoAttach'}]);
+      const {service} = await createService(t, [conn]);
+
+      await assert.rejects(take(service.listen(), 1), CompanionProxyError);
+    });
+
+    it('propagates receive errors to the consumer', async function (t) {
+      const conn = createFakeConnection([GREETING, new Error('socket lost')]);
+      const {service} = await createService(t, [conn]);
+
+      await assert.rejects(take(service.listen(), 1), /socket lost/);
+    });
+
+    it('reuses the persistent connection until close(), then reconnects', async function (t) {
+      const first = createFakeConnection([GREETING, attach, detach]);
+      const second = createFakeConnection([GREETING, attach]);
+      const {service, startedServices} = await createService(t, [first, second]);
+
+      assert.deepStrictEqual(await take(service.listen(), 1), [attach]);
+      assert.deepStrictEqual(await take(service.listen(), 1), [detach]);
+      assert.deepStrictEqual(startedServices, [RSD_SERVICE_NAME]);
+      assert.deepStrictEqual(first.sentMessages, [{Command: 'StartListeningForDevices'}]);
+
+      service.close();
+      assert.strictEqual(first.closeCount, 1);
+
+      assert.deepStrictEqual(await take(service.listen(), 1), [attach]);
+      assert.deepStrictEqual(startedServices, [RSD_SERVICE_NAME, RSD_SERVICE_NAME]);
+      assert.deepStrictEqual(second.sentMessages, [{Command: 'StartListeningForDevices'}]);
+    });
+
+    it('keeps the listen connection open across per-command calls', async function (t) {
+      const listenConn = createFakeConnection([GREETING, attach]);
+      const commandConn = createFakeConnection([GREETING, {PairedDevicesArray: [WATCH_UDID]}]);
+      const {service} = await createService(t, [listenConn, commandConn]);
+
+      await take(service.listen(), 1);
+      await service.list();
+
+      assert.strictEqual(listenConn.closeCount, 0);
+      assert.strictEqual(commandConn.closeCount, 1);
+    });
+  });
+
+  describe('connectToForwardedPort', function () {
+    it('dials the phone port over the tunnel for this udid and returns the raw socket', async function (t) {
+      const {service, connectViaTunnelCalls, tunnelSocket} = await createService(t, []);
+
+      const socket = await service.connectToForwardedPort(51234);
+
+      assert.strictEqual(socket, tunnelSocket);
+      assert.deepStrictEqual(connectViaTunnelCalls, [[UDID, 51234]]);
+    });
+  });
+
+  describe('close', function () {
+    it('is a no-op when listen() was never called', async function (t) {
+      const {service, startedServices} = await createService(t, []);
+
+      service.close();
+
+      assert.deepStrictEqual(startedServices, []);
+    });
+
+    it('swallows errors thrown by the underlying connection close', async function (t) {
+      const conn = createFakeConnection([GREETING, {Command: 'GizmoPaired', GizmoUDIDKey: WATCH_UDID}]);
+      conn.close = () => {
+        throw new Error('already closed');
+      };
+      const {service} = await createService(t, [conn]);
+      await take(service.listen(), 1);
+
+      service.close();
+    });
+  });
+});

--- a/test/unit/companion-proxy/companion-proxy-service.spec.ts
+++ b/test/unit/companion-proxy/companion-proxy-service.spec.ts
@@ -490,6 +490,53 @@ describe('CompanionProxyService', function () {
       assert.strictEqual(first.closeCount, 1);
       assert.strictEqual(second.closeCount, 1);
     });
+
+    it('settles a pending iteration with AbortError and closes only its own connection when the signal aborts', async function (t) {
+      const aborted = createFakeConnection([GREETING, PENDING]);
+      const untouched = createFakeConnection([GREETING, PENDING, attach]);
+      const {service} = await createService(t, [aborted, untouched]);
+      const controller = new AbortController();
+      const consumed = take(service.listen(undefined, controller.signal), 1);
+      const other = service.listen(undefined, new AbortController().signal);
+      const otherNext = other.next();
+      while (aborted.pendingRejects.length === 0 || untouched.pendingRejects.length === 0) {
+        await nextTick();
+      }
+
+      controller.abort();
+
+      await assert.rejects(consumed, {name: 'AbortError'});
+      assert.strictEqual(aborted.closeCount, 1);
+      assert.strictEqual(untouched.closeCount, 0);
+      untouched.pendingRejects.splice(0).forEach((reject) => reject(new Error('unblock')));
+      await assert.rejects(otherNext, /unblock/);
+      assert.strictEqual(untouched.closeCount, 1);
+    });
+
+    it('settles the next pull with AbortError and skips another receive when aborted between events', async function (t) {
+      const conn = createFakeConnection([GREETING, attach, PENDING]);
+      const {service} = await createService(t, [conn]);
+      const controller = new AbortController();
+      const events = service.listen(undefined, controller.signal);
+      assert.deepStrictEqual(await events.next(), {value: attach, done: false});
+
+      controller.abort();
+
+      await assert.rejects(events.next(), {name: 'AbortError'});
+      assert.strictEqual(conn.timeouts.length, 2);
+      assert.strictEqual(conn.closeCount, 1);
+    });
+
+    it('throws the abort reason without streaming when the signal is already aborted', async function (t) {
+      const conn = createFakeConnection([GREETING]);
+      const {service} = await createService(t, [conn]);
+      const reason = new Error('caller gave up');
+
+      await assert.rejects(take(service.listen(undefined, AbortSignal.abort(reason)), 1), reason);
+
+      assert.deepStrictEqual(conn.sentMessages, []);
+      assert.strictEqual(conn.closeCount, 1);
+    });
   });
 
   describe('connectToForwardedPort', function () {


### PR DESCRIPTION
Introduces `CompanionProxyService` for `com.apple.companion_proxy.shim.remote`, the iPhone service that exposes its paired Apple Watch.

### Public API

| Method | Returns |
| --- | --- |
| `list()` | `string[]` — UDIDs of paired watches |
| `listen(timeout?)` | `AsyncGenerator<CompanionDeviceEvent>` — `GizmoPaired` / `GizmoUnpaired` / `GizmoAttach` / `GizmoDetach` |
| `getValue(companionUdid, key)` | `PlistValue` — e.g. `DeviceName`, `ProductVersion`, `BatteryCurrentCapacity` |
| `startForwardingServicePort(gizmoPort, options?)` | `number` — phone port proxying to the watch port |
| `stopForwardingServicePort(gizmoPort)` | — |
| `connectToForwardedPort(companionPort)` | `net.Socket` — raw TCP over the tunnel |
| `close()` | — |

Daemon errors are raised as `CompanionProxyError` with the raw `Error` string in `code`.

Wiring into `Services` and the package exports, plus the integration spec, follow in a separate PR.

### Testing

- `npm run build`, `npm run lint`, `npm run format:check`: clean
- `npm run test:unit`: 881 pass, 36 new
- Not yet verified against a real device with a paired watch
