### PR TITLE
fix(remote-xpc): pad dictionary keys on UTF-8 byte length

### DIFF
--- a/src/lib/remote-xpc/xpc-protocol.ts
+++ b/src/lib/remote-xpc/xpc-protocol.ts
@@ -507,7 +507,7 @@ function readDictionaryKey(reader: Reader): string {
     bytes.push(b);
   }
   const key = Buffer.from(bytes).toString('utf8');
-  const pad = calcPadding(key.length + 1);
+  const pad = calcPadding(bytes.length + 1);
   reader.skip(pad);
   return key;
 }

--- a/test/unit/remote-xpc/xpc-protocol-key-padding.spec.ts
+++ b/test/unit/remote-xpc/xpc-protocol-key-padding.spec.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import {describe, it} from 'node:test';
+
+import {decodeMessage, encodeMessage} from '../../../src/lib/remote-xpc/xpc-protocol.js';
+import type {XPCDictionary} from '../../../src/lib/types.js';
+
+function roundTrip(body: XPCDictionary): XPCDictionary {
+  const decoded = decodeMessage(encodeMessage({flags: 1, id: 1n, body}));
+  assert.ok(decoded.message.body, 'expected a decoded body');
+  return decoded.message.body;
+}
+
+describe('xpc-protocol dictionary key padding', function () {
+  it('round-trips an ASCII key (control)', function () {
+    assert.deepStrictEqual(roundTrip({abc: 'x', next: 'y'}), {abc: 'x', next: 'y'});
+  });
+
+  it('round-trips a key whose UTF-8 byte length differs from its JS string length', function () {
+    const body = {clé: 'x', next: 'y'};
+    assert.deepStrictEqual(roundTrip(body), body);
+  });
+
+  it('round-trips a key with a 3-byte UTF-8 character', function () {
+    const body = {'€': 'x', next: 'y'};
+    assert.deepStrictEqual(roundTrip(body), body);
+  });
+
+  it('round-trips a key with a 4-byte UTF-8 character (surrogate pair)', function () {
+    const body = {'🙂': 'x', next: 'y'};
+    assert.deepStrictEqual(roundTrip(body), body);
+  });
+});


### PR DESCRIPTION
The decoder padded dictionary keys on the JS string length (`key.length`) while the encoder pads on the UTF-8 byte length (`bytes.length`), so any non-ASCII key mis-aligned the reader and the rest of the message failed with `Unsupported xpc type`. This pads on the byte length in `readDictionaryKey` instead and adds round-trip regression tests for 2-, 3- and 4-byte UTF-8 keys.