### PR TITLE
fix(remote-xpc): treat RST_STREAM and GOAWAY as fatal instead of ignoring them

### DIFF
--- a/src/lib/remote-xpc/http2-frame-parser.ts
+++ b/src/lib/remote-xpc/http2-frame-parser.ts
@@ -3,7 +3,9 @@ import {InvalidDataError, WindowUpdateFrame} from './handshake-frames.js';
 
 const FRAME_HEADER_SIZE = 9;
 const FRAME_TYPE_DATA = 0x00;
+const FRAME_TYPE_RST_STREAM = 0x03;
 const FRAME_TYPE_SETTINGS = 0x04;
+const FRAME_TYPE_GOAWAY = 0x07;
 const FRAME_TYPE_WINDOW_UPDATE = 0x08;
 const FLAG_PADDED = 0x08;
 const SETTINGS_ENTRY_SIZE = 6;
@@ -18,7 +20,11 @@ export type ParsedFrame =
   | {readonly type: 'data'; readonly frame: ParsedDataFrame}
   | {readonly type: 'settings'; readonly settings: Record<number, number>}
   | {readonly type: 'windowUpdate'; readonly streamId: number; readonly increment: number}
+  | {readonly type: 'rstStream'; readonly streamId: number; readonly errorCode: number}
+  | {readonly type: 'goAway'; readonly lastStreamId: number; readonly errorCode: number}
   | {readonly type: 'other'};
+
+export type PeerTeardownFrame = Extract<ParsedFrame, {type: 'rstStream' | 'goAway'}>;
 
 /**
  * Incrementally parse HTTP/2 frames from a byte stream (RFC 7540).
@@ -68,6 +74,12 @@ function parseFrame(buffer: Buffer): ParsedFrame {
   }
   if (type === FRAME_TYPE_WINDOW_UPDATE) {
     return {type: 'windowUpdate', streamId, increment: body.readUInt32BE(0) & 0x7fffffff};
+  }
+  if (type === FRAME_TYPE_RST_STREAM) {
+    return {type: 'rstStream', streamId, errorCode: body.readUInt32BE(0)};
+  }
+  if (type === FRAME_TYPE_GOAWAY) {
+    return {type: 'goAway', lastStreamId: body.readUInt32BE(0) & 0x7fffffff, errorCode: body.readUInt32BE(4)};
   }
   if (type !== FRAME_TYPE_DATA) {
     return {type: 'other'};

--- a/src/lib/remote-xpc/remote-xpc-framed-transport.ts
+++ b/src/lib/remote-xpc/remote-xpc-framed-transport.ts
@@ -6,7 +6,7 @@ import type {XPCDictionary} from '../types.js';
 import {Http2Constants} from './constants.js';
 import {DataFrame} from './handshake-frames.js';
 import Handshake from './handshake.js';
-import {Http2FrameParser, buildWindowUpdateFrames} from './http2-frame-parser.js';
+import {Http2FrameParser, type PeerTeardownFrame, buildWindowUpdateFrames} from './http2-frame-parser.js';
 import {decodeMessage, probeXpcFraming, XPC_WRAPPER_HEADER_SIZE} from './xpc-protocol.js';
 
 const log = getLogger('RemoteXpcFramedTransport');
@@ -272,6 +272,10 @@ export class RemoteXpcFramedTransport extends EventEmitter {
         this.flushPendingSends();
         continue;
       }
+      if (frame.type === 'rstStream' || frame.type === 'goAway') {
+        this.handlePeerTeardown(frame);
+        return;
+      }
       if (frame.type !== 'data') {
         continue;
       }
@@ -356,10 +360,26 @@ export class RemoteXpcFramedTransport extends EventEmitter {
    * emit so a listener that reconnects synchronously keeps its new socket.
    */
   private handleDesync(reason: string): void {
+    this.failConnection(reason);
+  }
+
+  /**
+   * RST_STREAM and GOAWAY are fatal: the peer is closing the channel or the
+   * connection, and nothing usable follows either frame.
+   */
+  private handlePeerTeardown(frame: PeerTeardownFrame): void {
+    this.failConnection(
+      frame.type === 'rstStream'
+        ? `Peer sent RST_STREAM on stream ${frame.streamId} with error code ${frame.errorCode}`
+        : `Peer sent GOAWAY (last stream ${frame.lastStreamId}) with error code ${frame.errorCode}`,
+    );
+  }
+
+  private failConnection(reason: string): void {
     this.desynced = true;
     this.connected = false;
     this.close().catch((error: unknown) => {
-      log.debug(`Failed to close a desynced RemoteXPC transport: ${error}`);
+      log.debug(`Failed to close a failed RemoteXPC transport: ${error}`);
     });
     this.emit('error', new Error(reason));
   }

--- a/src/lib/remote-xpc/remote-xpc-framed-transport.ts
+++ b/src/lib/remote-xpc/remote-xpc-framed-transport.ts
@@ -6,7 +6,12 @@ import type {XPCDictionary} from '../types.js';
 import {Http2Constants} from './constants.js';
 import {DataFrame} from './handshake-frames.js';
 import Handshake from './handshake.js';
-import {Http2FrameParser, type PeerTeardownFrame, buildWindowUpdateFrames} from './http2-frame-parser.js';
+import {
+  Http2FrameParser,
+  type ParsedDataFrame,
+  type PeerTeardownFrame,
+  buildWindowUpdateFrames,
+} from './http2-frame-parser.js';
 import {decodeMessage, probeXpcFraming, XPC_WRAPPER_HEADER_SIZE} from './xpc-protocol.js';
 
 const log = getLogger('RemoteXpcFramedTransport');
@@ -262,35 +267,42 @@ export class RemoteXpcFramedTransport extends EventEmitter {
     }
 
     for (const frame of frames) {
-      if (frame.type === 'settings') {
-        this.applyPeerSettings(frame.settings);
-        this.flushPendingSends();
-        continue;
+      switch (frame.type) {
+        case 'settings':
+          this.applyPeerSettings(frame.settings);
+          this.flushPendingSends();
+          break;
+        case 'windowUpdate':
+          this.adjustSendWindow(frame.streamId, frame.increment);
+          this.flushPendingSends();
+          break;
+        case 'rstStream':
+        case 'goAway':
+          this.handlePeerTeardown(frame);
+          return;
+        case 'data':
+          if (!this.handleDataFrame(frame.frame)) {
+            return;
+          }
+          break;
+        default:
+          break;
       }
-      if (frame.type === 'windowUpdate') {
-        this.adjustSendWindow(frame.streamId, frame.increment);
-        this.flushPendingSends();
-        continue;
-      }
-      if (frame.type === 'rstStream' || frame.type === 'goAway') {
-        this.handlePeerTeardown(frame);
-        return;
-      }
-      if (frame.type !== 'data') {
-        continue;
-      }
-
-      const socket = this.socket;
-      if (this.desynced || !socket) {
-        return;
-      }
-
-      const {streamId, data, bodyLen} = frame.frame;
-      for (const windowUpdate of buildWindowUpdateFrames(streamId, bodyLen)) {
-        socket.write(windowUpdate);
-      }
-      this.ingestXpcData(streamId, data);
     }
+  }
+
+  /** Returns false once the connection is desynced or closed, so callers stop feeding it frames. */
+  private handleDataFrame({streamId, data, bodyLen}: ParsedDataFrame): boolean {
+    const socket = this.socket;
+    if (this.desynced || !socket) {
+      return false;
+    }
+
+    for (const windowUpdate of buildWindowUpdateFrames(streamId, bodyLen)) {
+      socket.write(windowUpdate);
+    }
+    this.ingestXpcData(streamId, data);
+    return true;
   }
 
   /**
@@ -368,11 +380,14 @@ export class RemoteXpcFramedTransport extends EventEmitter {
    * connection, and nothing usable follows either frame.
    */
   private handlePeerTeardown(frame: PeerTeardownFrame): void {
-    this.failConnection(
-      frame.type === 'rstStream'
-        ? `Peer sent RST_STREAM on stream ${frame.streamId} with error code ${frame.errorCode}`
-        : `Peer sent GOAWAY (last stream ${frame.lastStreamId}) with error code ${frame.errorCode}`,
-    );
+    switch (frame.type) {
+      case 'rstStream':
+        this.failConnection(`Peer sent RST_STREAM on stream ${frame.streamId} with error code ${frame.errorCode}`);
+        return;
+      case 'goAway':
+        this.failConnection(`Peer sent GOAWAY (last stream ${frame.lastStreamId}) with error code ${frame.errorCode}`);
+        return;
+    }
   }
 
   private failConnection(reason: string): void {

--- a/src/lib/remote-xpc/remote-xpc-framed-transport.ts
+++ b/src/lib/remote-xpc/remote-xpc-framed-transport.ts
@@ -269,11 +269,12 @@ export class RemoteXpcFramedTransport extends EventEmitter {
     for (const frame of frames) {
       switch (frame.type) {
         case 'settings':
-          this.applyPeerSettings(frame.settings);
-          this.flushPendingSends();
-          break;
         case 'windowUpdate':
-          this.adjustSendWindow(frame.streamId, frame.increment);
+          if (frame.type === 'settings') {
+            this.applyPeerSettings(frame.settings);
+          } else {
+            this.adjustSendWindow(frame.streamId, frame.increment);
+          }
           this.flushPendingSends();
           break;
         case 'rstStream':
@@ -387,6 +388,10 @@ export class RemoteXpcFramedTransport extends EventEmitter {
       case 'goAway':
         this.failConnection(`Peer sent GOAWAY (last stream ${frame.lastStreamId}) with error code ${frame.errorCode}`);
         return;
+      default: {
+        const unhandled: never = frame;
+        throw new Error(`Unhandled peer teardown frame: ${JSON.stringify(unhandled)}`);
+      }
     }
   }
 

--- a/test/unit/remote-xpc/remote-xpc-framed-transport.spec.ts
+++ b/test/unit/remote-xpc/remote-xpc-framed-transport.spec.ts
@@ -8,7 +8,14 @@ import {Http2FrameParser, type ParsedDataFrame} from '../../../src/lib/remote-xp
 import {RemoteXpcFramedTransport} from '../../../src/lib/remote-xpc/remote-xpc-framed-transport.js';
 import {MAX_XPC_BODY_SIZE, probeXpcFraming} from '../../../src/lib/remote-xpc/xpc-protocol.js';
 import type {XPCDictionary} from '../../../src/lib/types.js';
-import {buildMessage, buildUndecodableMessage, toDataFrame} from './xpc-fixtures.js';
+import {
+  buildMessage,
+  buildUndecodableMessage,
+  toDataFrame,
+  toGoAwayFrame,
+  toPingFrame,
+  toRstStreamFrame,
+} from './xpc-fixtures.js';
 
 interface PendingXpcEntry {
   chunks: Buffer[];
@@ -513,6 +520,57 @@ describe('RemoteXpcFramedTransport', function () {
         await waitFor(() => sentBytes(sentFrames()) >= payload.length);
 
         assert.deepStrictEqual(Buffer.concat(sentFrames().map((frame) => frame.data)), payload);
+      });
+    });
+  });
+
+  describe('peer-initiated teardown', function () {
+    /** Resolves with the next 'error', or undefined once teardown time has passed without one. */
+    function nextErrorOrTimeout(transport: RemoteXpcFramedTransport): Promise<Error | undefined> {
+      return Promise.race([
+        new Promise<Error>((resolve) => transport.once('error', resolve)),
+        settle(SOCKET_TEARDOWN_MS).then((): undefined => undefined),
+      ]);
+    }
+
+    it('emits a diagnosable error when the peer resets the root channel with RST_STREAM', async function () {
+      await withPeer(async ({transport, peer}) => {
+        const failed = nextErrorOrTimeout(transport);
+
+        peer.write(toRstStreamFrame(Http2Constants.ROOT_CHANNEL, 5));
+
+        const error = await failed;
+        assert.ok(error, 'RST_STREAM was silently dropped instead of failing the transport');
+        assert.match(error.message, /RST_STREAM/);
+        assert.match(error.message, /\b5\b/, 'the error code must be reported so the reset is diagnosable');
+      });
+    });
+
+    it('emits an error and disconnects when the peer sends GOAWAY', async function () {
+      await withPeer(async ({transport, peer}) => {
+        const failed = nextErrorOrTimeout(transport);
+
+        peer.write(toGoAwayFrame(Http2Constants.ROOT_CHANNEL, 1));
+
+        const error = await failed;
+        assert.ok(error, 'GOAWAY was silently dropped instead of failing the transport');
+        assert.match(error.message, /GOAWAY/);
+        assert.strictEqual(transport.isConnected, false, 'GOAWAY ends the whole connection');
+      });
+    });
+
+    it('still tolerates a PING and delivers the DATA behind it', async function () {
+      await withPeer(async ({transport, peer}) => {
+        const messages: XPCDictionary[] = [];
+        const errors: Error[] = [];
+        transport.on('message', (body: XPCDictionary) => messages.push(body));
+        transport.on('error', (error: Error) => errors.push(error));
+
+        peer.write(Buffer.concat([toPingFrame(), toDataFrame(buildMessage({n: 1}))]));
+        await waitFor(() => messages.length > 0);
+
+        assert.deepStrictEqual(messages, [{n: 1}]);
+        assert.deepStrictEqual(errors, [], 'only RST_STREAM and GOAWAY are fatal, not every non-DATA frame');
       });
     });
   });

--- a/test/unit/remote-xpc/rsd-service-catalog-client.spec.ts
+++ b/test/unit/remote-xpc/rsd-service-catalog-client.spec.ts
@@ -3,7 +3,13 @@ import * as net from 'node:net';
 import {describe, it} from 'node:test';
 
 import {RsdServiceCatalogClient} from '../../../src/lib/remote-xpc/rsd-service-catalog-client.js';
-import {buildCatalogMessage, buildUndecodableMessage, toDataFrame} from './xpc-fixtures.js';
+import {
+  buildCatalogMessage,
+  buildUndecodableMessage,
+  toDataFrame,
+  toGoAwayFrame,
+  toRstStreamFrame,
+} from './xpc-fixtures.js';
 
 /** Exceeds the client's internal handshake delay so teardown cannot race it. */
 const HANDSHAKE_DRAIN_MS = 200;
@@ -70,6 +76,26 @@ describe('RsdServiceCatalogClient', function () {
   it('fails the connect attempt when the stream desyncs', async function () {
     await withScriptedRsd([toDataFrame(Buffer.alloc(64, 0xab))], async (client): Promise<void> => {
       await assert.rejects(client.connect({timeoutMs: 5000}), /Invalid XPC wrapper magic/);
+    });
+  });
+
+  it('fails the connect attempt as soon as the peer resets the root channel during check-in', async function () {
+    await withScriptedRsd([toRstStreamFrame(1, 5)], async (client): Promise<void> => {
+      const started = Date.now();
+
+      await assert.rejects(client.connect({timeoutMs: 5000}), /RST_STREAM/);
+
+      assert.ok(Date.now() - started < 2000, 'a reset must not sit out the post-handshake service timeout');
+    });
+  });
+
+  it('fails the connect attempt as soon as the peer sends GOAWAY during check-in', async function () {
+    await withScriptedRsd([toGoAwayFrame(1, 1)], async (client): Promise<void> => {
+      const started = Date.now();
+
+      await assert.rejects(client.connect({timeoutMs: 5000}), /GOAWAY/);
+
+      assert.ok(Date.now() - started < 2000, 'GOAWAY must not sit out the post-handshake service timeout');
     });
   });
 });

--- a/test/unit/remote-xpc/xpc-fixtures.ts
+++ b/test/unit/remote-xpc/xpc-fixtures.ts
@@ -34,3 +34,35 @@ export function buildCatalogMessage(serviceName = 'com.apple.afc.shim.remote', p
 export function toDataFrame(payload: Buffer, streamId = 1): Buffer {
   return new DataFrame(streamId, payload, []).serialize();
 }
+
+const FRAME_TYPE_RST_STREAM = 0x03;
+const FRAME_TYPE_PING = 0x06;
+const FRAME_TYPE_GOAWAY = 0x07;
+
+function toRawFrame(type: number, streamId: number, body: Buffer): Buffer {
+  const header = Buffer.alloc(9);
+  header.writeUIntBE(body.length, 0, 3);
+  header.writeUInt8(type, 3);
+  header.writeUInt32BE(streamId, 5);
+  return Buffer.concat([header, body]);
+}
+
+/** RST_STREAM (RFC 7540 §6.4); error code 5 (STREAM_CLOSED) is what `remoted` contention produces. */
+export function toRstStreamFrame(streamId: number, errorCode = 5): Buffer {
+  const body = Buffer.alloc(4);
+  body.writeUInt32BE(errorCode);
+  return toRawFrame(FRAME_TYPE_RST_STREAM, streamId, body);
+}
+
+/** GOAWAY (RFC 7540 §6.8) on stream 0. */
+export function toGoAwayFrame(lastStreamId: number, errorCode = 1): Buffer {
+  const body = Buffer.alloc(8);
+  body.writeUInt32BE(lastStreamId);
+  body.writeUInt32BE(errorCode, 4);
+  return toRawFrame(FRAME_TYPE_GOAWAY, 0, body);
+}
+
+/** PING (RFC 7540 §6.7): a non-DATA frame the transport must keep tolerating. */
+export function toPingFrame(): Buffer {
+  return toRawFrame(FRAME_TYPE_PING, 0, Buffer.alloc(8));
+}


### PR DESCRIPTION
The frame parser ignored RST_STREAM and GOAWAY frames, so when the device reset the connection the RSD connect attempt kept waiting until the post-handshake timeout. The transport now fails right away with the stream and error code. Adds tests for both frames and a PING control.
